### PR TITLE
Fast up-to-date check considers ApplicationManifest

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -412,7 +412,12 @@
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
   <!-- This target collects all the extra inputs for the up to date check. -->
-  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)" />
+  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
+    <ItemGroup>
+      <!-- app.manifest -->
+      <UpToDateCheckInput Condition=" '$(ApplicationManifest)' != '' " Include="$(ApplicationManifest)" />
+    </ItemGroup>
+  </Target>
 
   <!-- This target collects all the extra outputs for the up to date check. -->
   <Target Name="CollectUpToDateCheckOutputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckOutput)" />


### PR DESCRIPTION
Fixes #8092

On Windows, an executable may specify an `app.manifest` file that factors into the compilation of the output. Changes to this file must trigger a build.

This change adds such a file, if specified, to the list of inputs that the fast up-to-date check considers.

## Before

Change `app.manifest` and build:

```
Build started...
1>FastUpToDate: Adding UpToDateCheckBuilt outputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.pdb (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.dll (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\obj\Debug\net6.0\ConsoleApp404.pdb (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\obj\Debug\net6.0\ConsoleApp404.dll (ConsoleApp404)
1>FastUpToDate: Adding project file inputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\ConsoleApp404.csproj (ConsoleApp404)
1>FastUpToDate: Adding newest import input: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\ConsoleApp404.csproj (ConsoleApp404)
1>FastUpToDate: Adding Compile inputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\Program.cs (ConsoleApp404)
1>FastUpToDate: No inputs are newer than earliest output 'C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.pdb' (21/04/2022 11:17:39). Newest input is 'C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\ConsoleApp404.csproj' (21/04/2022 11:13:10). (ConsoleApp404)
1>FastUpToDate: Project is up-to-date. (ConsoleApp404)
1>FastUpToDate: Up-to-date check completed in 0.8 ms (ConsoleApp404)
========== Build: 0 succeeded, 0 failed, 1 up-to-date, 0 skipped ==========
```

## After

Change `app.manifest` and build:

```
Build started...
1>FastUpToDate: Adding UpToDateCheckBuilt outputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.pdb (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.dll (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\obj\Debug\net6.0\ConsoleApp404.pdb (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\obj\Debug\net6.0\ConsoleApp404.dll (ConsoleApp404)
1>FastUpToDate: Adding project file inputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\ConsoleApp404.csproj (ConsoleApp404)
1>FastUpToDate: Adding newest import input: (ConsoleApp404)
1>FastUpToDate:     D:\repos\project-system\artifacts\Debug\VSSetup\Rules\Microsoft.Managed.DesignTime.targets (ConsoleApp404)
1>FastUpToDate: Adding Compile inputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\Program.cs (ConsoleApp404)
1>FastUpToDate: Adding UpToDateCheckInput inputs: (ConsoleApp404)
1>FastUpToDate:     C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\app.manifest (ConsoleApp404)
1>FastUpToDate: Input UpToDateCheckInput item 'C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\app.manifest' is newer (21/04/2022 11:17:39) than earliest output 'C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.pdb' (21/04/2022 11:17:20), not up-to-date. (ConsoleApp404)
1>FastUpToDate: Up-to-date check completed in 0.9 ms (ConsoleApp404)
1>------ Build started: Project: ConsoleApp404, Configuration: Debug Any CPU ------
1>You are using a preview version of .NET. See: https://aka.ms/dotnet-core-preview
1>ConsoleApp404 -> C:\Users\drnoakes\source\repos\ConsoleApp404\ConsoleApp404\bin\Debug\net6.0\ConsoleApp404.dll
========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8094)