### PR TITLE
Remove unnecessary lambda expressions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                     // We don't need to thread switch here because if the caller is on the UI thread then everything is fine
                     // and if the caller is on a background thread, switching us to the UI thread doesn't provide any guarantees to it.
                     // It would mean the bridges state can't change, but it only reads the state once, and thats not our responsibility anyway.
-                    return _threadingService.ExecuteSynchronously(() => bridge.GetDesignTimeOutputMonikersAsync());
+                    return _threadingService.ExecuteSynchronously(bridge.GetDesignTimeOutputMonikersAsync);
                 }
 
                 throw new NotImplementedException();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         private static ImmutableArray<IProjectTree> GetChildren(IProjectTree projectTree)
         {
-            return projectTree.Children.Where(x => HasValidDisplayOrder(x)).OrderBy(x => GetDisplayOrder(x)).ToImmutableArray();
+            return projectTree.Children.Where(HasValidDisplayOrder).OrderBy(GetDisplayOrder).ToImmutableArray();
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 return property ?? string.Empty;
             }
 
-            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, projectXml => _helper.TryGetValueFromTarget(projectXml)) ?? string.Empty;
+            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, _helper.TryGetValueFromTarget) ?? string.Empty;
         }
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 return property;
             }
 
-            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, projectXml => _helper.TryGetValueFromTarget(projectXml)) ?? string.Empty;
+            return await _projectAccessor.OpenProjectXmlForReadAsync(_unconfiguredProject, _helper.TryGetValueFromTarget) ?? string.Empty;
         }
 
         public override async Task<string?> OnSetPropertyValueAsync(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -50,11 +50,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
             Assumes.NotNull(configuredProject);
 
-            return await ProjectAccessor.OpenProjectForReadAsync(configuredProject, evaluatedProject =>
-            {
-                // Need evaluated property to get inherited properties defines in props or targets.
-                return GetOrderedPropertyValues(evaluatedProject);
-            });
+            // Need evaluated property to get inherited properties defined in props or targets.
+            return await ProjectAccessor.OpenProjectForReadAsync(configuredProject, GetOrderedPropertyValues);
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
                 IPropertyPagesCatalog catalog = await catalogProvider.GetCatalogAsync(PropertyPageContexts.Project);
                 return catalog.GetPropertyPagesSchemas()
-                    .Select(name => catalog.GetSchema(name))
+                    .Select(catalog.GetSchema)
                     .WhereNotNull()
                     .Where(rule => string.Equals(rule.PageTemplate, "CommandNameBasedDebugger", StringComparison.OrdinalIgnoreCase)
                             && rule.Metadata.TryGetValue("CommandName", out object pageCommandNameObj))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             _prioritizedProjectLoadedInHost.SetResult();
 
-            _threadingService.ExecuteSynchronously(() => _prioritizedTasks.JoinTillEmptyAsync());
+            _threadingService.ExecuteSynchronously(_prioritizedTasks.JoinTillEmptyAsync);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IConfigurationGroupFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IConfigurationGroupFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         public static IConfigurationGroup<ProjectConfiguration> CreateFromConfigurationNames(params string[] configurationNames)
         {
-            IEnumerable<ProjectConfiguration> configurations = configurationNames.Select(name => ProjectConfigurationFactory.Create(name));
+            IEnumerable<ProjectConfiguration> configurations = configurationNames.Select(ProjectConfigurationFactory.Create);
 
             return Create(configurations);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 return Task.FromResult(ConfiguredProjectFactory.ImplementProjectConfiguration(projectConfiguration));
             });
 
-            var dimensionProviders = dimensionNames.Select(name => IActiveConfiguredProjectsDimensionProviderFactory.ImplementDimensionName(name));
+            var dimensionProviders = dimensionNames.Select(IActiveConfiguredProjectsDimensionProviderFactory.ImplementDimensionName);
 
             return CreateInstance(services: services, project: project, dimensionProviders: dimensionProviders);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/PublishableProjectConfigProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/PublishableProjectConfigProviderTests.cs
@@ -31,10 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         {
             var provider = CreateInstance();
 
-            await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            {
-                return provider.ShowPublishPromptAsync();
-            });
+            await Assert.ThrowsAsync<InvalidOperationException>(provider.ShowPublishPromptAsync);
         }
 
         private static PublishableProjectConfigProvider CreateInstance()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -277,10 +277,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             var moqFS = new IFileSystemMock();
             using var provider = GetLaunchSettingsProvider(moqFS);
-            await Assert.ThrowsAsync<FileNotFoundException>(() =>
-{
-    return provider.ReadSettingsFileFromDiskTestAsync();
-});
+            await Assert.ThrowsAsync<FileNotFoundException>(provider.ReadSettingsFileFromDiskTestAsync);
         }
 
         [Fact]
@@ -302,10 +299,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             using var provider = GetLaunchSettingsProvider(moqFS);
             await moqFS.WriteAllTextAsync(provider.LaunchSettingsFile, BadJsonString);
 
-            await Assert.ThrowsAsync<JsonReaderException>(() =>
-            {
-                return provider.ReadSettingsFileFromDiskTestAsync();
-            });
+            await Assert.ThrowsAsync<JsonReaderException>(provider.ReadSettingsFileFromDiskTestAsync);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeTests.cs
@@ -7,9 +7,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public void Constructor_ValueAsTreeService_SetTreeServiceProperty()
         {
-            var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.Create());
+            var projectTreeService = new Lazy<IProjectTreeService>(IProjectTreeServiceFactory.Create);
             var projectTreeProvider = new Lazy<IProjectTreeProvider>(() => IProjectTreeProviderFactory.Create());
-            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(() => IPhysicalProjectTreeStorageFactory.Create());
+            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(IPhysicalProjectTreeStorageFactory.Create);
 
             var projectTree = new PhysicalProjectTree(projectTreeService, projectTreeProvider, projectTreeStorage);
 
@@ -19,9 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public void Constructor_ValueAsTreeProvider_SetTreeProviderProperty()
         {
-            var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.Create());
+            var projectTreeService = new Lazy<IProjectTreeService>(IProjectTreeServiceFactory.Create);
             var projectTreeProvider = new Lazy<IProjectTreeProvider>(() => IProjectTreeProviderFactory.Create());
-            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(() => IPhysicalProjectTreeStorageFactory.Create());
+            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(IPhysicalProjectTreeStorageFactory.Create);
 
             var projectTree = new PhysicalProjectTree(projectTreeService, projectTreeProvider, projectTreeStorage);
 
@@ -31,9 +31,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public void Constructor_ValueAsTreeStorage_SetTreeStorageProperty()
         {
-            var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.Create());
+            var projectTreeService = new Lazy<IProjectTreeService>(IProjectTreeServiceFactory.Create);
             var projectTreeProvider = new Lazy<IProjectTreeProvider>(() => IProjectTreeProviderFactory.Create());
-            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(() => IPhysicalProjectTreeStorageFactory.Create());
+            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(IPhysicalProjectTreeStorageFactory.Create);
 
             var projectTree = new PhysicalProjectTree(projectTreeService, projectTreeProvider, projectTreeStorage);
 
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.ImplementCurrentTree(() => null));
             var projectTreeProvider = new Lazy<IProjectTreeProvider>(() => IProjectTreeProviderFactory.Create());
-            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(() => IPhysicalProjectTreeStorageFactory.Create());
+            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(IPhysicalProjectTreeStorageFactory.Create);
 
             var projectTree = new PhysicalProjectTree(projectTreeService, projectTreeProvider, projectTreeStorage);
 
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var projectTreeServiceState = IProjectTreeServiceStateFactory.ImplementTree(() => null);
             var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.ImplementCurrentTree(() => projectTreeServiceState));
             var projectTreeProvider = new Lazy<IProjectTreeProvider>(() => IProjectTreeProviderFactory.Create());
-            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(() => IPhysicalProjectTreeStorageFactory.Create());
+            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(IPhysicalProjectTreeStorageFactory.Create);
 
             var projectTree = new PhysicalProjectTree(projectTreeService, projectTreeProvider, projectTreeStorage);
 
@@ -75,7 +75,7 @@ Root (flags: {ProjectRoot})
             var projectTreeServiceState = IProjectTreeServiceStateFactory.ImplementTree(() => tree);
             var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.ImplementCurrentTree(() => projectTreeServiceState));
             var projectTreeProvider = new Lazy<IProjectTreeProvider>(() => IProjectTreeProviderFactory.Create());
-            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(() => IPhysicalProjectTreeStorageFactory.Create());
+            var projectTreeStorage = new Lazy<IPhysicalProjectTreeStorage>(IPhysicalProjectTreeStorageFactory.Create);
 
             var projectTree = new PhysicalProjectTree(projectTreeService, projectTreeProvider, projectTreeStorage);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             Assert.Collection(items,
                 item => Assert.Equal("Profile3", item!.EvaluatedInclude),
-                item => Assert.Null(item),
+                Assert.Null,
                 item => Assert.Equal("Profile1", item!.EvaluatedInclude));
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProviderTestBase.cs
@@ -156,7 +156,7 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
             // We override CreateFileAsync to call the CreateEmptyFileAsync which makes writting tests in the base easier
             var mock = new Mock<T>(arguments);
             mock.Protected().Setup<Task>("CreateFileAsync", ItExpr.IsAny<string>())
-                .Returns<string>(path => projectTree.TreeStorage.CreateEmptyFileAsync(path));
+                .Returns<string>(projectTree.TreeStorage.CreateEmptyFileAsync);
 
             mock.CallBase = true;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
@@ -229,7 +229,7 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
             // We override CreateFileAsync to call the CreateEmptyFileAsync which makes writting tests in the base easier
             var mock = new Mock<T>(arguments);
             mock.Protected().Setup<Task>("CreateFileCoreAsync", ItExpr.IsAny<string>())
-                .Returns<string>(path => projectTree.TreeStorage.CreateEmptyFileAsync(path));
+                .Returns<string>(projectTree.TreeStorage.CreateEmptyFileAsync);
 
             mock.CallBase = true;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 projectSystemOptions.Object,
                 configuredProject.Object,
                 projectAsynchronousTasksService.Object,
-                ITelemetryServiceFactory.Create(telemetryParameters => _telemetryEvents.Add(telemetryParameters)),
+                ITelemetryServiceFactory.Create(_telemetryEvents.Add),
                 _fileSystem,
                 upToDateCheckHost.Object);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             var mock = new Mock<IActiveConfiguredProjectSubscriptionService>();
 
             mock.SetupGet(s => s.ProjectRuleSource)
-                .Returns(() => IProjectValueDataSourceFactory.CreateInstance<IProjectSubscriptionUpdate>());
+                .Returns(IProjectValueDataSourceFactory.CreateInstance<IProjectSubscriptionUpdate>);
 
             if (sourceItemsRuleSource != null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IRoslynServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IRoslynServicesFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var mock = new Mock<IRoslynServices>();
 
             mock.Setup(h => h.IsValidIdentifier(It.IsAny<string>()))
-                .Returns<string>(name => syntaxFactsService.IsValidIdentifier(name));
+                .Returns<string>(syntaxFactsService.IsValidIdentifier);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -749,7 +749,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             threadingService ??= IProjectThreadingServiceFactory.Create();
             debugger ??= IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: false);
 
-            IUnconfiguredProjectVsServices unconfiguredProjectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(() => IVsHierarchyFactory.Create());
+            IUnconfiguredProjectVsServices unconfiguredProjectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(IVsHierarchyFactory.Create);
 
             IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService = Mock.Of<IRemoteDebuggerAuthenticationService>();
 
@@ -764,7 +764,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 threadingService,
                 IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger),
                 remoteDebuggerAuthenticationService,
-                new Lazy<IProjectHotReloadSessionManager>(() => IProjectHotReloadSessionManagerFactory.Create()),
+                new Lazy<IProjectHotReloadSessionManager>(IProjectHotReloadSessionManagerFactory.Create),
                 new Lazy<IHotReloadOptionService>(() => hotReloadSettings ?? IHotReloadOptionServiceFactory.Create()));
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -31,10 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(vsProjectDesignerPageService);
 
-            Assert.ThrowsAsync<InvalidOperationException>(() =>
-            {
-                return designerService.ShowProjectDesignerAsync();
-            });
+            Assert.ThrowsAsync<InvalidOperationException>(designerService.ShowProjectDesignerAsync);
         }
 
         [Fact]
@@ -49,10 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-            await Assert.ThrowsAsync<COMException>(() =>
-            {
-                return designerService.ShowProjectDesignerAsync();
-            });
+            await Assert.ThrowsAsync<COMException>(designerService.ShowProjectDesignerAsync);
         }
 
         [Fact]
@@ -67,10 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-            await Assert.ThrowsAsync<COMException>(() =>
-            {
-                return designerService.ShowProjectDesignerAsync();
-            });
+            await Assert.ThrowsAsync<COMException>(designerService.ShowProjectDesignerAsync);
         }
 
         [Fact]
@@ -90,10 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-            await Assert.ThrowsAsync<COMException>(() =>
-            {
-                return designerService.ShowProjectDesignerAsync();
-            });
+            await Assert.ThrowsAsync<COMException>(designerService.ShowProjectDesignerAsync);
         }
 
         [Fact]
@@ -134,10 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             var designerService = CreateInstance(projectVsServices, vsProjectDesignerPageService);
 
-            await Assert.ThrowsAsync<COMException>(() =>
-            {
-                return designerService.ShowProjectDesignerAsync();
-            });
+            await Assert.ThrowsAsync<COMException>(designerService.ShowProjectDesignerAsync);
         }
 
         [Fact]


### PR DESCRIPTION
This PR applies the automated codefix for IDE0200 across the solution.

Historically, Roslyn would not cache the delegate generated when converting a method group to a delegate. This changed recently and our version of the compiler now does so.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8078)