### PR TITLE
Correctly retrieve app.config template for C# projects.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/CSharp/CSharpAppConfigSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/CSharp/CSharpAppConfigSpecialFileProvider.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.CSharp
+{
+    /// <summary>
+    /// Provides a <see cref="ISpecialFileProvider"/> that handles the default 'App.config' file.
+    /// </summary>
+    [ExportSpecialFileProvider(SpecialFiles.AppConfig)]
+    [AppliesTo(ProjectCapability.CSharp)]
+    internal class CSharpAppConfigSpecialFileProvider : AbstractFindByNameSpecialFileProvider
+    {
+        private readonly ICreateFileFromTemplateService _templateFileCreationService;
+
+        [ImportingConstructor]
+        public CSharpAppConfigSpecialFileProvider(IPhysicalProjectTree projectTree, ICreateFileFromTemplateService templateFileCreationService)
+            : base("App.config", projectTree)
+        {
+            _templateFileCreationService = templateFileCreationService;
+        }
+
+        protected override Task CreateFileAsync(string path)
+        {
+            return _templateFileCreationService.CreateFileAsync("AppConfigInternal.zip", path);
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/VisualBasic/VisualBasicAppConfigSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/VisualBasic/VisualBasicAppConfigSpecialFileProvider.cs
@@ -1,20 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.VisualBasic
 {
     /// <summary>
-    ///     Provides a <see cref="ISpecialFileProvider"/> that handles the default 'App.config' file;
-    ///     which contains .NET Framework directives for assembly binding, compatibility and runtime
-    ///     settings.
+    /// Provides a <see cref="ISpecialFileProvider"/> that handles the default 'App.config' file.
     /// </summary>
     [ExportSpecialFileProvider(SpecialFiles.AppConfig)]
-    [AppliesTo(ProjectCapability.DotNet)]
-    internal class AppConfigSpecialFileProvider : AbstractFindByNameSpecialFileProvider
+    [AppliesTo(ProjectCapability.VisualBasic)]
+    internal class VisualBasicAppConfigSpecialFileProvider : AbstractFindByNameSpecialFileProvider
     {
         private readonly ICreateFileFromTemplateService _templateFileCreationService;
 
         [ImportingConstructor]
-        public AppConfigSpecialFileProvider(IPhysicalProjectTree projectTree, ICreateFileFromTemplateService templateFileCreationService)
+        public VisualBasicAppConfigSpecialFileProvider(IPhysicalProjectTree projectTree, ICreateFileFromTemplateService templateFileCreationService)
             : base("App.config", projectTree)
         {
             _templateFileCreationService = templateFileCreationService;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/CSharp/CSharpAppConfigSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/CSharp/CSharpAppConfigSpecialFileProviderTests.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.CSharp
+{
+    public class CSharpAppConfigSpecialFileProviderTests : AbstractFindByNameSpecialFileProviderTestBase
+    {
+        public CSharpAppConfigSpecialFileProviderTests()
+            : base("App.config")
+        {
+        }
+
+        internal override AbstractFindByNameSpecialFileProvider CreateInstance(IPhysicalProjectTree projectTree)
+        {
+            return CreateInstanceWithOverrideCreateFileAsync<CSharpAppConfigSpecialFileProvider>(projectTree, (ICreateFileFromTemplateService)null!);
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/VisualBasic/VisualBasicAppConfigSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/VisualBasic/VisualBasicAppConfigSpecialFileProviderTests.cs
@@ -1,17 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
+namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders.VisualBasic
 {
-    public class AppConfigSpecialFileProviderTests : AbstractFindByNameSpecialFileProviderTestBase
+    public class VisualBasicAppConfigSpecialFileProviderTests : AbstractFindByNameSpecialFileProviderTestBase
     {
-        public AppConfigSpecialFileProviderTests()
+        public VisualBasicAppConfigSpecialFileProviderTests()
             : base("App.config")
         {
         }
 
         internal override AbstractFindByNameSpecialFileProvider CreateInstance(IPhysicalProjectTree projectTree)
         {
-            return CreateInstanceWithOverrideCreateFileAsync<AppConfigSpecialFileProvider>(projectTree, (ICreateFileFromTemplateService)null!);
+            return CreateInstanceWithOverrideCreateFileAsync<VisualBasicAppConfigSpecialFileProvider>(projectTree, (ICreateFileFromTemplateService)null!);
         }
     }
 }


### PR DESCRIPTION
Fixes #7772.

An app.config file should be created when a setting is created/modified and the project doesn't have an app.config file already.

The issue was that it tries to create one but it doesn't find the template in the given folder [AppConfigurationInternal](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/src/vsproject/Templates/Windows/VisualBasic/ItemTemplates/AppConfigurationInternal) because that is specific to Visual Basic. Instead, it should be looking at the [AppConfigInternal](https://devdiv.visualstudio.com/DevDiv/_git/VS?path=/src/vsproject/Templates/Windows/CSharp/ItemTemplates/AppConfigInternal) folder.



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8110)