### PR TITLE
Express always-hidden property with static data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -176,14 +176,12 @@
   <BoolProperty Name="WarningLevelOverridden"
                 DisplayName="WarningLevelOverridden"
                 Category="ErrorsAndWarnings"
-                ReadOnly="True">
+                ReadOnly="True"
+                Visible="False">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="True"
                   Persistence="ProjectFileWithInterception" />
     </BoolProperty.DataSource>
-    <BoolProperty.Metadata>
-      <NameValuePair Name="VisibilityCondition" Value="false" />
-    </BoolProperty.Metadata>
   </BoolProperty>
   
   <EnumProperty Name="WarningLevel"


### PR DESCRIPTION
The `WarningLevelOverridden` property should never be visible. This was being achieved with a visibility condition. However that requires the UI to create and maintain an object for the property, re-evaluating its visibility as the UI updates.

By setting the `IsVisible` property to false, the UI can be slightly more efficient here.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8077)