### PR TITLE
Remove "interface" from externally_visible_symbols in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -96,7 +96,7 @@ dotnet_naming_rule.private_instance_fields_must_be_camel_cased_and_prefixed_with
 dotnet_naming_rule.private_instance_fields_must_be_camel_cased_and_prefixed_with_underscore.severity  = warning
 
 # Symbols
-dotnet_naming_symbols.externally_visible_symbols.applicable_kinds                                     = class,struct,interface,enum,property,method,field,event,delegate
+dotnet_naming_symbols.externally_visible_symbols.applicable_kinds                                     = class,struct,enum,property,method,field,event,delegate
 dotnet_naming_symbols.externally_visible_symbols.applicable_accessibilities                           = public,internal,friend,protected,protected_internal,protected_friend,private_protected
 
 dotnet_naming_symbols.interface_symbols.applicable_kinds                                              = interface


### PR DESCRIPTION
Using Rider, the rule `externally_visible_members_must_be_pascal_cased` competes with `interfaces_must_be_pascal_cased_and_prefixed_with_I`

![image](https://user-images.githubusercontent.com/25065744/166654136-29428c19-7c46-4243-ad54-d8c7568e8e76.png)

The scope is (as far as i can see) not used anywhere else

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8130)