### PR TITLE
Add properties to control symbol packages

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -174,6 +174,11 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <StringProperty Name="PackageOutputPath"
+                  DisplayName="Package Output Path"
+                  Description="Determines the output path in which the package will be dropped."
+                  Category="General" />
+
   <DynamicEnumProperty Name="NeutralLanguage"
                        DisplayName="Assembly neutral language"
                        EnumProvider="NeutralLanguageEnumProvider"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/PackagePropertyPage.xaml
@@ -14,6 +14,9 @@
     <Category Name="License"
               DisplayName="License"
               Description="Specifies the license for the package." />
+    <Category Name="Symbols"
+              DisplayName="Symbols"
+              Description="Specifies how symbols are added to the package." />
   </Rule.Categories>
 
   <Rule.DataSource>
@@ -270,5 +273,25 @@
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>
+
+  <BoolProperty Name="IncludeSymbols"
+                DisplayName="Produce a symbol package"
+                Description="Create an additional symbol package when the project is packed."
+                Category="Symbols" />
+
+  <EnumProperty Name="SymbolPackageFormat"
+                DisplayName="Symbol package format"
+                Description="Specifies the format of the symbols package."
+                Category="Symbols">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Package" "IncludeSymbols" true)</NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="symbols.nupkg"
+               DisplayName="symbols.nupkg (legacy)" />
+    <EnumValue Name="snupkg"
+               DisplayName="snupkg" />
+  </EnumProperty>
 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Při sestavení generovat balíček NuGet</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Licence</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Neutrální jazyk sestavení</target>
@@ -67,6 +87,16 @@
         <target state="translated">Licence balíčku</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Výraz licence SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Žádné</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.cs.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Soubor s licencí</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">Adresa URL domovské stránky balíčku, která se často zobrazuje v uživatelském rozhraní spolu s nuget.org</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Lizenzdatei</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">Eine URL für die Homepage des NuGet-Pakets, die häufig in der Benutzeroberfläche und auf nuget.org angezeigt wird.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.de.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Beim Erstellen NuGet-Paket generieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Lizenz</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Neutrale Sprache der Assembly</target>
@@ -67,6 +87,16 @@
         <target state="translated">Paketlizenz</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">SPDX-Lizenzausdruck</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Keine</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Archivo de licencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">Dirección URL de la página principal del paquete, que suele aparecer en la interfaz de usuario además de nuget.org.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.es.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Generar paquete NuGet al compilar</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Licencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Lenguaje neutro de ensamblado</target>
@@ -67,6 +87,16 @@
         <target state="translated">Licencia del paquete</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Expresión de licencia SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Ninguno</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Générer le package NuGet en même temps que la build</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Licence</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Langage neutre de l'assembly</target>
@@ -67,6 +87,16 @@
         <target state="translated">Licence du package</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Expression de licence SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Aucun</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.fr.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Fichier de licence</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">URL de la page d'accueil du package, souvent affichée dans l'IU (interface utilisateur) ainsi que sur nuget.org.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
@@ -172,6 +172,16 @@
         <target state="translated">File di licenza</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">URL della home page del pacchetto, spesso visualizzata nell'interfaccia utente come nuget.org.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.it.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Genera pacchetto NuGet durante la compilazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Licenza</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Lingua di sistema dell'assembly</target>
@@ -67,6 +87,16 @@
         <target state="translated">Licenza del pacchetto</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Espressione della licenza SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Nessuno</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
@@ -12,6 +12,16 @@
         <target state="translated">ビルド時に NuGet パッケージを生成</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">ライセンス</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">アセンブリ ニュートラル言語</target>
@@ -67,6 +87,16 @@
         <target state="translated">パッケージ ライセンス</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">SPDX ライセンス式</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">なし</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ja.xlf
@@ -172,6 +172,16 @@
         <target state="translated">ライセンス ファイル</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">UI 表示や nuget.org によく表示される、パッケージのホーム ページの URL。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
@@ -172,6 +172,16 @@
         <target state="translated">라이선스 파일</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">nuget.org뿐만 아니라 종종 UI 표시에 표시되는 패키지 홈페이지의 URL입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ko.xlf
@@ -12,6 +12,16 @@
         <target state="translated">빌드 시 NuGet 패키지 생성</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">라이선스</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">어셈블리 중립 언어</target>
@@ -67,6 +87,16 @@
         <target state="translated">패키지 라이선스</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">SPDX 라이선스 식</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">없음</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Generuj pakiet NuGet podczas kompilacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Licencja</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Język neutralny zestawu</target>
@@ -67,6 +87,16 @@
         <target state="translated">Licencja pakietu</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Wyrażenie licencji SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Brak</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pl.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Plik licencji</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">Adres URL strony głównej pakietu często wyświetlany w interfejsach użytkownika oraz w witrynie nuget.org.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Gerar o pacote NuGet no build</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Licença</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Idioma neutro do assembly</target>
@@ -67,6 +87,16 @@
         <target state="translated">Licença do Pacote</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Expressão de Licença SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Nenhum</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.pt-BR.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Arquivo de licença</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">Uma URL para a home page do pacote, geralmente mostrada em exibições da interface do usuário, além de em nuget.org.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Формировать пакет NuGet при сборке</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Лицензия</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Сборка на нейтральном языке</target>
@@ -67,6 +87,16 @@
         <target state="translated">Лицензия пакета</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">Выражение лицензии SPDX</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Нет</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.ru.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Файл лицензии</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">URL-адрес домашней страницы пакета, часто отображающийся в пользовательском интерфейсе, а также в nuget.org.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
@@ -172,6 +172,16 @@
         <target state="translated">Lisans dosyası</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">Paketin ana sayfasının URL'si; genellikle kullanıcı arabirimi görüntülerinde ve nuget.org'da gösterilir.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.tr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Derlemede NuGet paketi oluştur</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">Lisans</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">Bütünleştirilmiş kod bağımsız dili</target>
@@ -67,6 +87,16 @@
         <target state="translated">Paket Lisansı</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">SPDX Lisans İfadesi</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">Hiçbiri</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="translated">在构建时生成 NuGet 包</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">许可证</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">程序集非特定语言</target>
@@ -67,6 +87,16 @@
         <target state="translated">包许可证</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">SPDX 许可证表达式</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">无</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hans.xlf
@@ -172,6 +172,16 @@
         <target state="translated">许可证文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">包主页的 URL，通常显示在 UI 和 nuget.org 中。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
@@ -172,6 +172,16 @@
         <target state="translated">授權檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|Description">
+        <source>Determines the output path in which the package will be dropped.</source>
+        <target state="new">Determines the output path in which the package will be dropped.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PackageOutputPath|DisplayName">
+        <source>Package Output Path</source>
+        <target state="new">Package Output Path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|PackageProjectUrl|Description">
         <source>A URL for the package's home page, often shown in UI displays as well as nuget.org.</source>
         <target state="translated">套件首頁的 URL，通常顯示在 UI 顯示及 nuget.org 中。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/PackagePropertyPage.xaml.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="translated">在建置時產生 NuGet 套件</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|Description">
+        <source>Create an additional symbol package when the project is packed.</source>
+        <target state="new">Create an additional symbol package when the project is packed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IncludeSymbols|DisplayName">
+        <source>Produce a symbol package</source>
+        <target state="new">Produce a symbol package</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|PackAsTool|Description">
         <source>Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</source>
         <target state="new">Packs this project as a special package that contains a console application that may be installed via the "dotnet tool" command.</target>
@@ -52,6 +62,16 @@
         <target state="translated">授權</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Symbols|Description">
+        <source>Specifies how symbols are added to the package.</source>
+        <target state="new">Specifies how symbols are added to the package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Symbols|DisplayName">
+        <source>Symbols</source>
+        <target state="new">Symbols</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|NeutralLanguage|DisplayName">
         <source>Assembly neutral language</source>
         <target state="translated">組件中性語言</target>
@@ -67,6 +87,16 @@
         <target state="translated">套件授權</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|Description">
+        <source>Specifies the format of the symbols package.</source>
+        <target state="new">Specifies the format of the symbols package.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|SymbolPackageFormat|DisplayName">
+        <source>Symbol package format</source>
+        <target state="new">Symbol package format</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|PackageLicenseKind.Expression|DisplayName">
         <source>SPDX License Expression</source>
         <target state="translated">SPDX 授權運算式</target>
@@ -80,6 +110,16 @@
       <trans-unit id="EnumValue|PackageLicenseKind.None|DisplayName">
         <source>None</source>
         <target state="translated">無</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.snupkg|DisplayName">
+        <source>snupkg</source>
+        <target state="new">snupkg</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|SymbolPackageFormat.symbols.nupkg|DisplayName">
+        <source>symbols.nupkg (legacy)</source>
+        <target state="new">symbols.nupkg (legacy)</target>
         <note />
       </trans-unit>
       <trans-unit id="Rule|Package|Description">


### PR DESCRIPTION
When packing a project, the tooling supports producing an additional package containing debug symbols.

This change adds a boolean property to opt in to this feature, and a drop down to select the format of this package.

![image](https://user-images.githubusercontent.com/350947/162986834-ea7ff299-9f33-4c46-9b64-8422b0fef5fa.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8070)