### PR TITLE
Prevent a .csproj.user file being created during build

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -40,6 +40,9 @@
     <Compile Update="ProjectSystem\VS\LanguageServices\VisualBasic\VisualBasicCodeDomProvider.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Update="ProjectSystem\VS\PropertyPages\DebugPropertyPage.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml.cs">
       <DependentUpon>DebugPageControl.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION
We missed this item update in our .csproj file. As a consequence, for a clean clone of our repo, CPS creates a .user file that contains this metadata for the project. This means the project becomes immediately out-of-date, and we report an incremental build failure.

Adding this into the .csproj file fixes this issue.

The `.csproj.user` file has the following content:

```xml
<?xml version="1.0" encoding="utf-8"?>
<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup />
  <ItemGroup>
    <Compile Update="PropertyPages\PropertyPageControl.cs">
      <SubType>UserControl</SubType>
    </Compile>
  </ItemGroup>
</Project>
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8097)