### PR TITLE
Suppress NU1504

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,4 +91,10 @@
     <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      TODO: Suppress warnings about duplicate PackageReferences until we can remove them (https://github.com/dotnet/project-system/issues/8074)
+    -->
+    <NoWarn>$(NoWarn);NU1504</NoWarn>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to #8074.

Warnings about duplicate PackageReference items are being promoted to errors in build.cmd and thus breaking our build. Here we suppress the warning until we can remove the duplicates.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8075)