### PR TITLE
Extend component verification test coverage

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicNamespaceImportsList.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
 {
     [Export(typeof(VisualBasicNamespaceImportsList))]
     [AppliesTo(ProjectCapability.VisualBasic)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
     internal class VisualBasicNamespaceImportsList : UnconfiguredProjectHostBridge<IProjectVersionedValue<IProjectSubscriptionUpdate>, IProjectVersionedValue<ImmutableList<string>>, IProjectVersionedValue<ImmutableList<string>>>, IEnumerable<string>
     {
         private static readonly ImmutableHashSet<string> s_namespaceImportRule = Empty.OrdinalIgnoreCaseStringSet

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VisualBasic/VisualBasicVSImports.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation.VisualBasic
     [Export(typeof(VisualBasicVSImports))]
     [AppliesTo(ProjectCapability.VisualBasic)]
     [Order(Order.Default)]
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
     internal class VisualBasicVSImports : ConnectionPointContainer,
                                IEventSource<_dispImportsEvents>,
                                Imports,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -6,6 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
     [Export(typeof(OrderAddItemHintReceiver))]
     [ProjectChangeHintKind(ProjectChangeFileSystemEntityHint.AddedFileAsString)]
     [AppliesTo(ProjectCapability.SortByDisplayOrder + " & " + ProjectCapability.EditableDisplayOrder)]
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private)]
     internal class OrderAddItemHintReceiver : IProjectChangeHintReceiver
     {
         private readonly IProjectAccessor _accessor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Tracks the set of missing workload packs and SDK runtimes the .NET projects in a solution
     ///     need to improve the development experience.
     /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private)]
     internal interface IMissingSetupComponentRegistrationService
     {
         Task InitializeAsync(CancellationToken cancellationToken = default);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/IDependenciesViewModelFactory.cs
@@ -4,6 +4,7 @@ using Microsoft.VisualStudio.Imaging.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 {
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
     internal interface IDependenciesViewModelFactory
     {
         /// <summary>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.ScopeComponents.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.ScopeComponents.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     internal partial class ComponentComposition
     {
         // These components solely exist so that the MEF composition for 
-        // these tests can see the "scopes" that used within CPS.
+        // these tests can see the "scopes" used within CPS.
 
         [Export]
         private class GlobalScope

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private static bool IsAppliesToRequired(ImportDefinitionBinding import)
         {
             Type appliesToView = typeof(IAppliesToMetadataView);
-            return import.MetadataType != null && appliesToView.IsAssignableFrom(appliesToView);
+            return import.MetadataType != null && appliesToView.IsAssignableFrom(import.MetadataType);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     {
                         if (!IsSubclassOfGenericType(typeof(OrderPrecedenceImportCollection<,>), memberType))
                         {
-                            Assert.False(true, $"{part.Definition.Type.FullName}.{importingProperty.Name} needs to use OrderPrecedenceImportCollection to import components.");
+                            Assert.Fail($"{part.Definition.Type.FullName}.{importingProperty.Name} needs to use OrderPrecedenceImportCollection to import components.");
                         }
                     }
 
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                 if (requiredAppliesTo == null ||
                                     !ContainsExpression(requiredAppliesTo))
                                 {
-                                    Assert.False(true, $"{part.Definition.Type.FullName}.{ importingProperty.Name} needs to check AppliesTo metadata of the imported component.");
+                                    Assert.Fail($"{part.Definition.Type.FullName}.{ importingProperty.Name} needs to check AppliesTo metadata of the imported component.");
                                 }
                             }
                         }
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             // Now check all of them should be the same.
             if (appliesToMetadata.Distinct().Count() > 1)
             {
-                Assert.False(true, $"{definition.Type.FullName} exports multiple values with differing AppliesTo. All exports from a component must apply to the same capabilities.");
+                Assert.Fail($"{definition.Type.FullName} exports multiple values with differing AppliesTo. All exports from a component must apply to the same capabilities.");
             }
         }
 
@@ -209,7 +209,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
                     if (contractTypes.Any(t => t.IsAssignableFrom(exportType)))
                     {
-                        Assert.False(true, $"{definition.Type.FullName} must specify [AppliesTo] to its export of {exportType}.");
+                        Assert.Fail($"{definition.Type.FullName} must specify [AppliesTo] to its export of {exportType}.");
                     }
                 }
             }
@@ -233,7 +233,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 {
                     if (contractMetadata.Cardinality == ImportCardinality.ZeroOrMore && importDefinition.Cardinality != ImportCardinality.ZeroOrMore)
                     {
-                        Assert.False(true, $"Must use [ImportMany] in {definition.Type.FullName} to import a contract {importDefinition.ContractName} which can be implemented by an extension.");
+                        Assert.Fail($"Must use [ImportMany] in {definition.Type.FullName} to import a contract {importDefinition.ContractName} which can be implemented by an extension.");
                     }
                 }
             }
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             // Do we import from a child scope but export to a parent scope? ie Importing ConfiguredProject, but exporting to an UnconfiguredProject service would be invalid
                             if (exportContractMetadata.Scope < importContractMetadata.Scope)
                             {
-                                Assert.False(true, $"{definition.Type.FullName} exports to the {exportContractMetadata.Scope.Value} scope, but it imports {importDefinition.ContractName} from {importContractMetadata.Scope} scope, which is a child of the preceeding scope.");
+                                Assert.Fail($"{definition.Type.FullName} exports to the {exportContractMetadata.Scope.Value} scope, but it imports {importDefinition.ContractName} from {importContractMetadata.Scope} scope, which is a child of the preceeding scope.");
                             }
                         }
                     }
@@ -289,7 +289,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 ImportDefinition importDefinition = import.ImportDefinition;
                 if (!CheckContractHasMetadata(GetContractName(importDefinition), definition, ComponentComposition.Instance.Contracts, ComponentComposition.Instance.InterfaceNames))
                 {
-                    Assert.False(true, $"{definition.Type.FullName} imports a contract {importDefinition.ContractName}, which is not applied with [ProjectSystemContract]");
+                    Assert.Fail($"{definition.Type.FullName} imports a contract {importDefinition.ContractName}, which is not applied with [ProjectSystemContract]");
                 }
             }
         }
@@ -309,7 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 ExportDefinition exportDefinition = export.Value;
                 if (!CheckContractHasMetadata(exportDefinition.ContractName, definition, ComponentComposition.Instance.Contracts, ComponentComposition.Instance.InterfaceNames))
                 {
-                    Assert.False(true, $"{definition.Type.FullName} exports a contract {exportDefinition.ContractName}, which is not applied with [ProjectSystemContract]");
+                    Assert.Fail($"{definition.Type.FullName} exports a contract {exportDefinition.ContractName}, which is not applied with [ProjectSystemContract]");
                 }
             }
         }


### PR DESCRIPTION
For types imported and exported through MEF, we use the `[ProjectSystemContract]` attribute to capture scopes, purpose and cardinality.

We have a set of unit tests in `ComponentVerificationTests` that inspect our types and validate these constraints so we catch any issues before changes are merged into `main`.

While reviewing #8127 I noticed that `IMissingSetupComponentRegistrationService` was missing this annotation, and wondered why our tests didn't catch that omission.

This PR fixes the tests to cover all scenarios.

In response to the test being fixed, several missing annotations were discovered and added.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8135)