### PR TITLE
Ignore certain items from evaluation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
@@ -159,8 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         private bool IsItemInCurrentConfiguration(string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata)
         {
             if (metadata.TryGetValue(includePath, out IImmutableDictionary<string, string> itemMetadata)
-                && itemMetadata.TryGetValue("ExcludeFromCurrentConfiguration", out string excludeFromCurrentConfiguration)
-                && StringComparers.PropertyValues.Equals(excludeFromCurrentConfiguration, "true"))
+                && itemMetadata.GetBoolProperty(Compile.ExcludeFromCurrentConfigurationProperty) is true)
             {
                 return false;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
         protected abstract void UpdateInContext(string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger);
 
-        private bool ItemInCurrentConfiguration(string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata)
+        private bool IsItemInCurrentConfiguration(string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata)
         {
             if (metadata.TryGetValue(includePath, out IImmutableDictionary<string, string> itemMetadata)
                 && itemMetadata.TryGetValue("ExcludeFromCurrentConfiguration", out string excludeFromCurrentConfiguration)
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             foreach (string includePath in difference.AddedItems)
             {
-                if (evaluation && !ItemInCurrentConfiguration(includePath, currentMetadata))
+                if (evaluation && !IsItemInCurrentConfiguration(includePath, currentMetadata))
                 {
                     // The item is present in evaluation but contains metadata indicating it should be
                     // ignored.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.xaml
@@ -11,6 +11,9 @@
                 SourceOfDefaultValue="AfterContext" />
   </Rule.DataSource>
 
+  <BoolProperty Name="ExcludeFromCurrentConfiguration"
+                Visible="False" />
+
   <DynamicEnumProperty Name="{}{ItemType}"
                        EnumProvider="ItemTypes" />
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/MetadataFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/MetadataFactory.cs
@@ -9,5 +9,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal.Add(fileName,
                                                                                                     ImmutableStringDictionary<string>.EmptyOrdinalIgnoreCase.Add(metadata.name, metadata.value));
         }
+
+        public static IImmutableDictionary<string, IImmutableDictionary<string, string>> Add(
+            this IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata,
+            string fileName,
+            (string name, string value) itemMetadata)
+        {
+            return metadata.Add(fileName,
+                                ImmutableStringDictionary<string>.EmptyOrdinalIgnoreCase.Add(itemMetadata.name, itemMetadata.value));
+        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -222,13 +222,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             var handler = CreateInstance(@"C:\Project\Project.csproj");
 
-            var difference = IProjectChangeDiffFactory.WithAddedItems("A.cs;B.cs");
+            var difference = IProjectChangeDiffFactory.WithAddedItems("A.cs;B.cs;C.cs");
             var metadata = MetadataFactory.Create("A.cs", ("ExcludeFromCurrentConfiguration", "true"))
                                           .Add("B.cs", ("ExcludeFromCurrentConfiguration", "false"));
+                            
 
             ApplyProjectEvaluation(handler, 1, difference, metadata);
 
-            Assert.Single(handler.FileNames, @"C:\Project\B.cs");
+            string[] expectedFiles = new[] { @"C:\Project\B.cs", @"C:\Project\C.cs" };
+            Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
         }
 
         [Theory] // Current state                      Added files                      Expected state

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -217,6 +217,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Equal("Value", result["Name"]);
         }
 
+        [Fact]
+        public void AddEvaluationChanges_ItemsWithExclusionMetadataAreIgnored()
+        {
+            var handler = CreateInstance(@"C:\Project\Project.csproj");
+
+            var difference = IProjectChangeDiffFactory.WithAddedItems("A.cs;B.cs");
+            var metadata = MetadataFactory.Create("A.cs", ("ExcludeFromCurrentConfiguration", "true"))
+                                          .Add("B,cs", ("ExcludeFromCurrentConfiguration", "false"));
+
+            ApplyProjectEvaluation(handler, 1, difference, metadata);
+
+            Assert.Single(handler.FileNames, @"C:\Project\B.cs");
+        }
+
         [Theory] // Current state                      Added files                      Expected state
         [InlineData("",                                "A.cs",                          @"C:\Project\A.cs")]
         [InlineData("",                                "A.cs;B.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var difference = IProjectChangeDiffFactory.WithAddedItems("A.cs;B.cs");
             var metadata = MetadataFactory.Create("A.cs", ("ExcludeFromCurrentConfiguration", "true"))
-                                          .Add("B,cs", ("ExcludeFromCurrentConfiguration", "false"));
+                                          .Add("B.cs", ("ExcludeFromCurrentConfiguration", "false"));
 
             ApplyProjectEvaluation(handler, 1, difference, metadata);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
@@ -43,6 +43,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
                 var targetPathElement = none.XPathSelectElement(@"/msb:Rule/msb:StringProperty[@Name=""TargetPath""]", namespaceManager);
                 Assert.NotNull(targetPathElement);
                 targetPathElement.Remove();
+
+                // Remove the "ExcludeFromCurrentConfiguration" element.
+                // This is for internal use and hidden, so we don't expect all items to have it.
+                var excludeFromCurrentConfigurationElement = rule.XPathSelectElement(@"/msb:Rule/msb:BoolProperty[@Name=""ExcludeFromCurrentConfiguration""]", namespaceManager);
+                if (excludeFromCurrentConfigurationElement is not null)
+                {
+                    excludeFromCurrentConfigurationElement.Remove();
+                }
             }
 
             AssertXmlEqual(none, rule);


### PR DESCRIPTION
Related to [dotnet/maui #6681](https://github.com/dotnet/maui/pull/6681).
Related to [AB#1525249](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1525249).

This is an alternative to the approach in #8112.

Currently MAUI includes platform-specific files are for every platform in the MSBuild evaluation, and then at build a target removes _all_ these items and then adds back the ones for the current platform.

This works for an actual build but screws up VS, as the Project System doesn't properly handle a `Compile` item that is present in evaluation but removed during a build. The end result is that the platform-specific files are not actually treated as platform-specific, leading to a number of user-visible issues:

1. Platform-specific files incorrectly show all target frameworks in the Nav Bar
2. Spurious errors in the Error List
3. Squiggles in the editor, unless the user changes the Nav Bar to the "correct" target framework
4. Possibly they will not see actual errors in their code (e.g. if you use a Windows-only API in an Android-specific file, but the Nav Bar is set to Windows, you won't get an squiggle about that)
5. The spurious errors block Hot Reload as the Language Service thinks the project is very broken and will not attempt to apply changes

With this change the Project System will now check items for special metadata indicating that they should be ignored. If an item is marked with `ExcludeFromCurrentConfiguration=true` the Project System will pretend it does not exist in the evaluation data for the current build configuration. And as the file no longer exists in the evaluation data, it no longer matters that the Project System does not properly handle the removal in the target.

See [dotnet/maui #6681](https://github.com/dotnet/maui/pull/6681) for the related MAUI SDK changes that add the metadata to the appropriate items.

Note that this does not currently handle the case where the `ExcludeFromCurrentConfiguration` metadata changes on an item. That is a change we can make in the future, if need be.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8115)