### PR TITLE
Allow null set on unevaluated property value

### DIFF
--- a/docs/repo/property-pages/back-end-architecture.md
+++ b/docs/repo/property-pages/back-end-architecture.md
@@ -34,6 +34,8 @@ The Project Query API treats its use of brokered services as an implementation d
 
 Internally, the Project Query API handles serializing the query, sending it across the network, deserializing it, and coordinating the actions of an extensible set of data providers. These data providers are responsible for filling in the requested properties on various entities, creating child entities from their parents, and handling various "actions" that update state in some way. For example, one provider may be responsible for creating project entities representing all the projects in the solution, while a different provider is responsible for filling in the project's name, path, GUID, language, etc. There may be multiple providers that handle the same relationship from a parent to its children or the same action. Among other things, the Project Query API implementation glues together the results of all of these providers to create the final query result.
 
+Please note that internally, setting either a property's evaluated or unevaluated value to null will call `IProject.DeleteAsync` to delete the property.
+
 ### 5. Standard query data providers
 
 CPS provides a number of built-in/standard query data providers. These generally expose data about the solution, projects, project items, references, project configuration, etc. We build off the data model that is populated by some of these providers but do not interact with them directly; no more will be said about them here.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetEvaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetEvaluatedUIPropertyValueAction.cs
@@ -25,7 +25,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task SetValueAsync(IProperty property)
         {
-            return property.SetValueAsync(_parameter.Value);
+            if (_parameter.Value == null)
+            {
+                return property.DeleteAsync();
+            }
+            else
+            {
+                return property.SetValueAsync(_parameter.Value);
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
@@ -25,14 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task SetValueAsync(IProperty property)
         {
-            if (property is IEvaluatedProperty evaluatedProperty)
-            {
-                return evaluatedProperty.SetUnevaluatedValueAsync(_parameter.Value ?? string.Empty);
-            }
-            else
-            {
-                return property.SetValueAsync(_parameter.Value);
-            }
+            return property.SetValueAsync(_parameter.Value);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
@@ -25,7 +25,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task SetValueAsync(IProperty property)
         {
-            return property.SetValueAsync(_parameter.Value);
+            if (_parameter.Value == null)
+            {
+                return property.DeleteAsync();
+            }
+            else
+            {
+                return property.SetValueAsync(_parameter.Value);
+            }
         }
     }
 }


### PR DESCRIPTION
Similar to evaluated property values, this allows null-set unevaluated property values. This does not preclude an empty unevaluated value from being set.
This is for #6920 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8083)