### PR TITLE
[17.2] Don't load VC++ projects during build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -91,4 +91,10 @@
     <NoWarn>$(NoWarn);NU5125</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      TODO: Suppress warnings about duplicate PackageReferences until we can remove them (https://github.com/dotnet/project-system/issues/8074)
+    -->
+    <NoWarn>$(NoWarn);NU1504</NoWarn>
+  </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
     {
         private readonly ISolutionBuildManager _solutionBuildEvents;
         private readonly IRunningDocumentTable _rdtEvents;
-        private readonly IProjectService _projectService;
+        private readonly IProjectServiceAccessor _projectServiceAccessor;
 
         private IAsyncDisposable? _solutionBuildEventsSubscription;
         private IAsyncDisposable? _rdtEventsSubscription;
@@ -53,13 +53,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
         public IncrementalBuildFailureDetector(
             ISolutionBuildManager solutionBuildEvents,
             IRunningDocumentTable rdtEvents,
-            IProjectService projectService,
+            IProjectServiceAccessor projectServiceAccessor,
             JoinableTaskContext joinableTaskContext)
             : base(new(joinableTaskContext))
         {
             _solutionBuildEvents = solutionBuildEvents;
             _rdtEvents = rdtEvents;
-            _projectService = projectService;
+            _projectServiceAccessor = projectServiceAccessor;
         }
 
         async Task IPackageService.InitializeAsync(IAsyncServiceProvider _)
@@ -120,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
 
                 if (IsRelevantBuild(dwAction))
                 {
-                    UnconfiguredProject? unconfiguredProject = _projectService.GetUnconfiguredProject(pHierProj, appliesToExpression: BuildUpToDateCheck.AppliesToExpression);
+                    UnconfiguredProject? unconfiguredProject = _projectServiceAccessor.GetProjectService().GetUnconfiguredProject(pHierProj, appliesToExpression: BuildUpToDateCheck.AppliesToExpression);
 
                     IProjectChecker? checker = unconfiguredProject?.Services.ExportProvider.GetExportedValueOrDefault<IProjectChecker>();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -41,6 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
     {
         private readonly ISolutionBuildManager _solutionBuildEvents;
         private readonly IRunningDocumentTable _rdtEvents;
+        private readonly IProjectService _projectService;
 
         private IAsyncDisposable? _solutionBuildEventsSubscription;
         private IAsyncDisposable? _rdtEventsSubscription;
@@ -52,11 +53,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
         public IncrementalBuildFailureDetector(
             ISolutionBuildManager solutionBuildEvents,
             IRunningDocumentTable rdtEvents,
+            IProjectService projectService,
             JoinableTaskContext joinableTaskContext)
             : base(new(joinableTaskContext))
         {
             _solutionBuildEvents = solutionBuildEvents;
             _rdtEvents = rdtEvents;
+            _projectService = projectService;
         }
 
         async Task IPackageService.InitializeAsync(IAsyncServiceProvider _)
@@ -117,7 +120,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
 
                 if (IsRelevantBuild(dwAction))
                 {
-                    IProjectChecker? checker = pHierProj.AsUnconfiguredProject()?.Services.ExportProvider.GetExportedValueOrDefault<IProjectChecker>();
+                    UnconfiguredProject? unconfiguredProject = _projectService.GetUnconfiguredProject(pHierProj, appliesToExpression: BuildUpToDateCheck.AppliesToExpression);
+
+                    IProjectChecker? checker = unconfiguredProject?.Services.ExportProvider.GetExportedValueOrDefault<IProjectChecker>();
 
                     checker?.OnProjectBuildCompleted();
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/IProjectServiceExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+using static Microsoft.VisualStudio.VSConstants;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    /// <summary>
+    /// Extension methods for <see cref="IProjectService"/>.
+    /// </summary>
+    internal static class IProjectServiceExtensions
+    {
+        /// <summary>
+        /// Obtains the <see cref="UnconfiguredProject"/> for <paramref name="vsHierarchy"/>,
+        /// optionally testing whether it has a capability match to <paramref name="appliesToExpression"/>.
+        /// </summary>
+        /// <param name="projectService">The project service to invoke this method on.</param>
+        /// <param name="vsHierarchy">The VS hierarchy object, which must represent a CPS project.</param>
+        /// <param name="appliesToExpression">An optional project capability match expression to filter out non-matching projects.</param>
+        /// <returns>
+        /// The CPS <see cref="UnconfiguredProject"/> for the given hierarchy node, matching any (optional)
+        /// capability expression, or <see langword="null"/> if no suitable project exists.
+        /// </returns>
+        public static UnconfiguredProject? GetUnconfiguredProject(this IProjectService projectService, IVsHierarchy vsHierarchy, string? appliesToExpression = null)
+        {
+            // We need IProjectService2.GetLoadedProject.
+            if (projectService is IProjectService2 projectService2)
+            {
+                vsHierarchy.GetCanonicalName((uint)VSITEMID.Root, out string? projectFilePath);
+
+                // Ensure we have a path.
+                if (!Strings.IsNullOrEmpty(projectFilePath))
+                {
+                    UnconfiguredProject? unconfiguredProject = projectService2.GetLoadedProject(projectFilePath);
+
+                    // Ensure CPS knows a project having that path.
+                    if (unconfiguredProject is not null)
+                    {
+                        // If capabilites were requested, match them.
+                        if (appliesToExpression is null || unconfiguredProject.Capabilities.AppliesTo(appliesToExpression))
+                        {
+                            // Found a matching project.
+                            return unconfiguredProject;
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     [AppliesTo(BuildUpToDateCheck.AppliesToExpression)]
     internal sealed class UpToDateCheckBuildEventNotifier : OnceInitializedOnceDisposedAsync, IVsUpdateSolutionEvents2, IProjectDynamicLoadComponent
     {
+        private readonly IProjectService _projectService;
         private readonly ISolutionBuildManager _solutionBuildManager;
 
         private IAsyncDisposable? _solutionBuildEventsSubscription;
@@ -23,9 +24,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         [ImportingConstructor]
         public UpToDateCheckBuildEventNotifier(
             JoinableTaskContext joinableTaskContext,
+            IProjectService projectService,
             ISolutionBuildManager solutionBuildManager)
             : base(new(joinableTaskContext))
         {
+            _projectService = projectService;
             _solutionBuildManager = solutionBuildManager;
         }
 
@@ -94,9 +97,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             return (operation & flags) == flags;
         }
 
-        private static IEnumerable<IBuildUpToDateCheckProviderInternal> FindActiveConfiguredProviders(IVsHierarchy vsHierarchy)
+        private IEnumerable<IBuildUpToDateCheckProviderInternal> FindActiveConfiguredProviders(IVsHierarchy vsHierarchy)
         {
-            UnconfiguredProject? unconfiguredProject = vsHierarchy.AsUnconfiguredProject();
+            UnconfiguredProject? unconfiguredProject = _projectService.GetUnconfiguredProject(vsHierarchy, appliesToExpression: BuildUpToDateCheck.AppliesToExpression);
 
             if (unconfiguredProject is not null)
             {


### PR DESCRIPTION
Fixes [AB#1527166](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1527166)

Two components in the .NET Project System listen to build events. When notified about a project's build progress, they are passed `IVsHierarchy` objects.

Previously we used `AsUnconfiguredProject` to obtain the project from a hierarchy, however when this method is invoked on a VC++ project it forces that project to fully load. This is a performance regression for mixed .NET/VC++ solutions.

With this change, we use `IProjectService2.GetLoadedProject` to obtain the project. CPS won't make any operation against an external project system in this case, so there's no chance of inadvertently loading any unloaded components.

We also validate that the project has the required capabilities for the calling component.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8100)