### PR TITLE
Add FUTD "ignore kinds" to telemetry data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             private readonly string _fileName;
             private readonly ITelemetryService? _telemetryService;
             private readonly UpToDateCheckConfiguredInput _upToDateCheckConfiguredInput;
+            private readonly string? _ignoreKinds;
 
             public LogLevel Level { get; }
 
@@ -22,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             public string? FailureReason { get; private set; }
 
-            public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, ITelemetryService? telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput)
+            public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, ITelemetryService? telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput, string? ignoreKinds)
             {
                 _writer = writer;
                 Level = requestedLogLevel;
@@ -30,6 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _timestampCache = timestampCache;
                 _telemetryService = telemetryService;
                 _upToDateCheckConfiguredInput = upToDateCheckConfiguredInput;
+                _ignoreKinds = ignoreKinds;
                 _fileName = Path.GetFileNameWithoutExtension(projectPath);
             }
 
@@ -156,7 +158,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     (TelemetryPropertyName.UpToDateCheckDurationMillis, _stopwatch.Elapsed.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),
                     (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
-                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level)
+                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level),
+                    (TelemetryPropertyName.UpToDateCheckIgnoreKinds, _ignoreKinds ?? "")
                 });
 
                 // Remember the failure reason for use in IncrementalBuildFailureDetector.
@@ -177,7 +180,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     (TelemetryPropertyName.UpToDateCheckDurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),
                     (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
-                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level)
+                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level),
+                    (TelemetryPropertyName.UpToDateCheckIgnoreKinds, _ignoreKinds ?? "")
                 });
 
                 Info(nameof(Resources.FUTD_UpToDate));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -830,13 +830,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 // Short-lived cache of timestamp by path
                 var timestampCache = new TimestampCache(_fileSystem);
 
+                globalProperties.TryGetValue(FastUpToDateCheckIgnoresKindsGlobalPropertyName, out string? ignoreKindsString);
+
                 LogLevel requestedLogLevel = await _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token);
-                var logger = new Log(logWriter, requestedLogLevel, sw, timestampCache, _configuredProject.UnconfiguredProject.FullPath ?? "", isValidationRun ? null : _telemetryService, state);
+                var logger = new Log(logWriter, requestedLogLevel, sw, timestampCache, _configuredProject.UnconfiguredProject.FullPath ?? "", isValidationRun ? null : _telemetryService, state, ignoreKindsString);
 
                 try
                 {
                     HashSet<string>? ignoreKinds = null;
-                    if (globalProperties.TryGetValue(FastUpToDateCheckIgnoresKindsGlobalPropertyName, out string? ignoreKindsString))
+                    if (ignoreKindsString is not null)
                     {
                         ignoreKinds = new HashSet<string>(new LazyStringSplit(ignoreKindsString, ';'), StringComparer.OrdinalIgnoreCase);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -45,6 +45,12 @@ namespace Microsoft.VisualStudio.Telemetry
         public const string UpToDateCheckLogLevel = Prefix + ".uptodatecheck.loglevel";
 
         /// <summary>
+        ///     Indicates any ignore kinds provided to the fast up-to-date check.
+        ///     Used to skip analyzers during indirect builds (for debug or unit tests).
+        /// </summary>
+        public const string UpToDateCheckIgnoreKinds = Prefix + ".uptodatecheck.ignorekinds";
+
+        /// <summary>
         ///     Indicates the project when the dependency tree is updated with all resolved dependencies.
         /// </summary>
         public static readonly string TreeUpdatedResolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "Project");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1891,7 +1891,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             writer.Assert();
 
             if (telemetryReason != null)
-                AssertTelemetryFailureEvent(telemetryReason);
+                AssertTelemetryFailureEvent(telemetryReason, ignoreKinds);
             else
                 Assert.Empty(_telemetryEvents);
 
@@ -1904,18 +1904,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             Assert.True(await _buildUpToDateCheck.IsUpToDateAsync(BuildAction.Build, writer, CreateGlobalProperties(ignoreKinds, targetFramework)));
             
-            AssertTelemetrySuccessEvent();
+            AssertTelemetrySuccessEvent(ignoreKinds);
 
             writer.Assert();
         }
 
-        private void AssertTelemetryFailureEvent(string reason)
+        private void AssertTelemetryFailureEvent(string reason, string ignoreKinds)
         {
             var telemetryEvent = Assert.Single(_telemetryEvents);
 
             Assert.Equal(TelemetryEventName.UpToDateCheckFail, telemetryEvent.EventName);
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(5, telemetryEvent.Properties.Count);
+            Assert.Equal(6, telemetryEvent.Properties.Count);
 
             var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFailReason));
             Assert.Equal(reason, reasonProp.propertyValue);
@@ -1930,23 +1930,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             var configurationCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckConfigurationCount));
             var configurationCount = Assert.IsType<int>(configurationCountProp.propertyValue);
-            Assert.True(configurationCount == 1);
+            Assert.Equal(1, configurationCount);
 
             var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckLogLevel));
             var logLevel = Assert.IsType<LogLevel>(logLevelProp.propertyValue);
-            Assert.True(logLevel == _logLevel);
+            Assert.Equal(_logLevel, logLevel);
+
+            var ignoreKindsProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckIgnoreKinds));
+            var ignoreKindsStr = Assert.IsType<string>(ignoreKindsProp.propertyValue);
+            Assert.Equal(ignoreKinds, ignoreKindsStr);
 
             _telemetryEvents.Clear();
         }
 
-        private void AssertTelemetrySuccessEvent()
+        private void AssertTelemetrySuccessEvent(string ignoreKinds)
         {
             var telemetryEvent = Assert.Single(_telemetryEvents);
 
             Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, telemetryEvent.EventName);
 
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(4, telemetryEvent.Properties.Count);
+            Assert.Equal(5, telemetryEvent.Properties.Count);
 
             var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
@@ -1963,6 +1967,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckLogLevel));
             var logLevel = Assert.IsType<LogLevel>(logLevelProp.propertyValue);
             Assert.True(logLevel == _logLevel);
+
+            var ignoreKindsProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckIgnoreKinds));
+            var ignoreKindsStr = Assert.IsType<string>(ignoreKindsProp.propertyValue);
+            Assert.Equal(ignoreKinds, ignoreKindsStr);
 
             _telemetryEvents.Clear();
         }


### PR DESCRIPTION
When an indirect build occurs (for debug or unit test runs) a global property containing optional kinds of FUTD inputs to ignore is specified. This modifies the FUTD check such that subsequent full builds still occur.

This change adds the list of ignore kinds to the telemetry data we publish.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8087)