### PR TITLE
Use raw strings in test data

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -295,111 +295,118 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Theory]
-        [InlineData(@"
-Root
-    Parent
-",
-            @"
-Root[caption]
-[indent]Parent[caption]
-")]
-
-        [InlineData(@"
-Root
-    Parent1
-    Parent2
-",
-            @"
-Root[caption]
-[indent]Parent1[caption]
-[indent]Parent2[caption]
-")]
-
-        [InlineData(@"
-Root
-    Parent1
-        Child
-    Parent2
-",
-            @"
-Root[caption]
-[indent]Parent1[caption]
-[indent][indent]Child[caption]
-[indent]Parent2[caption]
-")]
-
-        [InlineData(@"
-Root
-    Parent1
-        Child1
-        Child2
-    Parent2
-    Parent3
-        Child3
-        Child4
-            Grandchild
-    Parent4
-",
-            @"
-Root[caption]
-[indent]Parent1[caption]
-[indent][indent]Child1[caption]
-[indent][indent]Child2[caption]
-[indent]Parent2[caption]
-[indent]Parent3[caption]
-[indent][indent]Child3[caption]
-[indent][indent]Child4[caption]
-[indent][indent][indent]Grandchild[caption]
-[indent]Parent4[caption]
-")]
-
+        [InlineData(
+            """
+            Root
+                Parent
+            """,
+            """
+            Root[caption]
+            [indent]Parent[caption]
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent1
+                Parent2
+            """,
+            """
+            Root[caption]
+            [indent]Parent1[caption]
+            [indent]Parent2[caption]
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent1
+                    Child
+                Parent2
+            """,
+            """
+            Root[caption]
+            [indent]Parent1[caption]
+            [indent][indent]Child[caption]
+            [indent]Parent2[caption]
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent1
+                    Child1
+                    Child2
+                Parent2
+                Parent3
+                    Child3
+                    Child4
+                        Grandchild
+                Parent4
+            """,
+            """
+            Root[caption]
+            [indent]Parent1[caption]
+            [indent][indent]Child1[caption]
+            [indent][indent]Child2[caption]
+            [indent]Parent2[caption]
+            [indent]Parent3[caption]
+            [indent][indent]Child3[caption]
+            [indent][indent]Child4[caption]
+            [indent][indent][indent]Grandchild[caption]
+            [indent]Parent4[caption]
+            """)]
         public void Parse_RootWithChildren_CanParse(string input, string expected)
         {
             AssertProjectTree(input, expected, ProjectTreeWriterOptions.None);
         }
 
         [Theory]
-        [InlineData(@"
-Root
-Root
-")]
-        [InlineData(@"
-Root
-    Parent
-Root
-")]
-        [InlineData(@"
-Root
-    Parent
-        Child
-Root
-")]
-        [InlineData(@"
-Root
-    Parent
-        Child
-        Child
-Root
-")]
+        [InlineData(
+            """
+            Root
+            Root
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent
+            Root
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent
+                    Child
+            Root
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent
+                    Child
+                    Child
+            Root
+            """)]
         public void Parse_MultipleRoots_ThrowsFormat(string input)
         {
             AssertThrows(input, ProjectTreeFormatError.MultipleRoots);
         }
 
         [Theory]
-        [InlineData(@"
-Root
-        Parent
-")]
-        [InlineData(@"
-Root
-    Parent 
-            Parent
-")]
-        [InlineData(@"
-Root
-            Parent
-")]
+        [InlineData(
+            """
+            Root
+                    Parent
+            """)]
+        [InlineData(
+            """
+            Root
+                Parent 
+                        Parent
+            """)]
+        [InlineData(
+            """
+            Root
+                        Parent
+            """)]
         public void Parse_IndentTooManyLevels_ThrowsFormat(string input)
         {
             AssertThrows(input, ProjectTreeFormatError.IndentTooManyLevels);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
@@ -32,12 +32,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public static IProjectSubscriptionUpdate CreateEmpty()
         {
-            return FromJson(@"
-{
-    ""CurrentState"": {
-    }
-}
-");
+            return FromJson(
+                """
+                {
+                    "CurrentState": {
+                    }
+                }
+                """);
         }
 
         public static IProjectSubscriptionUpdate FromJson(string jsonString)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/ApplyChangesToWorkspaceContextTests.cs
@@ -237,26 +237,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""RuleName"": {
-            ""Difference"": { 
-                ""AnyChanges"": false
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "RuleName": {
+                            "Difference": { 
+                                "AnyChanges": false
+                            },
+                        }
+                    }
+                }
+                """);
 
             var sourceItemsUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""RuleName"": {
-            ""Difference"": { 
-                ""AnyChanges"": false
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "RuleName": {
+                            "Difference": { 
+                                "AnyChanges": false
+                            },
+                        }
+                    }
+                }
+                """);
 
             var update = IProjectVersionedValueFactory.Create((projectUpdate, sourceItemsUpdate), ProjectDataSources.ConfiguredProjectVersion, 1);
 
@@ -274,15 +278,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": false
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": false
+                            },
+                        }
+                    }
+                }
+                """);
 
             var update = IProjectVersionedValueFactory.Create((projectUpdate, _unchangedCommandLineArguments));
 
@@ -304,15 +310,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""RuleName"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "RuleName": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        }
+                    }
+                }
+                """);
 
             var sourceItemsUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
             int version = 2;
@@ -342,15 +350,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
             var sourceItemsUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""RuleName"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "RuleName": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        }
+                    }
+                }
+                """);
             int version = 2;
 
             var update = IProjectVersionedValueFactory.Create((projectUpdate, sourceItemsUpdate), ProjectDataSources.ConfiguredProjectVersion, version);
@@ -379,17 +389,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(commandLineParser: parser, handlers: new[] { handler });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": true,
-                ""AddedItems"" : [ ""/reference:Added.dll"" ],
-                ""RemovedItems"" : [ ""/reference:Removed.dll"" ]
-            }
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": true,
+                                "AddedItems" : [ "/reference:Added.dll" ],
+                                "RemovedItems" : [ "/reference:Removed.dll" ]
+                            }
+                        }
+                    }
+                }
+                """);
             int version = 2;
 
             var update = IProjectVersionedValueFactory.Create((projectUpdate, _changedCommandLineArguments), ProjectDataSources.ConfiguredProjectVersion, version);
@@ -417,20 +429,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler1, handler2 });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""RuleName1"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        },
-        ""RuleName2"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "RuleName1": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        },
+                        "RuleName2": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        }
+                    }
+                }
+                """);
 
             var sourceItemsUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
 
@@ -458,15 +472,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler1, handler2 });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        }
+                    }
+                }
+                """);
             var update = IProjectVersionedValueFactory.Create((projectUpdate, _changedCommandLineArguments), ProjectDataSources.ConfiguredProjectVersion, 1);
 
             Assert.Throws<OperationCanceledException>(() =>
@@ -487,20 +503,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        },
-        ""RuleName"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        },
+                        "RuleName": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        }
+                    }
+                }
+                """);
 
             var sourceItemsUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
 
@@ -520,20 +538,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(handlers: new[] { handler });
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        },
-        ""RuleName"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        },
+                        "RuleName": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                        }
+                    }
+                }
+                """);
             var update = IProjectVersionedValueFactory.Create((projectUpdate, _changedCommandLineArguments), ProjectDataSources.ConfiguredProjectVersion, 1);
 
             applyChangesToWorkspace.ApplyProjectBuild(update, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), CancellationToken.None);
@@ -548,18 +568,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             context.LastDesignTimeBuildSucceeded = true;
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-            ""After"": { 
-                ""EvaluationSucceeded"": false
-            }
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                            "After": { 
+                                "EvaluationSucceeded": false
+                            }
+                        }
+                    }
+                }
+                """);
             var update = IProjectVersionedValueFactory.Create((projectUpdate, _changedCommandLineArguments), ProjectDataSources.ConfiguredProjectVersion, 1);
 
             applyChangesToWorkspace.ApplyProjectBuild(update, new ContextState(), CancellationToken.None);
@@ -573,18 +595,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             var applyChangesToWorkspace = CreateInitializedInstance(out var context);
 
             var projectUpdate = IProjectSubscriptionUpdateFactory.FromJson(
-@"{
-   ""ProjectChanges"": {
-        ""CompilerCommandLineArgs"": {
-            ""Difference"": { 
-                ""AnyChanges"": true
-            },
-            ""After"": { 
-                ""EvaluationSucceeded"": true
-            }
-        }
-    }
-}");
+                """
+                {
+                   "ProjectChanges": {
+                        "CompilerCommandLineArgs": {
+                            "Difference": { 
+                                "AnyChanges": true
+                            },
+                            "After": { 
+                                "EvaluationSucceeded": true
+                            }
+                        }
+                    }
+                }
+                """);
             var update = IProjectVersionedValueFactory.Create((projectUpdate, _changedCommandLineArguments), ProjectDataSources.ConfiguredProjectVersion, 1);
 
             applyChangesToWorkspace.ApplyProjectBuild(update, new ContextState(true, false), CancellationToken.None);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/DynamicItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/DynamicItemHandlerTests.cs
@@ -18,13 +18,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(project, context);
 
             var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty.Add(
-                "None", IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""AddedItems"": [ ""File1.razor"", ""File1.cshtml"", ""File1.cs"" ]
-    }
-}"));
+                "None",
+                IProjectChangeDescriptionFactory.FromJson(
+                    """
+                    {
+                        "Difference": { 
+                            "AnyChanges": true,
+                            "AddedItems": [ "File1.razor", "File1.cshtml", "File1.cs" ]
+                        }
+                    }
+                    """));
 
             Handle(handler, projectChanges);
 
@@ -44,21 +47,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = CreateInstance(project, context);
 
-            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty.Add(
-                "None", IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""AddedItems"": [ ""File1.razor"", ""File1.cs"" ]
-    }
-}")).Add(
-                "Content", IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""AddedItems"": [ ""File1.cshtml"", ""File2.cs"" ]
-    }
-}"));
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty
+                .Add(
+                    "None",
+                    IProjectChangeDescriptionFactory.FromJson(
+                        """
+                        {
+                            "Difference": { 
+                                "AnyChanges": true,
+                                "AddedItems": [ "File1.razor", "File1.cs" ]
+                            }
+                        }
+                        """))
+                .Add(
+                    "Content",
+                    IProjectChangeDescriptionFactory.FromJson(
+                        """
+                        {
+                            "Difference": { 
+                                "AnyChanges": true,
+                                "AddedItems": [ "File1.cshtml", "File2.cs" ]
+                            }
+                        }
+                        """));
 
             Handle(handler, projectChanges);
 
@@ -78,21 +89,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var handler = CreateInstance(project, context);
 
-            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty.Add(
-                "None", IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""AddedItems"": [ ""File1.razor"", ""File1.cs"" ]
-    }
-}")).Add(
-                "Content", IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""AddedItems"": [ ""File1.razor"", ""File1.cshtml"", ""File2.cs"" ]
-    }
-}"));
+            var projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty
+                .Add(
+                    "None",
+                    IProjectChangeDescriptionFactory.FromJson(
+                        """
+                        {
+                            "Difference": { 
+                                "AnyChanges": true,
+                                "AddedItems": [ "File1.razor", "File1.cs" ]
+                            }
+                        }
+                        """))
+                .Add(
+                    "Content",
+                    IProjectChangeDescriptionFactory.FromJson(
+                        """
+                        {
+                            "Difference": { 
+                                "AnyChanges": true,
+                                "AddedItems": [ "File1.razor", "File1.cshtml", "File2.cs" ]
+                            }
+                        }
+                        """));
 
             Handle(handler, projectChanges);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandlerTests.cs
@@ -17,11 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(context: context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true
+                    }
+                }
+                """);
 
             Handle(handler, projectChange);
 
@@ -38,17 +40,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(context: context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ""MSBuildProjectFullPath"" ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""MSBuildProjectFullPath"": ""NewProjectFilePath""
-        }
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true,
+                        "ChangedProperties": [ "MSBuildProjectFullPath" ]
+                    },
+                    "After": { 
+                        "Properties": {
+                            "MSBuildProjectFullPath": "NewProjectFilePath"
+                        }
+                    }
+                }
+                """);
             Handle(handler, projectChange);
 
             Assert.Equal(@"NewProjectFilePath", context.ProjectFilePath);
@@ -62,17 +66,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(context: context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ""MSBuildProjectFullPath"" ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj""
-        }
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true,
+                        "ChangedProperties": [ "MSBuildProjectFullPath" ]
+                    },
+                    "After": { 
+                        "Properties": {
+                            "MSBuildProjectFullPath": "C:\\Project\\Project.csproj"
+                        }
+                    }
+                }
+                """);
             Handle(handler, projectChange);
 
             Assert.Equal(@"Project", context.DisplayName);
@@ -97,17 +103,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(configuration, implicitlyActiveDimensionProvider, context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ""MSBuildProjectFullPath"" ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj""
-        }
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true,
+                        "ChangedProperties": [ "MSBuildProjectFullPath" ]
+                    },
+                    "After": { 
+                        "Properties": {
+                            "MSBuildProjectFullPath": "C:\\Project\\Project.csproj"
+                        }
+                    }
+                }
+                """);
             Handle(handler, projectChange);
 
             Assert.Equal(expected, context.DisplayName);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandlerTests.cs
@@ -16,17 +16,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(context: context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ""RootNamespace"" ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""RootNamespace"": ""value""
-        }
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true,
+                        "ChangedProperties": [ "RootNamespace" ]
+                    },
+                    "After": { 
+                        "Properties": {
+                            "RootNamespace": "value"
+                        }
+                    }
+                }
+                """);
 
             Handle(handler, projectChange);
 
@@ -43,17 +45,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(context: context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ""TargetPath"" ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""TargetPath"": ""NewBinOutputPath""
-        }
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true,
+                        "ChangedProperties": [ "TargetPath" ]
+                    },
+                    "After": { 
+                        "Properties": {
+                            "TargetPath": "NewBinOutputPath"
+                        }
+                    }
+                }
+                """);
 
             Handle(handler, projectChange);
 
@@ -69,17 +73,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var handler = CreateInstance(context: context);
 
             var projectChange = IProjectChangeDescriptionFactory.FromJson(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""TargetPath"": ""NewBinOutputPath""
-        }
-    }
-}");
+                """
+                {
+                    "Difference": { 
+                        "AnyChanges": true,
+                        "ChangedProperties": [ ]
+                    },
+                    "After": { 
+                        "Properties": {
+                            "TargetPath": "NewBinOutputPath"
+                        }
+                    }
+                }
+                """);
 
             Handle(handler, projectChange);
 
@@ -88,41 +94,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         [Theory]
         [InlineData(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": false,
-        ""ChangedProperties"": [ ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""RootNamespace"": ""value""
-        }
-    }
-}")]
+            """
+            {
+                "Difference": { 
+                    "AnyChanges": false,
+                    "ChangedProperties": [ ]
+                },
+                "After": { 
+                    "Properties": {
+                        "RootNamespace": "value"
+                    }
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ""TargetPath"" ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""TargetPath"": ""value""
-        }
-    }
-}")]
+            """
+            {
+                "Difference": { 
+                    "AnyChanges": true,
+                    "ChangedProperties": [ "TargetPath" ]
+                },
+                "After": { 
+                    "Properties": {
+                        "TargetPath": "value"
+                    }
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Difference"": { 
-        ""AnyChanges"": true,
-        ""ChangedProperties"": [ ]
-    },
-    ""After"": { 
-        ""Properties"": {
-            ""RootNamespace"": ""value""
-        }
-    }
-}")]
+            """
+            {
+                "Difference": { 
+                    "AnyChanges": true,
+                    "ChangedProperties": [ ]
+                },
+                "After": { 
+                    "Properties": {
+                        "RootNamespace": "value"
+                    }
+                }
+            }
+            """)]
         public void Handle_WhenPropertyIsNotChanged_DoesNotCallSetProperty(string input)
         {
             int callCount = 0;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceProjectContextProviderTests.cs
@@ -32,51 +32,62 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         [Theory]
         [InlineData(
-@"{
-    ""Properties"": {
-        ""LanguageServiceName"": ""CSharp"",
-        ""TargetPath"": ""C:\\Target.dll""
-    }
-}")]
-
+            """
+            {
+                "Properties": {
+                    "LanguageServiceName": "CSharp",
+                    "TargetPath": "C:\\Target.dll"
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Properties"": {
-        ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
-        ""TargetPath"": ""C:\\Target.dll""
-    }
-}")]
+            """
+            {
+                "Properties": {
+                    "MSBuildProjectFullPath": "C:\\Project\\Project.csproj",
+                    "TargetPath": "C:\\Target.dll"
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Properties"": {
-        ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
-        ""LanguageServiceName"": ""CSharp"",
-    }
-}")]
+            """
+            {
+                "Properties": {
+                    "MSBuildProjectFullPath": "C:\\Project\\Project.csproj",
+                    "LanguageServiceName": "CSharp",
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Properties"": {
-        ""MSBuildProjectFullPath"": """",
-        ""LanguageServiceName"": ""CSharp"",
-        ""TargetPath"": ""C:\\Target.dll""
-    }
-}")]
+            """
+            {
+                "Properties": {
+                    "MSBuildProjectFullPath": "",
+                    "LanguageServiceName": "CSharp",
+                    "TargetPath": "C:\\Target.dll"
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Properties"": {
-        ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
-        ""LanguageServiceName"": """",
-        ""TargetPath"": ""C:\\Target.dll""
-    }
-}")]
+            """
+            {
+                "Properties": {
+                    "MSBuildProjectFullPath": "C:\\Project\\Project.csproj",
+                    "LanguageServiceName": "",
+                    "TargetPath": "C:\\Target.dll"
+                }
+            }
+            """)]
         [InlineData(
-@"{
-    ""Properties"": {
-        ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
-        ""LanguageServiceName"": ""CSharp"",
-        ""TargetPath"": """"
-    }
-}")]
+            """
+            {
+                "Properties": {
+                    "MSBuildProjectFullPath": "C:\\Project\\Project.csproj",
+                    "LanguageServiceName": "CSharp",
+                    "TargetPath": ""
+                }
+            }
+            """)]
         public async Task CreateProjectContextAsync_WhenEmptyOrMissingMSBuildProperties_ReturnsNull(string json)
         {
             var snapshot = IProjectRuleSnapshotFactory.FromJson(json);
@@ -205,14 +216,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         private static WorkspaceProjectContextProvider CreateInstance(UnconfiguredProject? project = null, IProjectThreadingService? threadingService = null, IWorkspaceProjectContextFactory? workspaceProjectContextFactory = null, ISafeProjectGuidService? projectGuidService = null, IProjectRuleSnapshot? projectRuleSnapshot = null)
         {
             projectRuleSnapshot ??= IProjectRuleSnapshotFactory.FromJson(
-@"{
-    ""Properties"": {
-        ""MSBuildProjectFullPath"": ""C:\\Project\\Project.csproj"",
-        ""LanguageServiceName"": ""CSharp"",
-        ""TargetPath"": ""C:\\Target.dll"",
-        ""AssemblyName"": ""Project""
-    }
-}");
+                """
+                {
+                    "Properties": {
+                        "MSBuildProjectFullPath": "C:\\Project\\Project.csproj",
+                        "LanguageServiceName": "CSharp",
+                        "TargetPath": "C:\\Target.dll",
+                        "AssemblyName": "Project"
+                    }
+                }
+                """);
 
             var projectFaultService = IProjectFaultHandlerServiceFactory.Create();
             project ??= UnconfiguredProjectFactory.Create();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PhysicalProjectTreeTests.cs
@@ -68,9 +68,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public void Constructor_ValueAsTreeService_SetsCurrentTreeToTreeServiceCurrentTreeTree()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                """);
 
             var projectTreeServiceState = IProjectTreeServiceStateFactory.ImplementTree(() => tree);
             var projectTreeService = new Lazy<IProjectTreeService>(() => IProjectTreeServiceFactory.ImplementCurrentTree(() => projectTreeServiceState));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Reload/ProjectReloadInterceptorTests.cs
@@ -10,85 +10,96 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class ProjectReloadInterceptorTests
     {
         [Theory]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>    
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>    
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-</Project>
-")]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+                <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData("""
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>    
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>    
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+                <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+              </PropertyGroup>
+            </Project>
+            """)]
         public void InterceptProjectReload_WhenDimensionsChange_ReturnsNeedsForceReload(string oldProjectXml, string newProjectXml)
         {
             var oldProperties = CreateProperties(oldProjectXml);
@@ -102,58 +113,66 @@ namespace Microsoft.VisualStudio.ProjectSystem
         }
 
         [Theory]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
-  </PropertyGroup>
-</Project>
-")]
-        [InlineData(@"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-", @"
-<Project>
-  <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
-  </PropertyGroup>
-</Project>
-")]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworkIdentifier>.NETFramework</TargetFrameworkIdentifier>
+                <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFramework>net45</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """)]
+        [InlineData(
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+              <PropertyGroup>
+                <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+              </PropertyGroup>
+            </Project>
+            """)]
         public void InterceptProjectReload_WhenNoDimensionsChange_ReturnsNoAction(string oldProjectXml, string newProjectXml)
         {
             var oldProperties = CreateProperties(oldProjectXml);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractAppXamlSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractAppXamlSpecialFileProviderTestBase.cs
@@ -10,40 +10,46 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         }
 
         [Theory]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Application.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\Application.xaml""
-",
-@"C:\Project\Application.xaml")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    App.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\App.xaml""
-",
-@"C:\Project\App.xaml")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    ThisCanBeAnyName.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\ThisCanBeAnyName.xaml""
-",
-@"C:\Project\ThisCanBeAnyName.xaml")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Application.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\Application.xaml""
-    App.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\App.xaml""
-",
-@"C:\Project\Application.xaml")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties
-        Application.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\Properties\Application.xaml""
-",
-@"C:\Project\Properties\Application.xaml")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties
-        App.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\Properties\App.xaml""
-    Application.xaml, ItemType: ApplicationDefinition, FilePath: ""C:\Project\Application.xaml""
-",
-@"C:\Project\Application.xaml")]        // Breadthfirst
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Application.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\Application.xaml"
+            """,
+            @"C:\Project\Application.xaml")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                App.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\App.xaml"
+            """,
+            @"C:\Project\App.xaml")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                ThisCanBeAnyName.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\ThisCanBeAnyName.xaml"
+            """,
+            @"C:\Project\ThisCanBeAnyName.xaml")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Application.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\Application.xaml"
+                App.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\App.xaml"
+            """,
+            @"C:\Project\Application.xaml")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties
+                    Application.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\Properties\Application.xaml"
+            """,
+            @"C:\Project\Properties\Application.xaml")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties
+                    App.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\Properties\App.xaml"
+                Application.xaml, ItemType: ApplicationDefinition, FilePath: "C:\Project\Application.xaml"
+            """,
+            @"C:\Project\Application.xaml")]        // Breadthfirst
         public async Task GetFileAsync_WhenItemMarkedWithApplicationManifest_ReturnsPath(string input, string expected)
         {
             var tree = ProjectTreeParser.Parse(input);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProviderTestBase.cs
@@ -16,9 +16,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         [Fact]
         public async Task GetFileAsync_ReturnsPathUnderProjectRoot()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                """);
             var provider = CreateInstance(tree);
 
             var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
@@ -29,10 +30,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenRootWithFile_ReturnsPath()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             var provider = CreateInstance(tree);
 
             var result = await provider.GetFileAsync(0, SpecialFileFlags.FullPath);
@@ -43,10 +45,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithFolderSameName_ReturnsPath()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity Folder}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity Folder}), FilePath: "C:\Project\{{_fileName}}"
+                """);
 
             var provider = CreateInstance(tree);
 
@@ -58,10 +61,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithFolderSameName_ThrowsIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity Folder}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity Folder}), FilePath: "C:\Project\{{_fileName}}"
+                """);
 
             var provider = CreateInstance(tree);
 
@@ -74,10 +78,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithExcludedFile_IsAddedToProjectIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk IncludeInProjectCandidate}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk IncludeInProjectCandidate}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementAddFileAsync(path => callCount++);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
@@ -91,10 +96,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithExistentFile_ReturnsPathIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree);
             var provider = CreateInstance(physicalProjectTree);
 
@@ -106,9 +112,10 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithNoFile_IsCreatedIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                """);
 
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateEmptyFileAsync(path => callCount++);
@@ -123,10 +130,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithMissingFile_IsCreatedIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateEmptyFileAsync(path => callCount++);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProviderTestBase.cs
@@ -16,9 +16,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         [Fact]
         public async Task GetFileAsync_WhenNoAppDesigner_ReturnsPathUnderAppDesigner()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                """);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
             var provider = CreateInstance(specialFilesManager, tree);
 
@@ -30,10 +31,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenAppDesigner_ReturnsPathUnderAppDesigner()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {{FileSystemEntity Folder AppDesignerFolder}}), FilePath: ""C:\Project\Properties""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity Folder AppDesignerFolder}), FilePath: "C:\Project\Properties"
+                """);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
             var provider = CreateInstance(specialFilesManager, tree);
 
@@ -45,9 +47,10 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenAppDesignerNotSupported_ReturnsPathUnderProjectRoot()
         {   // AppDesigner is turned off
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                """);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
 
             var provider = CreateInstance(specialFilesManager, tree);
@@ -60,11 +63,12 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenAppDesignerWithFile_ReturnsPath()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {{FileSystemEntity Folder AppDesignerFolder}}), FilePath: ""C:\Project\Properties""
-        {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\Properties\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity Folder AppDesignerFolder}), FilePath: "C:\Project\Properties"
+                        {{_fileName}} (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\Properties\{{_fileName}}"
+                """);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
             var provider = CreateInstance(specialFilesManager, tree);
 
@@ -76,11 +80,12 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenAppDesignerButRootWithFile_ReturnsPath()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {{FileSystemEntity Folder AppDesignerFolder}}), FilePath: ""C:\Project\Properties""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity Folder AppDesignerFolder}), FilePath: "C:\Project\Properties"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(@"C:\Project\Properties");
             var provider = CreateInstance(specialFilesManager, tree);
 
@@ -92,10 +97,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenRootWithFile_ReturnsPath()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
 
             var provider = CreateInstance(specialFilesManager, tree);
@@ -108,10 +114,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithFolderSameName_ReturnsPath()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity Folder}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity Folder}), FilePath: "C:\Project\{{_fileName}}"
+                """);
 
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
             var provider = CreateInstance(specialFilesManager, tree);
@@ -124,10 +131,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithFolderSameName_ThrowsIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity Folder}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity Folder}), FilePath: "C:\Project\{{_fileName}}"
+                """);
 
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
             var provider = CreateInstance(specialFilesManager, tree);
@@ -141,10 +149,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithExcludedFile_IsAddedToProjectIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk IncludeInProjectCandidate}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk IncludeInProjectCandidate}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementAddFileAsync(path => callCount++);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
@@ -159,10 +168,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithExistentFile_ReturnsPathIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{FileSystemEntity FileOnDisk}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);
             var provider = CreateInstance(specialFilesManager, physicalProjectTree);
@@ -175,9 +185,10 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithNoFile_IsCreatedIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                """);
 
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateEmptyFileAsync(path => callCount++);
@@ -193,10 +204,11 @@ Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithMissingFile_IsCreatedIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse($@"
-Project (flags: {{ProjectRoot}}), FilePath: ""C:\Project\Project.csproj""
-    {_fileName} (flags: {{}}), FilePath: ""C:\Project\{_fileName}""
-");
+            var tree = ProjectTreeParser.Parse(
+                $$"""
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    {{_fileName}} (flags: {}), FilePath: "C:\Project\{{_fileName}}"
+                """);
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateEmptyFileAsync(path => callCount++);
             var specialFilesManager = ISpecialFilesManagerFactory.ImplementGetFile(null);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
@@ -5,69 +5,80 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
     public class AppDesignerFolderSpecialFileProviderTests
     {
         [Theory]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\Properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    properties (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    PROPERTIES (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\PROPERTIES")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder UnrecognizedCapability AppDesignerFolder BubbleUp})
-",
-@"C:\Project\Properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-        AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
-",
-@"C:\Project\Properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-        AssemblyInfo.cs (flags: {})
-",
-@"C:\Project\Properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder (flags: {Folder})
-",
-@"C:\Project\Properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Folder (flags: {Folder})
-        Properties (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\Folder\Properties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Folder (flags: {Folder})
-        NotCalledProperties (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\Folder\NotCalledProperties")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Folder (flags: {Folder})
-        My Project (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\Folder\My Project")]
-        [InlineData(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Folder1 (flags: {Folder})
-    Folder2 (flags: {Folder})
-        My Project (flags: {Folder AppDesignerFolder BubbleUp})
-",
-@"C:\Project\Folder2\My Project")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\Properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                PROPERTIES (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\PROPERTIES")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties (flags: {Folder UnrecognizedCapability AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\Properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                    AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
+            """,
+            @"C:\Project\Properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                    AssemblyInfo.cs (flags: {})
+            """,
+            @"C:\Project\Properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder (flags: {Folder})
+            """,
+            @"C:\Project\Properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Folder (flags: {Folder})
+                    Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\Folder\Properties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Folder (flags: {Folder})
+                    NotCalledProperties (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\Folder\NotCalledProperties")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Folder (flags: {Folder})
+                    My Project (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\Folder\My Project")]
+        [InlineData(
+            """
+            Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                Folder1 (flags: {Folder})
+                Folder2 (flags: {Folder})
+                    My Project (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            @"C:\Project\Folder2\My Project")]
         public async Task GetFile_WhenTreeWithAppDesignerFolder_ReturnsPath(string input, string expected)
         {
             var tree = ProjectTreeParser.Parse(input);
@@ -84,9 +95,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFile_WhenTreeWithAppDesignerFolder_ReturnsPathIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                """);
 
             var treeProvider = new ProjectTreeProvider();
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
@@ -105,10 +118,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [InlineData(@"",                        null)]
         public async Task GetFile_WhenTreeWithoutAppDesignerFolder_ReturnsDefaultAppDesignerFolder(string input, string expected)
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {FileSystemEntity Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity Folder})
+                """);
 
             var treeProvider = new ProjectTreeProvider();
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
@@ -125,10 +139,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithFileSameName_ReturnsDefaultAppDesignerFolder()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {FileSystemEntity FileOnDisk})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity FileOnDisk})
+                """);
 
             var treeProvider = new ProjectTreeProvider();
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
@@ -145,10 +160,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithFileSameName_ThrowsIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {FileSystemEntity FileOnDisk}), FilePath: ""C:\Project\Properties""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity FileOnDisk}), FilePath: "C:\Project\Properties"
+                """);
 
             var treeProvider = new ProjectTreeProvider();
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(provider: treeProvider, currentTree: tree);
@@ -166,10 +182,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithExcludedFolder_IsAddedToProjectIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {FileSystemEntity Folder IncludeInProjectCandidate}), FilePath: ""C:\Project\Properties""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity Folder IncludeInProjectCandidate}), FilePath: "C:\Project\Properties"
+                """);
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementAddFolderAsync(path => callCount++);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
@@ -184,10 +201,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithExistentAppDesignerFolder_ReturnsPathIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {FileSystemEntity Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {FileSystemEntity Folder AppDesignerFolder})
+                """);
 
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree);
 
@@ -201,8 +219,10 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenTreeWithNoAppDesignerFolder_IsCreatedIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                """);
 
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateFolderAsync(path => callCount++);
@@ -220,10 +240,11 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""");
         [Fact]
         public async Task GetFileAsync_WhenTreeWithMissingAppDesignerFolder_IsCreatedIfCreateIfNotExist()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot}), FilePath: "C:\Project\Project.csproj"
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
             int callCount = 0;
             var storage = IPhysicalProjectTreeStorageFactory.ImplementCreateFolderAsync(path => callCount++);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree, storage: storage);
@@ -238,9 +259,10 @@ Project (flags: {ProjectRoot}), FilePath: ""C:\Project\Project.csproj""
         [Fact]
         public async Task GetFileAsync_WhenRootMarkedWithDisableAddItemFolder_ReturnsNull()
         {   // Mimics an extension turning on DisableAddItem flag for our parent
-            var tree = ProjectTreeParser.Parse(@"
-Project (flags: {ProjectRoot DisableAddItemFolder}), FilePath: ""C:\Project\Project.csproj""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Project (flags: {ProjectRoot DisableAddItemFolder}), FilePath: "C:\Project\Project.csproj"
+                """);
             var physicalProjectTree = IPhysicalProjectTreeFactory.Create(currentTree: tree);
 
             var provider = CreateInstance(physicalProjectTree);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -70,19 +70,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => false);   // Don't support AppDesigner
             var propertiesProvider = CreateInstance(designerService);
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder})
+                """);
 
             Verify(propertiesProvider, tree, tree);
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+            """)]
         public void ChangePropertyValues_TreeWithMyProjectFolder_ReturnsUnmodifiedTree(string input)
         {   // "Properties" is the default, so we shouldn't find "My Project"
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -94,24 +96,28 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-        AssemblyInfo.cs (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-        AssemblyInfo.cs (flags: {})
-    NotProperties (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+                    AssemblyInfo.cs (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+                    AssemblyInfo.cs (flags: {})
+                NotProperties (flags: {Folder})
+            """)]
         public void ChangePropertyValues_TreeWithoutAppDesignerFolder_ReturnsUnmodifiedTree(string input)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => false);
@@ -123,18 +129,21 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {NotFolder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Unrecognized NotAFolder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {NotFolder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Unrecognized NotAFolder})
+            """)]
         public void ChangePropertyValues_TreeWithFileCalledProperties_ReturnsUnmodifiedTree(string input)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -146,18 +155,21 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder IncludeInProjectCandidate})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {IncludeInProjectCandidate Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {IncludeInProjectCandidate})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder IncludeInProjectCandidate})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {IncludeInProjectCandidate Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {IncludeInProjectCandidate})
+            """)]
         public void ChangePropertyValues_TreeWithExcludedAppDesignerFolder_ReturnsUnmodifiedTree(string input)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -169,23 +181,26 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-        Properties (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-        Folder (flags: {Folder})
-            Properties (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder1 (flags: {Folder})
-    Folder2 (flags: {Folder})
-        Properties (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+                    Properties (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+                    Folder (flags: {Folder})
+                        Properties (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder1 (flags: {Folder})
+                Folder2 (flags: {Folder})
+                    Properties (flags: {Folder})
+            """)]
         public void ChangePropertyValues_TreeWithNestedAppDesignerFolder_ReturnsUnmodifiedTree(string input)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -197,34 +212,42 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-", @"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-", @"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder BubbleUp})
-", @"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder Unrecognized AppDesignerFolder})
-", @"
-Root(flags: {ProjectRoot})
-    Properties (flags: {Folder Unrecognized AppDesignerFolder BubbleUp})
-")]
+        [InlineData(
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder})
+            """,
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder BubbleUp})
+            """,
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder Unrecognized AppDesignerFolder})
+            """,
+            """
+            Root(flags: {ProjectRoot})
+                Properties (flags: {Folder Unrecognized AppDesignerFolder BubbleUp})
+            """)]
         public void ChangePropertyValues_TreeWithAppDesignerFolderAlreadyMarkedAsAppDesignerOrBubbleup_AddsRemainingFlags(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -237,68 +260,84 @@ Root(flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder BubbleUp})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    properties (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    properties (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    PROPERTIES (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    PROPERTIES (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder UnrecognizedCapability})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder UnrecognizedCapability AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-        AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-        AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-        AssemblyInfo.cs (flags: {})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-        AssemblyInfo.cs (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-        Folder (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder BubbleUp})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                properties (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                properties (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                PROPERTIES (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                PROPERTIES (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder UnrecognizedCapability})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder UnrecognizedCapability AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder})
+                    AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                    AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder})
+                    AssemblyInfo.cs (flags: {})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                    AssemblyInfo.cs (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder})
+                    Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder (flags: {Folder})
+            """)]
         public void ChangePropertyValues_TreeWithAppDesignerFolder_ReturnsCandidateMarkedWithAppDesignerFolderAndBubbleUp(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -311,15 +350,17 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {FileSystemEntity Folder})
-        Folder (flags: {FileSystemEntity Folder})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {FileSystemEntity Folder AppDesignerFolder BubbleUp}), Icon: {259567C1-AA6B-46BF-811C-C145DD9F3B48 28}
-        Folder (flags: {FileSystemEntity Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {FileSystemEntity Folder})
+                    Folder (flags: {FileSystemEntity Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {FileSystemEntity Folder AppDesignerFolder BubbleUp}), Icon: {259567C1-AA6B-46BF-811C-C145DD9F3B48 28}
+                    Folder (flags: {FileSystemEntity Folder})
+            """)]
         public void ChangePropertyValues_TreeWithAppDesignerFolder_SetsIconToAppDesignerFolder(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -333,15 +374,17 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {FileSystemEntity Folder})
-        Folder (flags: {FileSystemEntity Folder})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {FileSystemEntity Folder AppDesignerFolder BubbleUp}), ExpandedIcon: {259567C1-AA6B-46BF-811C-C145DD9F3B48 29}
-        Folder (flags: {FileSystemEntity Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {FileSystemEntity Folder})
+                    Folder (flags: {FileSystemEntity Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {FileSystemEntity Folder AppDesignerFolder BubbleUp}), ExpandedIcon: {259567C1-AA6B-46BF-811C-C145DD9F3B48 29}
+                    Folder (flags: {FileSystemEntity Folder})
+            """)]
         public void ChangePropertyValues_TreeWithAppDesignerFolder_SetsExpandedIconToExpandedAppDesignerFolder(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -355,24 +398,28 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
-        Folder (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
-        Folder (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder}), Icon: {}, ExpandedIcon: {}
-        Folder (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {}, ExpandedIcon: {}
-        Folder (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
+                    Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 1}, ExpandedIcon: {AE27A6B0-E345-4288-96DF-5EAF394EE369 2}
+                    Folder (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder}), Icon: {}, ExpandedIcon: {}
+                    Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Properties (flags: {Folder AppDesignerFolder BubbleUp}), Icon: {}, ExpandedIcon: {}
+                    Folder (flags: {Folder})
+            """)]
         public void ChangePropertyValues_TreeWithAppDesignerFolderWhenImageProviderReturnsNull_DoesNotSetIconAndExpandedIcon(string input, string expected)
         {
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
@@ -391,14 +438,16 @@ Root (flags: {ProjectRoot})
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
             var propertiesProvider = CreateInstance(designerService);
 
-            var inputTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-");
-            var expectedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-");
+            var inputTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder})
+                """);
+            var expectedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                """);
 
             Verify(propertiesProvider, expectedTree, inputTree, folderName: null);
         }
@@ -409,14 +458,16 @@ Root (flags: {ProjectRoot})
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
             var propertiesProvider = CreateInstance(designerService);
 
-            var inputTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-");
-            var expectedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder BubbleUp})
-");
+            var inputTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder})
+                """);
+            var expectedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder BubbleUp})
+                """);
 
             Verify(propertiesProvider, expectedTree, inputTree, folderName: "");
         }
@@ -427,166 +478,198 @@ Root (flags: {ProjectRoot})
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);
             var propertiesProvider = CreateInstance(designerService);
 
-            var inputTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    FooBar (flags: {Folder})
-");
-            var expectedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    FooBar (flags: {Folder AppDesignerFolder BubbleUp})
-");
+            var inputTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    FooBar (flags: {Folder})
+                """);
+            var expectedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    FooBar (flags: {Folder AppDesignerFolder BubbleUp})
+                """);
 
             Verify(propertiesProvider, expectedTree, inputTree, folderName: "FooBar");
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder BubbleUp})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    my project (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    my project (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    MY PROJECT (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    MY PROJECT (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder UnrecognizedCapability})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder UnrecognizedCapability AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        My Project (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        My Project (flags: {Folder VisibleOnlyInShowAllFiles})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        Folder (flags: {IncludeInProjectCandidate})
-            Item.cs (flags: {IncludeInProjectCandidate})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder (flags: {IncludeInProjectCandidate})
-            Item.cs (flags: {IncludeInProjectCandidate})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        Folder1 (flags: {IncludeInProjectCandidate})
-            Item.cs (flags: {IncludeInProjectCandidate})
-        Folder2 (flags: {Folder})
-            Item.cs (flags: {})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder1 (flags: {IncludeInProjectCandidate})
-            Item.cs (flags: {IncludeInProjectCandidate})
-        Folder2 (flags: {Folder VisibleOnlyInShowAllFiles})
-            Item.cs (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        Resources.resx (flags: {})
-            Resources.Designer.cs (flags: {})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        Resources.resx (flags: {VisibleOnlyInShowAllFiles})
-            Resources.Designer.cs (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        AssemblyInfo.cs (flags: {})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        AssemblyInfo.cs (flags: {VisibleOnlyInShowAllFiles})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        Folder (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder (flags: {Folder VisibleOnlyInShowAllFiles})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        Folder (flags: {Folder})
-            Folder (flags: {Folder})
-                File (flags: {})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder (flags: {Folder VisibleOnlyInShowAllFiles})
-            Folder (flags: {Folder})
-                File (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder})
-        Folder1 (flags: {Folder})
-            Folder (flags: {Folder})
-                File (flags: {})
-        Folder2 (flags: {Folder})
-            Folder (flags: {Folder})
-                File (flags: {})
-", @"
-Root (flags: {ProjectRoot})
-    My Project (flags: {Folder AppDesignerFolder BubbleUp})
-        Folder1 (flags: {Folder VisibleOnlyInShowAllFiles})
-            Folder (flags: {Folder})
-                File (flags: {})
-        Folder2 (flags: {Folder VisibleOnlyInShowAllFiles})
-            Folder (flags: {Folder})
-                File (flags: {})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder BubbleUp})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                my project (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                my project (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                MY PROJECT (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                MY PROJECT (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder UnrecognizedCapability})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder UnrecognizedCapability AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    My Project (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    My Project (flags: {Folder VisibleOnlyInShowAllFiles})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    AssemblyInfo.cs (flags: {IncludeInProjectCandidate})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    Folder (flags: {IncludeInProjectCandidate})
+                        Item.cs (flags: {IncludeInProjectCandidate})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder (flags: {IncludeInProjectCandidate})
+                        Item.cs (flags: {IncludeInProjectCandidate})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    Folder1 (flags: {IncludeInProjectCandidate})
+                        Item.cs (flags: {IncludeInProjectCandidate})
+                    Folder2 (flags: {Folder})
+                        Item.cs (flags: {})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder1 (flags: {IncludeInProjectCandidate})
+                        Item.cs (flags: {IncludeInProjectCandidate})
+                    Folder2 (flags: {Folder VisibleOnlyInShowAllFiles})
+                        Item.cs (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    Resources.resx (flags: {})
+                        Resources.Designer.cs (flags: {})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    Resources.resx (flags: {VisibleOnlyInShowAllFiles})
+                        Resources.Designer.cs (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    AssemblyInfo.cs (flags: {})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    AssemblyInfo.cs (flags: {VisibleOnlyInShowAllFiles})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder (flags: {Folder VisibleOnlyInShowAllFiles})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    Folder (flags: {Folder})
+                        Folder (flags: {Folder})
+                            File (flags: {})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder (flags: {Folder VisibleOnlyInShowAllFiles})
+                        Folder (flags: {Folder})
+                            File (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder})
+                    Folder1 (flags: {Folder})
+                        Folder (flags: {Folder})
+                            File (flags: {})
+                    Folder2 (flags: {Folder})
+                        Folder (flags: {Folder})
+                            File (flags: {})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                My Project (flags: {Folder AppDesignerFolder BubbleUp})
+                    Folder1 (flags: {Folder VisibleOnlyInShowAllFiles})
+                        Folder (flags: {Folder})
+                            File (flags: {})
+                    Folder2 (flags: {Folder VisibleOnlyInShowAllFiles})
+                        Folder (flags: {Folder})
+                            File (flags: {})
+            """)]
         public void ChangePropertyValues_TreeWithMyProjectCandidateAndContentVisibleOnlyInShowAllFiles_ReturnsCandidateMarkedWithAppDesignerFolderAndBubbleUp(string input, string expected)
         {   // Mimic's Visual Basic projects
             var designerService = IProjectDesignerServiceFactory.ImplementSupportsProjectDesigner(() => true);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/ProjectRootImageProjectTreeModifierTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/ProjectRootImageProjectTreeModifierTests.cs
@@ -31,25 +31,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {Unrecognized ProjectRoot})
-", @"
-Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-")]
-        [InlineData(@"
-Root (flags: {Unrecognized ProjectRoot})
-    Folder (flags: {Folder})
-", @"
-Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-    Folder (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-    Folder (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {Unrecognized ProjectRoot})
+            """,
+            """
+            Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+            """)]
+        [InlineData(
+            """
+            Root (flags: {Unrecognized ProjectRoot})
+                Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+                Folder (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+                Folder (flags: {Folder})
+            """)]
         public void CalculatePropertyValues_ProjectRootAsTree_SetsIconToProjectRoot(string input, string expected)
         {
             var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.ProjectRoot, new ProjectImageMoniker(new Guid("{A140CD9F-FF94-483C-87B1-9EF5BE9F469A}"), 1));
@@ -64,25 +70,31 @@ Root (flags: {ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, Exp
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {Unrecognized ProjectRoot})
-", @"
-Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-")]
-        [InlineData(@"
-Root (flags: {Unrecognized ProjectRoot})
-    Folder (flags: {Folder})
-", @"
-Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-    Folder (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-", @"
-Root (flags: {ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-    Folder (flags: {Folder})
-")]
+        [InlineData(
+            """
+            Root (flags: {Unrecognized ProjectRoot})
+            """,
+            """
+            Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+            """)]
+        [InlineData(
+            """
+            Root (flags: {Unrecognized ProjectRoot})
+                Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {Unrecognized ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+                Folder (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+            """,
+            """
+            Root (flags: {ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+                Folder (flags: {Folder})
+            """)]
         public void CalculatePropertyValues_WhenSharedProjectRootAsTree_SetsIconToSharedProjectRoot(string input, string expected)
         {
             var capabilities = IProjectCapabilitiesServiceFactory.ImplementsContains(capability =>
@@ -102,20 +114,24 @@ Root (flags: {ProjectRoot}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, Exp
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Shared.items (flags: {SharedItemsImportFile})
-", @"
-Root (flags: {ProjectRoot})
-    Shared.items (flags: {SharedItemsImportFile}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Shared.items (flags: {SharedItemsImportFile Unrecognized})
-", @"
-Root (flags: {ProjectRoot})
-    Shared.items (flags: {SharedItemsImportFile Unrecognized}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Shared.items (flags: {SharedItemsImportFile})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Shared.items (flags: {SharedItemsImportFile}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Shared.items (flags: {SharedItemsImportFile Unrecognized})
+            """,
+            """
+            Root (flags: {ProjectRoot})
+                Shared.items (flags: {SharedItemsImportFile Unrecognized}), Icon: {A140CD9F-FF94-483C-87B1-9EF5BE9F469A 1}, ExpandedIcon: {}
+            """)]
         public void CalculatePropertyValues_WhenSharedItemsImportFileAsTree_SetsIconToSharedItemsImportFile(string input, string expected)
         {
             var capabilities = IProjectCapabilitiesServiceFactory.ImplementsContains(capability =>
@@ -135,22 +151,26 @@ Root (flags: {ProjectRoot})
         }
 
         [Theory]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    File (flags: {})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    File (flags: {IncludeInProjectCandidate})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder})
-")]
-        [InlineData(@"
-Root (flags: {ProjectRoot})
-    Folder (flags: {Folder IncludeInProjectCandidate})
-")]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                File (flags: {})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                File (flags: {IncludeInProjectCandidate})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder})
+            """)]
+        [InlineData(
+            """
+            Root (flags: {ProjectRoot})
+                Folder (flags: {Folder IncludeInProjectCandidate})
+            """)]
         public void CalculatePropertyValues_NonProjectRootAsTree_DoesNotSetIcon(string input)
         {
             var imageProvider = IProjectImageProviderFactory.ImplementGetProjectImage(ProjectImageKey.ProjectRoot, new ProjectImageMoniker(new Guid("{A140CD9F-FF94-483C-87B1-9EF5BE9F469A}"), 1));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsListTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsListTests.cs
@@ -85,14 +85,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 
             static string ConstructNamespaceImportChangeJson(string[] importNames)
             {
-                var json = @"{
-    ""ProjectChanges"": {
-        ""NamespaceImport"": {
-            ""Difference"": {
-                ""AnyChanges"": ""True""
-            },
-            ""After"": {
-                ""Items"": {";
+                var json =
+                    """
+                    {
+                        "ProjectChanges": {
+                            "NamespaceImport": {
+                                "Difference": {
+                                    "AnyChanges": "True"
+                                },
+                                "After": {
+                                    "Items": {
+                    """;
 
                 for (int i = 0; i < importNames.Length; i++)
                 {
@@ -103,11 +106,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
                     }
                 }
 
-                json += @"                }
-               }
-           }
-       }
-   }";
+                json +=
+                    """
+                                   }
+                                }
+                            }
+                        }
+                    }
+                    """;
                 return json;
             }
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
@@ -23,9 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree);
 
@@ -39,9 +40,10 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance(capability: "IncorrectCapability");
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree);
 
@@ -55,10 +57,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree, tree.Children[0]);
 
@@ -72,10 +75,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Code (flags: {Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Code (flags: {Folder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -91,10 +95,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Code (flags: {Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Code (flags: {Folder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -122,10 +127,11 @@ Root (flags: {ProjectRoot})
 
             var command = CreateInstance(addItemDialogService: addItemDialogService);
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -144,10 +150,11 @@ Root (flags: {ProjectRoot})
 
             var command = CreateInstance(addItemDialogService);
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Code (flags: {Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Code (flags: {Folder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommandTests.cs
@@ -44,9 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             var solutionEventsListener = IVsUpdateSolutionEventsFactory.Create(onUpdateSolutionBegin, onUpdateSolutionCancel, onUpdateSolutionDone);
             var command = CreateInstance(solutionEventsListener: solutionEventsListener);
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse("Root (flags: {ProjectRoot})");
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
@@ -70,9 +68,7 @@ Root (flags: {ProjectRoot})
             var solutionEventsListener = IVsUpdateSolutionEventsFactory.Create(onUpdateSolutionBegin, onUpdateSolutionCancel, onUpdateSolutionDone);
             var command = CreateInstance(solutionEventsListener: solutionEventsListener, cancelBuild: true);
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse("Root (flags: {ProjectRoot})");
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
@@ -87,9 +83,7 @@ Root (flags: {ProjectRoot})
         [Fact]
         public async Task GetCommandStatusAsync_BuildInProgress()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse("Root (flags: {ProjectRoot})");
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
@@ -109,9 +103,7 @@ Root (flags: {ProjectRoot})
         [Fact]
         public async Task TryHandleCommandAsync_BuildInProgress()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-");
+            var tree = ProjectTreeParser.Parse("Root (flags: {ProjectRoot})");
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
@@ -22,10 +22,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -39,10 +40,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -56,10 +58,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree, tree.Children[0]);
 
@@ -73,10 +76,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree, tree.Children[0]);
 
@@ -90,10 +94,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -107,10 +112,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -124,10 +130,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -143,10 +150,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 
@@ -163,10 +171,11 @@ Root (flags: {ProjectRoot})
 
             var command = CreateInstance(designerService);
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {Folder AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {Folder AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageProjectContextMenuCommandTests.cs
@@ -24,10 +24,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
@@ -41,10 +42,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/GenerateNuGetPackageTopLevelBuildMenuCommandTests.cs
@@ -24,10 +24,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Root);
 
@@ -41,10 +42,11 @@ Root (flags: {ProjectRoot})
         {
             var command = CreateInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot})
-    Properties (flags: {AppDesignerFolder})
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot})
+                    Properties (flags: {AppDesignerFolder})
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveDownCommandTests.cs
@@ -11,11 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
 
@@ -30,11 +31,12 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
 
@@ -49,14 +51,15 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
 
@@ -71,14 +74,15 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
 
@@ -93,17 +97,18 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-    Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                    Folder (flags: {Folder}), DisplayOrder: 6
+                        File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 7
+                        File (flags: {}), FilePath: "C:\Foo\test6.fs", DisplayOrder: 8
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
 
@@ -118,17 +123,18 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 4
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5
-    Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    Folder (flags: {Folder}), DisplayOrder: 1
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 2
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 3
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 4
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 5
+                    Folder (flags: {Folder}), DisplayOrder: 6
+                        File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 7
+                        File (flags: {}), FilePath: "C:\Foo\test6.fs", DisplayOrder: 8
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
 
@@ -143,15 +149,16 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
-    Folder (flags: {Folder}), DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 5
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 6
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    Folder (flags: {Folder}), DisplayOrder: 1
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 2
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 3
+                    Folder (flags: {Folder}), DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 5
+                        File (flags: {}), FilePath: "C:\Foo\test6.fs", DisplayOrder: 6
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // second folder
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/MoveUpCommandTests.cs
@@ -11,11 +11,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[1]); // test2.fs
 
@@ -30,11 +31,12 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // test1.fs
 
@@ -49,14 +51,15 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[1]); // test4.fs
 
@@ -71,14 +74,15 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[2].Children[0]); // test3.fs
 
@@ -93,17 +97,18 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-    Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                    Folder (flags: {Folder}), DisplayOrder: 6
+                        File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 7
+                        File (flags: {}), FilePath: "C:\Foo\test6.fs", DisplayOrder: 8
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[3]); // second folder
 
@@ -118,17 +123,18 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2
-    Folder (flags: {Folder}), DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 5
-    Folder (flags: {Folder}), DisplayOrder: 6
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 7
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 8
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2
+                    Folder (flags: {Folder}), DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 5
+                    Folder (flags: {Folder}), DisplayOrder: 6
+                        File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 7
+                        File (flags: {}), FilePath: "C:\Foo\test6.fs", DisplayOrder: 8
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[2]); // first folder
 
@@ -143,15 +149,16 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         {
             var command = CreateAbstractInstance();
 
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2
-        File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3
-    Folder (flags: {Folder}), DisplayOrder: 4
-        File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 5
-        File (flags: {}), FilePath: ""C:\Foo\test6.fs"", DisplayOrder: 6
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    Folder (flags: {Folder}), DisplayOrder: 1
+                        File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 2
+                        File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 3
+                    Folder (flags: {Folder}), DisplayOrder: 4
+                        File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 5
+                        File (flags: {}), FilePath: "C:\Foo\test6.fs", DisplayOrder: 6
+                """);
 
             var nodes = ImmutableHashSet.Create(tree.Children[0]); // first folder
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -50,42 +50,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         [Fact]
         public void MoveUpFile_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.True(OrderingHelper.TryMoveUp(project, tree.Children[1]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test1.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test1.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -93,42 +98,47 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveUpFile_IsUnsuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.False(OrderingHelper.TryMoveUp(project, tree.Children[0]));
             Assert.False(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -136,48 +146,53 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveUpFolder_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    Folder (flags: {Folder}), FilePath: ""C:\Foo\test"", DisplayOrder: 3
-        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 4, ItemName: ""test/test3.fs""
-        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test/test4.fs""
-");
-            var projectRootElement = @"
-<Project>
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    Folder (flags: {Folder}), FilePath: "C:\Foo\test", DisplayOrder: 3
+                        File (flags: {}), FilePath: "C:\Foo\test\test3.fs", DisplayOrder: 4, ItemName: "test/test3.fs"
+                        File (flags: {}), FilePath: "C:\Foo\test\test4.fs", DisplayOrder: 5, ItemName: "test/test4.fs"
+                """);
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test/test3.fs"" />
-    <Compile Include=""test/test4.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test/test3.fs" />
+                    <Compile Include="test/test4.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.True(OrderingHelper.TryMoveUp(project, tree.Children[2]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test/test3.fs"" />
-    <Compile Include=""test/test4.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test/test3.fs" />
+                    <Compile Include="test/test4.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -185,42 +200,47 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveDownFile_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.True(OrderingHelper.TryMoveDown(project, tree.Children[0]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test1.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test1.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -228,42 +248,47 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveDownFile_IsUnsuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.False(OrderingHelper.TryMoveDown(project, tree.Children[1]));
             Assert.False(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -271,48 +296,53 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveDownFolder_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), FilePath: ""C:\Foo\test"", DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 2, ItemName: ""test/test3.fs""
-        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 3, ItemName: ""test/test4.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 4, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 5, ItemName: ""test2.fs""
-");
-            var projectRootElement = @"
-<Project>
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    Folder (flags: {Folder}), FilePath: "C:\Foo\test", DisplayOrder: 1
+                        File (flags: {}), FilePath: "C:\Foo\test\test3.fs", DisplayOrder: 2, ItemName: "test/test3.fs"
+                        File (flags: {}), FilePath: "C:\Foo\test\test4.fs", DisplayOrder: 3, ItemName: "test/test4.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 4, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 5, ItemName: "test2.fs"
+                """);
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test/test3.fs"" />
-    <Compile Include=""test/test4.fs"" />
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test/test3.fs" />
+                    <Compile Include="test/test4.fs" />
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.True(OrderingHelper.TryMoveDown(project, tree.Children[0]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test/test3.fs"" />
-    <Compile Include=""test/test4.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test/test3.fs" />
+                    <Compile Include="test/test4.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -320,52 +350,57 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveDownFolder_ContainsNestedFolder_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), FilePath: ""C:\Foo\test"", DisplayOrder: 1
-        File (flags: {}), FilePath: ""C:\Foo\test\test3.fs"", DisplayOrder: 2, ItemName: ""test/test3.fs""
-        Folder (flags: {Folder}), FilePath: ""C:\Foo\test\nested"", DisplayOrder: 3
-            File (flags: {}), FilePath: ""C:\Foo\test\nested\nested.fs"", DisplayOrder: 4, ItemName: ""test/nested/nested.fs""
-        File (flags: {}), FilePath: ""C:\Foo\test\test4.fs"", DisplayOrder: 5, ItemName: ""test/test4.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 6, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 7, ItemName: ""test2.fs""
-");
-            var projectRootElement = @"
-<Project>
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    Folder (flags: {Folder}), FilePath: "C:\Foo\test", DisplayOrder: 1
+                        File (flags: {}), FilePath: "C:\Foo\test\test3.fs", DisplayOrder: 2, ItemName: "test/test3.fs"
+                        Folder (flags: {Folder}), FilePath: "C:\Foo\test\nested", DisplayOrder: 3
+                            File (flags: {}), FilePath: "C:\Foo\test\nested\nested.fs", DisplayOrder: 4, ItemName: "test/nested/nested.fs"
+                        File (flags: {}), FilePath: "C:\Foo\test\test4.fs", DisplayOrder: 5, ItemName: "test/test4.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 6, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 7, ItemName: "test2.fs"
+                """);
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test/test3.fs"" />
-    <Compile Include=""test/nested/nested.fs"" />
-    <Compile Include=""test/test4.fs"" />
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test/test3.fs" />
+                    <Compile Include="test/nested/nested.fs" />
+                    <Compile Include="test/test4.fs" />
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
             Assert.True(OrderingHelper.TryMoveDown(project, tree.Children[0]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test/test3.fs"" />
-    <Compile Include=""test/nested/nested.fs"" />
-    <Compile Include=""test/test4.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test/test3.fs" />
+                    <Compile Include="test/nested/nested.fs" />
+                    <Compile Include="test/test4.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -373,28 +408,30 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveAboveFile_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 3, ItemName: "test3.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
@@ -403,17 +440,20 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(OrderingHelper.TryMoveElementsAbove(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -421,28 +461,30 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveBelowFile_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 3, ItemName: "test3.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
@@ -451,17 +493,20 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(OrderingHelper.TryMoveElementsBelow(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-    <Compile Include=""test1.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                    <Compile Include="test1.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -469,37 +514,40 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void AddItem_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 3, ItemName: "test3.fs"
+                """);
 
-            var updatedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3, ItemName: ""test4.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 4, ItemName: ""test3.fs""
-");
+            var updatedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 3, ItemName: "test4.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 4, ItemName: "test3.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test4.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test4.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
@@ -508,18 +556,21 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test4.fs"" />
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test4.fs" />
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -527,39 +578,42 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void AddItems_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 3, ItemName: "test3.fs"
+                """);
 
-            var updatedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test4.fs"", DisplayOrder: 3, ItemName: ""test4.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test5.fs"", DisplayOrder: 4, ItemName: ""test5.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 5, ItemName: ""test3.fs""
-");
+            var updatedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test4.fs", DisplayOrder: 3, ItemName: "test4.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test5.fs", DisplayOrder: 4, ItemName: "test5.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 5, ItemName: "test3.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test4.fs"" />
-    <Compile Include=""test5.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test4.fs" />
+                    <Compile Include="test5.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
@@ -570,19 +624,22 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test4.fs"" />
-    <Compile Include=""test5.fs"" />
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test4.fs" />
+                    <Compile Include="test5.fs" />
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -590,43 +647,46 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void AddItemsInNestedFolder_IsSuccessful()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    Folder (flags: {Folder}), FilePath: ""C:\Foo\test""
-        Folder (flags: {Folder}), FilePath: ""C:\Foo\test\nested""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 3, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    Folder (flags: {Folder}), FilePath: "C:\Foo\test"
+                        Folder (flags: {Folder}), FilePath: "C:\Foo\test\nested"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 3, ItemName: "test3.fs"
+                """);
 
-            var updatedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    Folder (flags: {Folder}), FilePath: ""C:\Foo\test"", DisplayOrder: 3
-        Folder (flags: {Folder}), FilePath: ""C:\Foo\test\nested"", DisplayOrder: 4
-            File (flags: {}), FilePath: ""C:\Foo\test\nested\test4.fs"", DisplayOrder: 5, ItemName: ""test\nested\test4.fs""
-            File (flags: {}), FilePath: ""C:\Foo\test\tested\test5.fs"", DisplayOrder: 6, ItemName: ""test\nested\test5.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 7, ItemName: ""test3.fs""
-");
+            var updatedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    Folder (flags: {Folder}), FilePath: "C:\Foo\test", DisplayOrder: 3
+                        Folder (flags: {Folder}), FilePath: "C:\Foo\test\nested", DisplayOrder: 4
+                            File (flags: {}), FilePath: "C:\Foo\test\nested\test4.fs", DisplayOrder: 5, ItemName: "test\nested\test4.fs"
+                            File (flags: {}), FilePath: "C:\Foo\test\tested\test5.fs", DisplayOrder: 6, ItemName: "test\nested\test5.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 7, ItemName: "test3.fs"
+                """);
 
-            var projectRootElement = @"
-<Project>
+            var projectRootElement =
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test\nested\test4.fs"" />
-    <Compile Include=""test\nested\test5.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test\nested\test4.fs" />
+                    <Compile Include="test\nested\test5.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
 
             var project = new Project(projectRootElement);
 
@@ -637,19 +697,22 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
-            var expected = @"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test\nested\test4.fs"" />
-    <Compile Include=""test\nested\test5.fs"" />
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
-</Project>";
+            var expected =
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test\nested\test4.fs" />
+                    <Compile Include="test\nested\test5.fs" />
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
+                </Project>
+                """;
 
             AssertEqualProject(expected, project);
         }
@@ -657,45 +720,49 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void AddFile_WithImportedFileAtTop()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                """);
 
-            var updatedTree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
-");
+            var updatedTree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 2, ItemName: "test3.fs"
+                """);
 
             var (tempPath, testPropsFile) = CreateTempPropsFilePath();
 
-            var projectRootElement = string.Format(@"
-<Project>
+            var projectRootElement = string.Format(
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <Import Project=""{0}"" />
+                  <Import Project="{0}" />
 
-  <ItemGroup>
-    <Compile Include=""test2.fs"" />
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test2.fs" />
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-", testPropsFile).AsProjectRootElement();
+                </Project>
+                """, testPropsFile).AsProjectRootElement();
 
-            var projectImportElement = @"
-<Project>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-  </ItemGroup>
-</Project>
-".AsProjectRootElement();
+            var projectImportElement =
+                """
+                <Project>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                  </ItemGroup>
+                </Project>
+                """.AsProjectRootElement();
 
             var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
 
@@ -706,17 +773,20 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
 
-            var expected = string.Format(@"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <Import Project=""{0}"" />
-  <ItemGroup>
-    <Compile Include=""test3.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>", testPropsFile);
+            var expected = string.Format(
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <Import Project="{0}" />
+                  <ItemGroup>
+                    <Compile Include="test3.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """, testPropsFile);
 
             AssertEqualProject(expected, project);
         }
@@ -724,42 +794,45 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveFileUp_WithImportedFileInterspersed()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 2, ItemName: "test3.fs"
+                """);
 
             var (tempPath, testPropsFile) = CreateTempPropsFilePath();
 
-            var projectRootElement = string.Format(@"
-<Project>
+            var projectRootElement = string.Format(
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                  </ItemGroup>
 
-  <Import Project=""{0}"" />
+                  <Import Project="{0}" />
 
-  <ItemGroup>
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
 
-</Project>
-", testPropsFile).AsProjectRootElement();
+                </Project>
+                """, testPropsFile).AsProjectRootElement();
 
-            var projectImportElement = @"
-<Project>
-  <ItemGroup>
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-</Project>
-".AsProjectRootElement();
+            var projectImportElement =
+                """
+                <Project>
+                  <ItemGroup>
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                </Project>
+                """.AsProjectRootElement();
 
             var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
 
@@ -768,18 +841,21 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
 
             // The expected result here may not be the desired behavior, but it is the current behavior that we need to test for.
             // Moving test3.fs up, skips the import, but also moves above test1.fs, that is due to skipping imports during manipulation.
-            var expected = string.Format(@"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test3.fs"" />
-    <Compile Include=""test1.fs"" />
-  </ItemGroup>
-  <Import Project=""{0}"" />
-  <ItemGroup />
-</Project>", testPropsFile);
+            var expected = string.Format(
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test3.fs" />
+                    <Compile Include="test1.fs" />
+                  </ItemGroup>
+                  <Import Project="{0}" />
+                  <ItemGroup />
+                </Project>
+                """, testPropsFile);
 
             AssertEqualProject(expected, project);
         }
@@ -787,39 +863,42 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
         [Fact]
         public void MoveFileDown_WithImportedFileAtBottom()
         {
-            var tree = ProjectTreeParser.Parse(@"
-Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
-    File (flags: {}), FilePath: ""C:\Foo\test1.fs"", DisplayOrder: 1, ItemName: ""test1.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test2.fs"", DisplayOrder: 2, ItemName: ""test2.fs""
-    File (flags: {}), FilePath: ""C:\Foo\test3.fs"", DisplayOrder: 2, ItemName: ""test3.fs""
-");
+            var tree = ProjectTreeParser.Parse(
+                """
+                Root (flags: {ProjectRoot}), FilePath: "C:\Foo\testing.fsproj"
+                    File (flags: {}), FilePath: "C:\Foo\test1.fs", DisplayOrder: 1, ItemName: "test1.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test2.fs", DisplayOrder: 2, ItemName: "test2.fs"
+                    File (flags: {}), FilePath: "C:\Foo\test3.fs", DisplayOrder: 2, ItemName: "test3.fs"
+                """);
 
             var (tempPath, testPropsFile) = CreateTempPropsFilePath();
 
-            var projectRootElement = string.Format(@"
-<Project>
+            var projectRootElement = string.Format(
+                """
+                <Project>
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
 
-  <Import Project=""{0}"" />
+                  <Import Project="{0}" />
 
-</Project>
-", testPropsFile).AsProjectRootElement();
+                </Project>
+                """, testPropsFile).AsProjectRootElement();
 
-            var projectImportElement = @"
-<Project>
-  <ItemGroup>
-    <Compile Include=""test3.fs"" />
-  </ItemGroup>
-</Project>
-".AsProjectRootElement();
+            var projectImportElement =
+                """
+                <Project>
+                  <ItemGroup>
+                    <Compile Include="test3.fs" />
+                  </ItemGroup>
+                </Project>
+                """.AsProjectRootElement();
 
             var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
 
@@ -827,17 +906,20 @@ Root (flags: {ProjectRoot}), FilePath: ""C:\Foo\testing.fsproj""
             Assert.False(OrderingHelper.TryMoveDown(project, tree.Children[1]));
             Assert.False(project.IsDirty);
 
-            var expected = string.Format(@"<?xml version=""1.0"" encoding=""utf-16""?>
-<Project>
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include=""test1.fs"" />
-    <Compile Include=""test2.fs"" />
-  </ItemGroup>
-  <Import Project=""{0}"" />
-</Project>", testPropsFile);
+            var expected = string.Format(
+                """
+                <?xml version="1.0" encoding="utf-16"?>
+                <Project>
+                  <PropertyGroup>
+                    <TargetFramework>netstandard2.0</TargetFramework>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Compile Include="test1.fs" />
+                    <Compile Include="test2.fs" />
+                  </ItemGroup>
+                  <Import Project="{0}" />
+                </Project>
+                """, testPropsFile);
 
             AssertEqualProject(expected, project);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/RestoreBuilderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/RestoreBuilderTests.cs
@@ -19,30 +19,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_WhenNoItems_ReturnsEmptyItemCollections()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""ProjectReference"": {
-            ""Items"" : {}
-        },
-        ""PackageReference"": {
-            ""Items"" : {}
-        },
-        ""DotNetCliToolReference"": {
-            ""Items"" : {}
-        },
-        ""CollectedFrameworkReference"": {
-            ""Items"" : {}
-        },
-        ""CollectedPackageDownload"": {
-            ""Items"" : {}
-        },
-        ""CollectedPackageVersion"": {
-            ""Items"" : {}
-        }
-    }
-}
-");
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "ProjectReference": {
+                            "Items" : {}
+                        },
+                        "PackageReference": {
+                            "Items" : {}
+                        },
+                        "DotNetCliToolReference": {
+                            "Items" : {}
+                        },
+                        "CollectedFrameworkReference": {
+                            "Items" : {}
+                        },
+                        "CollectedPackageDownload": {
+                            "Items" : {}
+                        },
+                        "CollectedPackageVersion": {
+                            "Items" : {}
+                        }
+                    }
+                }
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             AssertNoItems(result);
@@ -67,18 +68,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_RespectsNuGetTargetMonikerIfPresent()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""NuGetRestore"": {
-            ""Properties"": {
-                ""NuGetTargetMoniker"": ""UWP, Version=v10"",
-                ""TargetFrameworkMoniker"": "".NETFramework, Version=v4.5""
-            },
-        }
-    }
-}
-");
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "NuGetRestore": {
+                            "Properties": {
+                                "NuGetTargetMoniker": "UWP, Version=v10",
+                                "TargetFrameworkMoniker": ".NETFramework, Version=v4.5"
+                            },
+                        }
+                    }
+                }
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
             var targetFramework = result.TargetFrameworks.Item(0);
 
@@ -88,19 +90,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsCoreProperties()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""NuGetRestore"": {
-            ""Properties"": {
-                ""MSBuildProjectExtensionsPath"": ""C:\\Project\\obj"",
-                ""TargetFrameworks"": ""net45"",               
-                ""TargetFrameworkMoniker"": "".NETFramework, Version=v4.5""
-            },
-        }
-    }
-}
-");
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "NuGetRestore": {
+                            "Properties": {
+                                "MSBuildProjectExtensionsPath": "C:\\Project\\obj",
+                                "TargetFrameworks": "net45",
+                                "TargetFrameworkMoniker": ".NETFramework, Version=v4.5"
+                            },
+                        }
+                    }
+                }
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal("C:\\Project\\obj", result.MSBuildProjectExtensionsPath);
@@ -115,19 +118,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_WhenEmpty_SetsCorePropertiesToEmpty()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""NuGetRestore"": {
-            ""Properties"": {
-                ""MSBuildProjectExtensionsPath"": """",
-                ""TargetFrameworks"": """",               
-                ""TargetFrameworkMoniker"": """"
-            },
-        }
-    }
-}
-");
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "NuGetRestore": {
+                            "Properties": {
+                                "MSBuildProjectExtensionsPath": "",
+                                "TargetFrameworks": "",
+                                "TargetFrameworkMoniker": ""
+                            },
+                        }
+                    }
+                }
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Empty(result.MSBuildProjectExtensionsPath);
@@ -142,18 +146,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsTargetFrameworkProperties()
         {   // All NuGetRestore properties end up in the "target framework" property bag
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""NuGetRestore"": {
-            ""Properties"": {
-                ""Property"": ""Value"",
-                ""AnotherProperty"": ""AnotherValue""
-            },
-        }
-    }
-}
-");
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "NuGetRestore": {
+                            "Properties": {
+                                "Property": "Value",
+                                "AnotherProperty": "AnotherValue"
+                            },
+                        }
+                    }
+                }
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -167,25 +172,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsToolReferences()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""DotNetCliToolReference"": {
-            ""Items"" : {
-                ""ToolReference1"" : {
-                    ""Version"" : ""1.0.0.0"",
-                },
-                ""ToolReference2"" : {
-                    ""Version"" : ""2.0.0.0"",
-                },
-                ""ToolReference3"" : {
-                    ""Name"" : ""Value""
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "DotNetCliToolReference": {
+                            "Items" : {
+                                "ToolReference1" : {
+                                    "Version" : "1.0.0.0",
+                                },
+                                "ToolReference2" : {
+                                    "Version" : "2.0.0.0",
+                                },
+                                "ToolReference3" : {
+                                    "Name" : "Value"
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}
-");
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
             var references = result.ToolReferences;
 
@@ -204,25 +210,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsPackageReferences()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""CollectedPackageReference"": {
-            ""Items"" : {
-                ""PackageReference1"" : {
-                    ""Version"" : ""1.0.0.0"",
-                },
-                ""PackageReference2"" : {
-                    ""Version"" : ""2.0.0.0"",
-                },
-                ""PackageReference3"" : {
-                    ""Name"" : ""Value""
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "CollectedPackageReference": {
+                            "Items" : {
+                                "PackageReference1" : {
+                                    "Version" : "1.0.0.0",
+                                },
+                                "PackageReference2" : {
+                                    "Version" : "2.0.0.0",
+                                },
+                                "PackageReference3" : {
+                                    "Name" : "Value"
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}
-");
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -244,24 +251,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsCentralPackageVersions()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""CollectedPackageVersion"": {
-            ""Items"" : {
-                ""Newtonsoft.Json"" : {
-                    ""Version"" : ""1.0"",
-                },
-                ""System.IO"" : {
-                    ""Version"" : ""2.0"",
-                },
-                ""Microsoft.Extensions"" : {
-                    ""Version"" : ""3.0""
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "CollectedPackageVersion": {
+                            "Items" : {
+                                "Newtonsoft.Json" : {
+                                    "Version" : "1.0",
+                                },
+                                "System.IO" : {
+                                    "Version" : "2.0",
+                                },
+                                "Microsoft.Extensions" : {
+                                    "Version" : "3.0"
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}");
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -289,25 +298,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsProjectReferences()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""ProjectReference"": {
-            ""Items"" : {
-                ""..\\Project\\Project1.csproj"" : {
-                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project1.csproj"",
-                },
-                ""..\\Project\\Project2.csproj"" : {
-                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project2.csproj"",
-                },
-                ""..\\Project\\Project3.csproj"" : {
-                    ""ProjectFileFullPath"" : ""C:\\Solution\\Project\\Project3.csproj"",
-                    ""MetadataName"": ""MetadataValue""
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "ProjectReference": {
+                            "Items" : {
+                                "..\\Project\\Project1.csproj" : {
+                                    "ProjectFileFullPath" : "C:\\Solution\\Project\\Project1.csproj",
+                                },
+                                "..\\Project\\Project2.csproj" : {
+                                    "ProjectFileFullPath" : "C:\\Solution\\Project\\Project2.csproj",
+                                },
+                                "..\\Project\\Project3.csproj" : {
+                                    "ProjectFileFullPath" : "C:\\Solution\\Project\\Project3.csproj",
+                                    "MetadataName": "MetadataValue"
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}");
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -336,20 +347,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsFrameworkReferences()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""CollectedFrameworkReference"": {
-            ""Items"" : {
-                ""WindowsForms"" : {
-                },
-                ""WPF"" : {
-                    ""PrivateAssets"" : ""all"",
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "CollectedFrameworkReference": {
+                            "Items" : {
+                                "WindowsForms" : {
+                                },
+                                "WPF" : {
+                                    "PrivateAssets" : "all",
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}");
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);
@@ -371,21 +384,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         [Fact]
         public void ToProjectRestoreInfo_SetsPackageDownloads()
         {
-            var update = IProjectSubscriptionUpdateFactory.FromJson(@"
-{
-    ""CurrentState"": {
-        ""CollectedPackageDownload"": {
-            ""Items"" : {
-                ""NuGet.Common"" : {
-                    ""Version"" : ""[4.0.0];[5.0.0]"",
-                },
-                ""NuGet.Frameworks"" : {
-                    ""Version"" : ""[4.9.4]"",
+            var update = IProjectSubscriptionUpdateFactory.FromJson(
+                """
+                {
+                    "CurrentState": {
+                        "CollectedPackageDownload": {
+                            "Items" : {
+                                "NuGet.Common" : {
+                                    "Version" : "[4.0.0];[5.0.0]",
+                                },
+                                "NuGet.Frameworks" : {
+                                    "Version" : "[4.9.4]",
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        }
-    }
-}");
+                """);
             var result = RestoreBuilder.ToProjectRestoreInfo(update.CurrentState);
 
             Assert.Equal(1, result.TargetFrameworks.Count);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProviderTests.cs
@@ -9,41 +9,47 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
     {
         [Theory]
         [InlineData(
-@"<Project/>"
-)]
+            """
+            <Project/>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-    <PropertyGroup>
-    </PropertyGroup>
-</Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuids>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuids>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                    <ProjectGuids>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuids>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-         <ProjectGuid Include=""{C26D43ED-ED18-46F9-8950-0B1A7232746E}"" />
-     </ItemGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <ItemGroup>
+                    <ProjectGuid Include="{C26D43ED-ED18-46F9-8950-0B1A7232746E}" />
+                </ItemGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <Target Name=""Target"">
-         <PropertyGroup>
-            <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-         </PropertyGroup>
-     </Target>
- </Project>"
-)]
+            """
+            <Project>
+                <Target Name="Target">
+                    <PropertyGroup>
+                       <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                    </PropertyGroup>
+                </Target>
+            </Project>
+            """
+            )]
         public async Task GetProjectGuidAsync_WhenNoProjectGuidProperty_ReturnsEmpty(string projectXml)
         {
             var provider = CreateInstance(projectXml);
@@ -62,12 +68,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [InlineData("{ 0xFFFFFFFFFFFFFFFFFF,0xdddd,0xdddd,{ 0xdd,0xdd,0xdd,0xdd,0xdd,0xdd,0xdd,0xdd} }")]   // Overflow
         public async Task GetProjectGuidAsync_WhenInvalidProjectGuidProperty_ReturnsEmpty(string guid)
         {
-            var projectXml = $@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuid>{guid}</ProjectGuid>
-     </PropertyGroup>
- </Project>";
+            var projectXml =
+                $"""
+                <Project>
+                    <PropertyGroup>
+                        <ProjectGuid>{guid}</ProjectGuid>
+                    </PropertyGroup>
+                </Project>
+                """;
 
             var provider = CreateInstance(projectXml);
 
@@ -78,83 +86,91 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
         [Theory]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-         <projectguid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</projectguid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                    <projectguid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</projectguid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-     </PropertyGroup>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                </PropertyGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
 
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <ItemGroup>
+                </ItemGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <ItemGroup>
+                </ItemGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-        <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-        <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <ItemGroup>
+                </ItemGroup>
+                <PropertyGroup>
+                   <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                   <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-        <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
-     <PropertyGroup>
-        <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid> 
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                 <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                 </PropertyGroup>
+                 <PropertyGroup>
+                    <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid> 
+                 </PropertyGroup>
+             </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup> 
-        <ProjectGuid Condition=""'$(FalseCondition)' == 'true'"">{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup> 
+                   <ProjectGuid Condition="'$(FalseCondition)' == 'true'">{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         public async Task GetProjectGuidAsync_ReturnsFirstProjectGuidIgnoringConditions(string projectXml)
         {
             var provider = CreateInstance(projectXml);
@@ -182,12 +198,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public async Task GetProjectGuidAsync_ReturnsProjectGuid(string guid)
         {
             var projectXml =
-$@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuid>{guid}</ProjectGuid>
-     </PropertyGroup>
- </Project>";
+                $"""
+                <Project>
+                    <PropertyGroup>
+                        <ProjectGuid>{guid}</ProjectGuid>
+                    </PropertyGroup>
+                </Project>
+                """;
 
             var provider = CreateInstance(projectXml);
 
@@ -198,124 +215,137 @@ $@"
 
         [Theory]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-,
-@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                 <PropertyGroup>
+                     <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                 </PropertyGroup>
+             </Project>
+            """,
+            """
+            <Project>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-         <projectguid>{D110509C-066B-434E-B456-15B71F0DA330}</projectguid>
-     </PropertyGroup>
- </Project>",
-@"
-<Project>
-     <PropertyGroup>
-         <projectguid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</projectguid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                    <projectguid>{D110509C-066B-434E-B456-15B71F0DA330}</projectguid>
+                </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+                <PropertyGroup>
+                    <projectguid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</projectguid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-    <PropertyGroup>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-    </PropertyGroup>
-</Project>",
-@"
-<Project>
-    <PropertyGroup>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-    </PropertyGroup>
-</Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                </PropertyGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+                <PropertyGroup>
+                </PropertyGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-         <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-     </PropertyGroup>
- </Project>",
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                 <ItemGroup>
+                 </ItemGroup>
+                 <PropertyGroup>
+                     <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                 </PropertyGroup>
+             </Project>
+            """,
+            """
+            <Project>
+                <ItemGroup>
+                </ItemGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-         <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>",
-@"
-<Project>
-     <ItemGroup>
-     </ItemGroup>
-     <PropertyGroup>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-         <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                 <ItemGroup>
+                 </ItemGroup>
+                 <PropertyGroup>
+                     <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                     <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                 </PropertyGroup>
+             </Project>
+            """,
+            """
+            <Project>
+                <ItemGroup>
+                </ItemGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-    <PropertyGroup>
-        <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid> 
-    </PropertyGroup>
-</Project>",
-@"
-<Project>
-    <PropertyGroup>
-        <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid> 
-    </PropertyGroup>
-</Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                    <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                </PropertyGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid> 
+                </PropertyGroup>
+            </Project>
+            """,
+            """
+            <Project>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+                <PropertyGroup>
+                    <ProjectGuid>{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid> 
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup> 
-        <ProjectGuid Condition=""'$(FalseCondition)' == 'true'"">{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-     </PropertyGroup>
- </Project>",
-@"
-<Project>
-     <PropertyGroup> 
-        <ProjectGuid Condition=""'$(FalseCondition)' == 'true'"">{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                 <PropertyGroup> 
+                    <ProjectGuid Condition="'$(FalseCondition)' == 'true'">{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                 </PropertyGroup>
+             </Project>
+            """,
+            """
+            <Project>
+                <PropertyGroup> 
+                   <ProjectGuid Condition="'$(FalseCondition)' == 'true'">{C26D43ED-ED18-46F9-8950-0B1A7232746E}</ProjectGuid>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         public async Task SetProjectGuidAsync_SetsFirstProjectGuidIgnoringConditions(string input, string expected)
         {
             var result = ProjectRootElementFactory.Create(input);
@@ -343,12 +373,14 @@ $@"
         [InlineData("C26D43EDED1846F989500B1%417232746E")] // With escaped characters
         public async Task SetProjectGuidAsync_WhenProjectGuidPropertyAlreadyHasSameGuid_DoesNotSet(string guid)
         {
-            var projectXml = $@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuid>{guid}</ProjectGuid>
-     </PropertyGroup>
- </Project>";
+            var projectXml =
+                $"""
+                <Project>
+                    <PropertyGroup>
+                        <ProjectGuid>{guid}</ProjectGuid>
+                    </PropertyGroup>
+                </Project>
+                """;
 
             var result = ProjectRootElementFactory.Create(projectXml);
             var provider = CreateInstance(result);
@@ -360,41 +392,47 @@ $@"
 
         [Theory]
         [InlineData(
-@"<Project/>"
-)]
+            """
+            <Project/>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-    <PropertyGroup>
-    </PropertyGroup>
-</Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <PropertyGroup>
-         <ProjectGuids>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuids>
-     </PropertyGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <PropertyGroup>
+                    <ProjectGuids>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuids>
+                </PropertyGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <ItemGroup>
-         <ProjectGuid Include=""{D110509C-066B-434E-B456-15B71F0DA330}"" />
-     </ItemGroup>
- </Project>"
-)]
+            """
+            <Project>
+                <ItemGroup>
+                    <ProjectGuid Include="{D110509C-066B-434E-B456-15B71F0DA330}" />
+                </ItemGroup>
+            </Project>
+            """
+            )]
         [InlineData(
-@"
-<Project>
-     <Target Name=""Target"">
-         <PropertyGroup>
-            <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
-         </PropertyGroup>
-     </Target>
- </Project>"
-)]
+            """
+            <Project>
+                <Target Name="Target">
+                    <PropertyGroup>
+                       <ProjectGuid>{D110509C-066B-434E-B456-15B71F0DA330}</ProjectGuid>
+                    </PropertyGroup>
+                </Target>
+            </Project>
+            """
+            )]
         public async Task SetProjectGuidAsync_WhenNoProjectGuidProperty_DoesNotSet(string projectXml)
         {
             var result = ProjectRootElementFactory.Create(projectXml);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PostBuildEventValueProviderTests.cs
@@ -13,24 +13,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_AllTargetsPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
 
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;prebuild output&quot;"" />
-  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;prebuild output&quot;" />
+                  </Target>
 
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""post build output""", actual);
         }
@@ -38,20 +39,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_PostBuildTargetPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
 
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""post build output""", actual);
         }
@@ -59,20 +61,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_PostBuildTargetPresent_LowerCase()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
 
-  <Target Name=""postbuild"" AfterTargets=""postbuildevent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
+                  <Target Name="postbuild" AfterTargets="postbuildevent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""post build output""", actual);
         }
@@ -80,16 +83,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_NoTargetsPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
 
-</Project>
-".AsProjectRootElement();
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(actual);
         }
@@ -107,18 +111,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_WrongTargetName()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PoostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
@@ -126,18 +131,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_WrongExec()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Commmand=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Commmand="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
@@ -145,23 +151,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_NoTargetsPresent()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build output""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -170,26 +182,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -198,26 +216,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_LowerCase()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""postbuild"" AfterTargets=""postbuildevent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="postbuild" AfterTargets="postbuildevent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""postbuild"" AfterTargets=""postbuildevent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="postbuild" AfterTargets="postbuildevent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -226,27 +250,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_NoTasks()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-  </Target>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -255,33 +285,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_NoTasks_Removal()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-  </Target>
-  <Target Name=""PostBuild1"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                  </Target>
+                  <Target Name="PostBuild1" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-  </Target>
-  <Target Name=""PostBuild1"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command="""" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                  </Target>
+                  <Target Name="PostBuild1" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -290,28 +326,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_MultipleTasks()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -320,28 +362,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_DoNotRemoveTarget_EmptyString()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command="""" />
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="" />
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -350,23 +398,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_RemoveTarget_EmptyString()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -375,23 +429,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_RemoveTarget_WhitespaceCharacter()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty("       ", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -400,23 +460,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_RemoveTarget_TabCharacter()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty("\t\t\t", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -425,26 +491,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_DoNotRemoveTarget_NewlineCharacter()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty("\r\n", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""&#xD;&#xA;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="&#xD;&#xA;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -453,27 +525,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetNameCollision()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"">
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"">
-  </Target>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild">
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -482,32 +560,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetNameCollision02()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"">
-  </Target>
-  <Target Name=""PostBuild1"">
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild">
+                  </Target>
+                  <Target Name="PostBuild1">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"">
-  </Target>
-  <Target Name=""PostBuild1"">
-  </Target>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild">
+                  </Target>
+                  <Target Name="PostBuild1">
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -516,32 +599,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetNameCollision_LowerCase()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""postBuild"">
-  </Target>
-  <Target Name=""postBuild1"">
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="postBuild">
+                  </Target>
+                  <Target Name="postBuild1">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""postBuild"">
-  </Target>
-  <Target Name=""postBuild1"">
-  </Target>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="postBuild">
+                  </Target>
+                  <Target Name="postBuild1">
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -575,29 +663,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_WrongTargetName()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PoostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PoostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PoostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -606,16 +700,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Read_CheckEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo %25DATE%"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo %25DATE%" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
 
             const string expected = "echo %DATE%";
             string? actual = systemUnderTest.TryGetValueFromTarget(root);
@@ -625,16 +721,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Read_CheckNotDoubleEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo %2525DATE%"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo %2525DATE%" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
 
             const string expected = "echo %25DATE%";
             string? actual = systemUnderTest.TryGetValueFromTarget(root);
@@ -644,23 +742,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Write_CheckEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
 
-            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo %25DATE%25"" />
-  </Target>
-</Project>";
+            const string expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo %25DATE%25" />
+                  </Target>
+                </Project>
+                """;
 
             systemUnderTest.SetProperty("echo %DATE%", root);
             var actual = root.SaveAndGetChanges();
@@ -670,23 +773,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Write_CheckNotDoubleEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
 
-            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo %2525DATE%25"" />
-  </Target>
-</Project>";
+            const string expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo %2525DATE%25" />
+                  </Target>
+                </Project>
+                """;
 
             systemUnderTest.SetProperty("echo %25DATE%", root);
             var actual = root.SaveAndGetChanges();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/PreBuildEventValueProviderTests.cs
@@ -13,24 +13,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_AllTargetsPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;prebuild output&quot;"" />
-  </Target>
-
-  <Target Name=""PostBuild"" AfterTargets=""PostBuildEvent"">
-    <Exec Command=""echo &quot;post build output&quot;"" />
-  </Target>
-
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;prebuild output&quot;" />
+                  </Target>
+                  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+                    <Exec Command="echo &quot;post build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
@@ -38,20 +35,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_PreBuildTargetPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;prebuild output&quot;"" />
-  </Target>
-
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;prebuild output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
@@ -59,20 +54,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_PreBuildTargetPresent_LowerCase()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-  <Target Name=""prebuild"" BeforeTargets=""prebuildevent"">
-    <Exec Command=""echo &quot;prebuild output&quot;"" />
-  </Target>
-
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="prebuild" BeforeTargets="prebuildevent">
+                    <Exec Command="echo &quot;prebuild output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Equal(@"echo ""prebuild output""", actual);
         }
@@ -80,16 +73,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_NoTargetsPresent()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
             var actual = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(actual);
         }
@@ -107,20 +99,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_WrongTargetName()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-  <Target Name=""PreeBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;prebuild output&quot;"" />
-  </Target>
-
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreeBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;prebuild output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
@@ -128,19 +118,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void GetPropertyAsync_WrongExec()
         {
-            var root = @"
-<Project Sdk=""Microsoft.NET.Sdk"">
-
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-
-  <Target Name=""PreBuild"" AfterTargets=""PreBuildEvent"">
-    <Exec Commmand=""echo &quot;prebuild output&quot;"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" AfterTargets="PreBuildEvent">
+                    <Exec Commmand="echo &quot;prebuild output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             var result = systemUnderTest.TryGetValueFromTarget(root);
             Assert.Null(result);
         }
@@ -148,23 +137,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_NoTargetsPresent()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build output""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -173,26 +168,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -201,26 +202,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_LowerCase()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""prebuild"" BeforeTargets=""prebuildevent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="prebuild" BeforeTargets="prebuildevent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""prebuild"" BeforeTargets=""prebuildevent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="prebuild" BeforeTargets="prebuildevent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -229,27 +236,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_NoTasks()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-  </Target>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -258,33 +271,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_NoTasks_Removal()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-  </Target>
-  <Target Name=""PreBuild1"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                  </Target>
+                  <Target Name="PreBuild1" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-  </Target>
-  <Target Name=""PreBuild1"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command="""" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                  </Target>
+                  <Target Name="PreBuild1" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -293,28 +312,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetPresent_MultipleTasks()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -323,29 +348,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_DoNotRemoveTarget_EmptyString()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command="""" />
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="" />
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -354,23 +384,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_RemoveTarget_EmptyString()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(string.Empty, root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -379,25 +415,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_RemoveTarget_WhitespaceCharacter()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty("       ", root);
             var stringWriter = new System.IO.StringWriter();
             root.Save(stringWriter);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -406,23 +448,29 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_RemoveTarget_TabCharacter()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty("\t\t\t", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -431,27 +479,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_DoNotRemoveTarget_NewlineCharacter()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty("\r\n", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""&#xD;&#xA;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="&#xD;&#xA;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -460,28 +513,33 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetNameCollision()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"">
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"">
-  </Target>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild">
+                  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -490,31 +548,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetNameCollision02()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"">
-  </Target>
-  <Target Name=""PreBuild1"">
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild">
+                  </Target>
+                  <Target Name="PreBuild1">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"">
-  </Target>
-  <Target Name=""PreBuild1"">
-  </Target>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild">
+                  </Target>
+                  <Target Name="PreBuild1">
+                  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -523,31 +587,37 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_TargetNameCollision_LowerCase()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""prebuild"">
-  </Target>
-  <Target Name=""prebuild1"">
-  </Target>
-</Project>".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="prebuild">
+                  </Target>
+                  <Target Name="prebuild1">
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""pre build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""prebuild"">
-  </Target>
-  <Target Name=""prebuild1"">
-  </Target>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="prebuild">
+                  </Target>
+                  <Target Name="prebuild1">
+                  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -581,30 +651,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void SetPropertyAsync_WrongTargetName()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreeBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreeBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
             systemUnderTest.SetProperty(@"echo ""post build $(OutDir)""", root);
 
-            var expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreeBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;pre build output&quot;"" />
-  </Target>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo &quot;post build $(OutDir)&quot;"" />
-  </Target>
-</Project>";
+            var expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreeBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;pre build output&quot;" />
+                  </Target>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo &quot;post build $(OutDir)&quot;" />
+                  </Target>
+                </Project>
+                """;
 
             var actual = root.SaveAndGetChanges();
             Assert.Equal(expected, actual);
@@ -613,16 +688,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Read_CheckEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo %25DATE%"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo %25DATE%" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
 
             const string expected = "echo %DATE%";
             string? actual = systemUnderTest.TryGetValueFromTarget(root);
@@ -632,16 +709,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Read_CheckNotDoubleEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo %2525DATE%"" />
-  </Target>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo %2525DATE%" />
+                  </Target>
+                </Project>
+                """.AsProjectRootElement();
 
             const string expected = "echo %25DATE%";
             string? actual = systemUnderTest.TryGetValueFromTarget(root);
@@ -651,23 +730,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Write_CheckEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
 
-            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo %25DATE%25"" />
-  </Target>
-</Project>";
+            const string expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo %25DATE%25" />
+                  </Target>
+                </Project>
+                """;
 
             systemUnderTest.SetProperty("echo %DATE%", root);
             var actual = root.SaveAndGetChanges();
@@ -677,23 +761,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         [Fact]
         public static void EscapeValue_Write_CheckNotDoubleEscaped()
         {
-            var root = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-</Project>
-".AsProjectRootElement();
+            var root =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                </Project>
+                """.AsProjectRootElement();
 
-            const string expected = @"<Project Sdk=""Microsoft.NET.Sdk"">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
-  </PropertyGroup>
-  <Target Name=""PreBuild"" BeforeTargets=""PreBuildEvent"">
-    <Exec Command=""echo %2525DATE%25"" />
-  </Target>
-</Project>";
+            const string expected =
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>netcoreapp1.1</TargetFramework>
+                  </PropertyGroup>
+                  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+                    <Exec Command="echo %2525DATE%25" />
+                  </Target>
+                </Project>
+                """;
 
             systemUnderTest.SetProperty("echo %25DATE%", root);
             var actual = root.SaveAndGetChanges();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
@@ -276,35 +276,52 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             _intermediateOutputPath = intermediateOutputPath ?? _intermediateOutputPath;
 
-            var ruleUpdate = @"{
-                                      ""ProjectChanges"": {
-                                          ""ConfigurationGeneral"": {
-                                              ""Difference"": {
-                                                  ""ChangedProperties"": [ ";
+            var ruleUpdate =
+                """
+                {
+                    "ProjectChanges": {
+                        "ConfigurationGeneral": {
+                            "Difference": {
+                                "ChangedProperties": [
+
+                """;
 
             if (_lastIntermediateOutputPath != _intermediateOutputPath)
             {
-                ruleUpdate += @"                        ""IntermediateOutputPath"",";
+                ruleUpdate +=
+                    """
+                                        "IntermediateOutputPath",
+
+                    """;
             }
+
             // root namespace and project folder have changed if its the first time we've sent inputs
             if (_lastIntermediateOutputPath == null)
             {
-                ruleUpdate += @"                        ""ProjectDir"",
-                                                        ""RootNamespace""";
+                ruleUpdate +=
+                    """
+                                       "ProjectDir",
+                                       "RootNamespace"
+
+                    """;
             }
+
             ruleUpdate = ruleUpdate.TrimEnd(',');
-            ruleUpdate += @"                      ]
-                                              },
-                                              ""After"": {
-                                                  ""Properties"": {
-                                                      ""ProjectDir"": """ + _projectFolder.Replace("\\", "\\\\") + @""",
-                                                      ""IntermediateOutputPath"": """ + _intermediateOutputPath.Replace("\\", "\\\\") + @""",
-                                                      ""RootNamespace"": ""MyNamespace""
-                                                  }
-                                              }
-                                          }
-                                      }
-                                  }";
+            ruleUpdate +=
+                $$"""
+                                ]
+                            },
+                            "After": {
+                                "Properties": {
+                                    "ProjectDir": "{{_projectFolder.Replace("\\", "\\\\")}}",
+                                    "IntermediateOutputPath": "{{_intermediateOutputPath.Replace("\\", "\\\\")}}",
+                                    "RootNamespace": "MyNamespace"
+                                }
+                            }
+                        }
+                    }
+                }
+                """;
             IProjectSubscriptionUpdate subscriptionUpdate = IProjectSubscriptionUpdateFactory.FromJson(ruleUpdate);
 
             _lastIntermediateOutputPath = _intermediateOutputPath;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -77,9 +77,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         [Fact]
         public async Task GetSpecificEditorAsync_WhenFileNotInProject_ReturnsNull()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                """);
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
 
             Assert.Null(result);
@@ -88,9 +89,10 @@ Project
         [Fact]
         public async Task SetUseGlobalEditorAsync_WhenFileNotInProject_ReturnsFalse()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                """);
             var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", true);
 
             Assert.False(result);
@@ -99,10 +101,11 @@ Project
         [Fact]
         public async Task GetSpecificEditorAsync_WhenFileNotCompileItem_ReturnsNull()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: None
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs, FilePath: "C:\Foo.cs", ItemType: None
+                """);
 
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
 
@@ -112,10 +115,11 @@ Project
         [Fact]
         public async Task SetUseGlobalEditorAsync_WhenFileNotCompileItem_ReturnsFalse()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: None
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs, FilePath: "C:\Foo.cs", ItemType: None
+                """);
 
             var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", false);
 
@@ -125,10 +129,11 @@ Project
         [Fact]
         public async Task GetSpecificEditorAsync_WhenCompileItemWithNoSubType_ReturnsNull()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs, FilePath: "C:\Foo.cs", ItemType: Compile
+                """);
 
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
 
@@ -138,10 +143,11 @@ Project
         [Fact]
         public async Task SetUseGlobalEditorAsync_WhenCompileItemWithNoSubType_ReturnsFalse()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs, FilePath: "C:\Foo.cs", ItemType: Compile
+                """);
 
             var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", false);
 
@@ -151,10 +157,11 @@ Project
         [Fact]
         public async Task GetSpecificEditorAsync_WhenCompileItemWithUnrecognizedSubType_ReturnsNull()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Code
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Code
+                """);
 
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.cs");
 
@@ -164,10 +171,11 @@ Project
         [Fact]
         public async Task SetUseGlobalEditorAsync_WhenCompileItemWithUnrecognizedSubType_ReturnsFalse()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Code
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Code
+                """);
 
             var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.cs", false);
 
@@ -177,11 +185,13 @@ Project
         [Fact]
         public async Task GetSpecificEditorAsync_WhenParentIsSourceFile_ReturnsNull()
         {   // Let's folks double-click the designer file to open it as text
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs (flags: {SourceFile})
-        Foo.Designer.cs, FilePath: ""C:\Foo.Designer.cs"", ItemType: Compile, SubType: Designer
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs (flags: {SourceFile})
+                        Foo.Designer.cs, FilePath: "C:\Foo.Designer.cs", ItemType: Compile, SubType: Designer
+
+                """);
 
             var result = await provider.GetSpecificEditorAsync(@"C:\Foo.Designer.cs");
 
@@ -191,11 +201,13 @@ Project
         [Fact]
         public async Task SetUseGlobalEditorAsync_WhenParentIsSourceFile_ReturnsFalse()
         {
-            var provider = CreateInstanceWithDefaultEditorProvider(@"
-Project
-    Foo.cs (flags: {SourceFile})
-        Foo.Designer.cs, FilePath: ""C:\Foo.Designer.cs"", ItemType: Compile, SubType: Designer
-");
+            var provider = CreateInstanceWithDefaultEditorProvider(
+                """
+                Project
+                    Foo.cs (flags: {SourceFile})
+                        Foo.Designer.cs, FilePath: "C:\Foo.Designer.cs", ItemType: Compile, SubType: Designer
+
+                """);
 
             var result = await provider.SetUseGlobalEditorAsync(@"C:\Foo.Designer.cs", false);
 
@@ -203,22 +215,26 @@ Project
         }
 
         [Theory]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Form
-", true)]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Designer
-", true)]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: UserControl
-", true)]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Component
-", false)]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Form
+            """, true)]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Designer
+            """, true)]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: UserControl
+            """, true)]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Component
+            """, false)]
         public async Task GetSpecificEditorAsync_WhenMarkedWithRecognizedSubType_ReturnsResult(string tree, bool useDesignerByDefault)
         {
             var defaultEditorFactory = Guid.NewGuid();
@@ -236,22 +252,30 @@ Project
         }
 
         [Theory]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Form
-", "Form")]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Designer
-", "Designer")]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: UserControl
-", "UserControl")]
-        [InlineData(@"
-Project
-    Foo.txt, FilePath: ""C:\Foo.cs"", ItemType: Compile, SubType: Component
-", "Component")]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Form
+            """,
+            "Form")]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Designer
+            """,
+            "Designer")]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: UserControl
+            """,
+            "UserControl")]
+        [InlineData(
+            """
+            Project
+                Foo.txt, FilePath: "C:\Foo.cs", ItemType: Compile, SubType: Component
+            """,
+            "Component")]
         public async Task SetUseGlobalEditorAsync_WhenMarkedWithRecognizedSubType_ReturnsTrue(string tree, string expectedCategory)
         {
             string? categoryResult = null;


### PR DESCRIPTION
Recently this change was made in c62261b947dc6406f4f6f8178095d2bfd4583e6a to launch settings test data, which was a nice clean up. This commit applies it to remaining test data.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8086)