### PR TITLE
update CPS and pass ValueDefinedInContext back to CPS

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -73,10 +73,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.11.32-alpha" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.3.16-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.3.16-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.3.16-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.3.16-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.3.63-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.3.63-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.3.63-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.3.63-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -59,6 +59,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 };
             }
 
+            if (requestedProperties.ValueDefinedInContext)
+            {
+                newUIPropertyValue.ValueDefinedInContext = await property.IsDefinedInContextAsync();
+            }
+
             ((IEntityValueFromProvider)newUIPropertyValue).ProviderState = new PropertyValueProviderState(configuration, property);
 
             return newUIPropertyValue;


### PR DESCRIPTION
The new metadata property ValueDefinedInContext needs to be passed back to CPS from the project-system side

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8091)