### PR TITLE
Add lock to protect s_listOfMissingRuntimes.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
@@ -92,17 +92,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             UnregisterProjectConfiguration(projectGuid, project);
         }
 
-        public void RegisterMissingSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string runtimeComponentId)
+        public void RegisterMissingSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId)
         {
-            // If a runtime is detected as missing, it will remain in that state until the user install it using the VS Installer.
-            // Due to this, during a solution load all the projects might register to install the same runtime version.
-            // This optimization can avoid executing displayMissingComponentsTask unnecesarily by registering a missing runtime once in the solution.
-            if (!_missingRuntimesRegistered.Add(runtimeComponentId))
+            if (runtimeComponentId is not null)
             {
-                return;
-            }
+                _missingRuntimesRegistered.Add(runtimeComponentId);
 
-            _projectGuidToRuntimeDescriptorMap.GetOrAdd(projectGuid, runtimeComponentId);
+                _projectGuidToRuntimeDescriptorMap.GetOrAdd(projectGuid, runtimeComponentId);
+            }
 
             UnregisterProjectConfiguration(projectGuid, project);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             UnregisterProjectConfiguration(projectGuid, project);
         }
 
-        public void RegisterMissingSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId)
+        public void RegisterSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId)
         {
             if (runtimeComponentId is not null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         void RegisterMissingWorkloads(Guid projectGuid, ConfiguredProject project, ISet<WorkloadDescriptor> workloadDescriptors);
 
-        void RegisterMissingSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string runtimeComponentId);
+        void RegisterMissingSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId);
 
         void RegisterProjectConfiguration(Guid projectGuid, ConfiguredProject project);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         void RegisterMissingWorkloads(Guid projectGuid, ConfiguredProject project, ISet<WorkloadDescriptor> workloadDescriptors);
 
-        void RegisterMissingSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId);
+        void RegisterSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId);
 
         void RegisterProjectConfiguration(Guid projectGuid, ConfiguredProject project);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private Guid _projectGuid;
         private bool _enabled;
-        private static readonly HashSet<string> s_listOfMissingRuntimes = new(StringComparer.OrdinalIgnoreCase);
 
         private readonly ConfiguredProject _project;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
@@ -49,7 +48,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         protected override Task DisposeCoreAsync(bool initialized)
         {
-            s_listOfMissingRuntimes.Clear();
             return Task.CompletedTask;
         }
 
@@ -58,7 +56,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
             _missingSetupComponentRegistrationService.RegisterProjectConfiguration(_projectGuid, _project);
             _ = RegisterSdkRuntimeNeededInProjectAsync(_project);
-            
         }
 
         private async Task RegisterSdkRuntimeNeededInProjectAsync(ConfiguredProject project)
@@ -74,11 +71,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 string? TargetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
 
                 if (string.Equals(TargetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) &&
-                    !string.IsNullOrEmpty(TargetFrameworkVersion) &&
-                    !s_listOfMissingRuntimes.Contains(TargetFrameworkVersion) &&
-                    s_packageVersionToComponentId.TryGetValue(TargetFrameworkVersion, out var componentId))
+                !string.IsNullOrEmpty(TargetFrameworkVersion) &&
+                s_packageVersionToComponentId.TryGetValue(TargetFrameworkVersion, out var componentId))
                 {
-                    s_listOfMissingRuntimes.Add(TargetFrameworkVersion);
                     _missingSetupComponentRegistrationService.RegisterMissingSdkRuntimeComponentId(_projectGuid, project, componentId);
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
@@ -70,12 +70,22 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
                 string? TargetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
 
+                string? componentId = GetComponentId(TargetFrameworkIdentifier, TargetFrameworkVersion);
+                
+                _missingSetupComponentRegistrationService.RegisterMissingSdkRuntimeComponentId(_projectGuid, project, componentId);
+            }
+
+            static string? GetComponentId(string TargetFrameworkIdentifier, string TargetFrameworkVersion)
+            {
+                string? componentId = null;
+
                 if (string.Equals(TargetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) &&
-                !string.IsNullOrEmpty(TargetFrameworkVersion) &&
-                s_packageVersionToComponentId.TryGetValue(TargetFrameworkVersion, out var componentId))
+                    !string.IsNullOrEmpty(TargetFrameworkVersion))
                 {
-                    _missingSetupComponentRegistrationService.RegisterMissingSdkRuntimeComponentId(_projectGuid, project, componentId);
+                    s_packageVersionToComponentId.TryGetValue(TargetFrameworkVersion, out componentId);
                 }
+
+                return componentId;
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
@@ -66,23 +66,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
                 ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
 
-                string? TargetFrameworkIdentifier = await configuration.TargetFrameworkIdentifier.GetDisplayValueAsync();
+                string? targetFrameworkIdentifier = await configuration.TargetFrameworkIdentifier.GetDisplayValueAsync();
 
-                string? TargetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
+                string? targetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
 
-                string? componentId = GetComponentId(TargetFrameworkIdentifier, TargetFrameworkVersion);
+                string? componentId = GetComponentId(targetFrameworkIdentifier, targetFrameworkVersion);
                 
-                _missingSetupComponentRegistrationService.RegisterMissingSdkRuntimeComponentId(_projectGuid, project, componentId);
+                _missingSetupComponentRegistrationService.RegisterSdkRuntimeComponentId(_projectGuid, project, componentId);
             }
 
-            static string? GetComponentId(string TargetFrameworkIdentifier, string TargetFrameworkVersion)
+            static string? GetComponentId(string targetFrameworkIdentifier, string targetFrameworkVersion)
             {
                 string? componentId = null;
 
-                if (string.Equals(TargetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) &&
-                    !string.IsNullOrEmpty(TargetFrameworkVersion))
+                if (string.Equals(targetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) &&
+                    !string.IsNullOrEmpty(targetFrameworkVersion))
                 {
-                    s_packageVersionToComponentId.TryGetValue(TargetFrameworkVersion, out componentId);
+                    s_packageVersionToComponentId.TryGetValue(targetFrameworkVersion, out componentId);
                 }
 
                 return componentId;


### PR DESCRIPTION
Fixes [AB#1523369](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1523369) threadpool starvation due to incorrect synchronization.

The issue here is that s_listOfMissingRuntimes was not thread-safe.

This PR:
- Renames `s_listOfMissingRuntimes` to `_missingRuntimesRegistered `
- Changes the type to use a thread-safe collection.
- Moves `_missingRuntimesRegistered`  to `MissingSetupComponentRegistrationService` that fits the lifetime of this global variable.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8127)