### PR TITLE
Define properties for the VB Compile (Build) page

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -1,6 +1,375 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="Build"
-      OverrideMode="Extend"
+      OverrideMode="Replace"
+      Description="Specifies properties that control how the project builds."
+      DisplayName="Compile"
+      PageTemplate="generic"
+      Order="200"
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
+  <Rule.Categories>
+    <Category Name="General"
+              DisplayName="General" />
+
+    <Category Name="CompileOptions"
+              DisplayName="Compile Options" />
+
+    <Category Name="WarningConfigurations"
+              DisplayName="Warning configurations" />
+
+    <Category Name="Events"
+              Description="Configures custom events that run before and after build."
+              DisplayName="Events" />
+
+    <Category Name="Advanced"
+              DisplayName="Advanced"
+              Description="Advanced settings for the application." />
+  </Rule.Categories>
+
+  <Rule.DataSource>
+    <DataSource Persistence="ProjectFileWithInterception"
+                HasConfigurationCondition="True" />
+  </Rule.DataSource>
+
+  <StringProperty Name="Output path"
+                  DisplayName="Build output path"
+                  Category="General"
+                  Subtype="directory" />
+
+  <!-- TODO: Update this with correct behavior for SDK-style projects -->
+  <BoolProperty Name="GenerateDocumentationFile"
+                DisplayName="Generate XML documentation file"
+                Description="Specifies whether to generate documentation information."
+                Category="General" />
+
+  <!-- TODO: Condition the visibility on this being a class library -->
+  <BoolProperty Name="RegisterForComInterop"
+                DisplayName="Register for COM interop"
+                Description="Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application."
+                Category="General" />
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="OptionExplicit"
+                DisplayName="Option explicit"
+                Description="Specifies whether to require explicit declaration of variables."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="CompileOptions">
+    <EnumValue Name="On" DisplayName="On" />
+    <EnumValue Name="Off" DisplayName="Off" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <!-- TODO: Enum values need to to come from a dynamic enum provider -->
+  <EnumProperty Name="OptionStrict"
+                DisplayName="Option strict"
+                Description="Specifies whether to enforce strict type semantics."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="CompileOptions">
+    <EnumValue Name="On" DisplayName="On" />
+    <EnumValue Name="Off" DisplayName="Off" />
+    <EnumValue Name="Custom" DisplayName="(custom)" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="OptionCompare"
+                DisplayName="Option compare"
+                Description="Specifies the type of string comparison to use."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="CompileOptions">
+    <EnumValue Name="Binary" DisplayName="Binary" />
+    <EnumValue Name="Text" DisplayName="Text" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="OptionInfer"
+                DisplayName="Option Infer"
+                Description="Specifies whether to allow local type inference in variable declarations."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="CompileOptions">
+    <EnumValue Name="On" DisplayName="On" />
+    <EnumValue Name="Off" DisplayName="Off" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <DynamicEnumProperty Name="PlatformTarget"
+                DisplayName="Target CPU"
+                Description="Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="CompileOptions"
+                EnumProvider="PlatformTargetEnumProvider"
+                MultipleValuesAllowed="False"/>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <BoolProperty Name="Prefer32Bit"
+                DisplayName="Prefer 32-bit"
+                Description="Run in 32-bit mode on systems that support both 32-bit and 64-bit applications."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="CompileOptions">
+    <BoolProperty.Metadata>
+      <NameValuePair Name="DependsOn" Value="Build::PlatformTarget" />
+      <NameValuePair Name="DependsOn" Value="Application::OutputType" />
+      <NameValuePair Name="VisibilityCondition">
+        <!-- Visibility based on: https://github.com/dotnet/msbuild/blob/9bcc06cbe19ae2482ab18eab90a82fd079b26897/src/Tasks/Microsoft.NETFramework.CurrentVersion.props#L87 -->
+        <NameValuePair.Value>
+          (and
+            (has-net-framework)
+            (has-evaluated-value "Build" "PlatformTarget" "AnyCPU")
+            (or
+              (has-evaluated-value "Application" "OutputType" "Exe")
+              (has-evaluated-value "Application" "OutputType" "WinExe")
+              (has-evaluated-value "Application" "OutputType" "AppContainerExe")
+            )
+          )
+        </NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="ImplicitConversion"
+                DisplayName="Implicit conversion"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="LateBinding"
+                DisplayName="Late binding; call could fail at run time"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="ImplicitType"
+                DisplayName="Implicit type; object assumed"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="UseOfVariablePriorToAssignment"
+                DisplayName="Use of variable prior to assignment"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="ReturningRefTypeWithoutReturnValue"
+                DisplayName="Function returning reference type without return value"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="ReturningIntrinsicValueTypeWithoutReturnValue"
+                DisplayName="Function returning intrinsic value type without return value"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="UnusedLocalVariable"
+                DisplayName="Unused local variable"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="InstanceVariableAccessesSharedMember"
+                DisplayName="Instance variable accesses shared member"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="RecursiveOperatorOrPropertyAccess"
+                DisplayName="Recursive operator or property access"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="DuplicateOrOverlappingCatchBlocks"
+                DisplayName="Duplicate or overlapping catch blocks"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations">
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <BoolProperty Name="DisableAllWarnings"
+                DisplayName="Disable all warnings"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations" />
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <!-- TODO: Reconcile visibility with DisableAllWarnings setting -->
+  <BoolProperty Name="TreatWarningsAsErrors"
+                DisplayName="Treat all warnings as errors"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
+                Category="WarningConfigurations" />
+
+  <!-- TODO: Update HelpUrl -->
+  <StringProperty Name="PreBuildEvent"
+                  DisplayName="Pre-build event"
+                  Description="Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs."
+                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/build-events-dialog-box-visual-basic"
+                  Category="Events">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="MultiLineString">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="UseMonospaceFont" Value="True" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+
+  <!-- TODO: Update HelpUrl -->
+  <StringProperty Name="PostBuildEvent"
+                  DisplayName="Post-build event"
+                  Description="Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build."
+                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/build-events-dialog-box-visual-basic"
+                  Category="Events">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="MultiLineString">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="UseMonospaceFont" Value="True" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+
+  <!-- TODO: Update HelpUrl -->
+  <EnumProperty Name="RunPostBuildEvent"
+                DisplayName="When to run the post-build event"
+                Description="Specifies under which condition the post-build event will be executed."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/build-events-dialog-box-visual-basic"
+                Category="Events">
+    <EnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  PersistedName="RunPostBuildEvent"
+                  Persistence="ProjectFileWithInterception"
+                  SourceOfDefaultValue="AfterContext" />
+    </EnumProperty.DataSource>
+    <EnumValue Name="Always"
+               DisplayName="Always" />
+    <EnumValue Name="OnBuildSuccess"
+               DisplayName="When the build succeeds"
+               IsDefault="True" />
+    <EnumValue Name="OnOutputUpdated"
+               DisplayName="When the output is updated" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <BoolProperty Name="RemoveIntegerChecks"
+                DisplayName="Remove integer overflow checks"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic?view=#optimizations"
+                Category="Advanced" />
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <BoolProperty Name="Optimize"
+                DisplayName="Enable optimizations"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic?view=#optimizations"
+                Category="Advanced" />
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <!-- TODO: Validation -->
+  <StringProperty Name="BaseAddress"
+                  DisplayName="DLL base address"
+                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic?view=#optimizations"
+                  Category="Advanced" />
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="DebugType"
+                DisplayName="Debug symbols"
+                Description="Specifies the kind of debug symbols produced during build."
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic?view=#optimizations"
+                Category="Advanced">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="SearchTerms" Value="debug type" />
+    </EnumProperty.Metadata>
+    <EnumValue Name="none"
+               DisplayName="No symbols are emitted" />
+    <!--
+    Note that 'pdbonly' is the same as 'full'.
+    <EnumValue Name="pdbonly"
+               DisplayName="PDB Only" />
+    -->
+    <EnumValue Name="full"
+               DisplayName="PDB file, current platform" />
+    <EnumValue Name="portable"
+               DisplayName="PDB file, portable across platforms" />
+    <EnumValue Name="embedded"
+               DisplayName="Embedded in DLL/EXE, portable across platforms" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <BoolProperty Name="DefineDebug"
+                DisplayName="Define DEBUG constant"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic#compilation-constants"
+                Category="Advanced"/>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <BoolProperty Name="DefineTrace"
+                DisplayName="Degine TRACE constant"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic#compilation-constants"
+                Category="Advanced"/>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <StringProperty Name="DefineConstants"
+                  DisplayName="Custom constants"
+                  HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic#compilation-constants"
+                  Category="Advanced">
+    <StringProperty.Description>Enter any custom constants for your application in this text box. Entries should be delimited by commas, using this form: Name1="Value1",Name2="Value2",Name3="Value3".</StringProperty.Description>
+  </StringProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="GenerateSerializationAssemblies"
+                DisplayName="Generate serialization assemblies"
+                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/advanced-compiler-settings-dialog-box-visual-basic#compilation-constants"
+                Category="Advanced">
+    <EnumValue Name="On" DisplayName="On"/>
+    <EnumValue Name="Off" DisplayName="Off"/>
+    <EnumValue Name="Auto" DisplayName="Auto"/>
+  </EnumProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -12,11 +12,11 @@
     <Category Name="General"
               DisplayName="General" />
 
-    <Category Name="CompileOptions"
-              DisplayName="Compile Options" />
+    <Category Name="Options"
+              DisplayName="Options" />
 
-    <Category Name="WarningConfigurations"
-              DisplayName="Warning configurations" />
+    <Category Name="Warnings"
+              DisplayName="Warnings" />
 
     <Category Name="Events"
               Description="Configures custom events that run before and after build."
@@ -54,7 +54,7 @@
                 DisplayName="Option explicit"
                 Description="Specifies whether to require explicit declaration of variables."
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="CompileOptions">
+                Category="Options">
     <EnumValue Name="On" DisplayName="On" />
     <EnumValue Name="Off" DisplayName="Off" />
   </EnumProperty>
@@ -65,7 +65,7 @@
                 DisplayName="Option strict"
                 Description="Specifies whether to enforce strict type semantics."
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="CompileOptions">
+                Category="Options">
     <EnumValue Name="On" DisplayName="On" />
     <EnumValue Name="Off" DisplayName="Off" />
     <EnumValue Name="Custom" DisplayName="(custom)" />
@@ -76,17 +76,17 @@
                 DisplayName="Option compare"
                 Description="Specifies the type of string comparison to use."
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="CompileOptions">
+                Category="Options">
     <EnumValue Name="Binary" DisplayName="Binary" />
     <EnumValue Name="Text" DisplayName="Text" />
   </EnumProperty>
 
   <!-- TODO: Replace HelpUrl with a fwlink -->
   <EnumProperty Name="OptionInfer"
-                DisplayName="Option Infer"
+                DisplayName="Option infer"
                 Description="Specifies whether to allow local type inference in variable declarations."
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="CompileOptions">
+                Category="Options">
     <EnumValue Name="On" DisplayName="On" />
     <EnumValue Name="Off" DisplayName="Off" />
   </EnumProperty>
@@ -96,7 +96,7 @@
                 DisplayName="Target CPU"
                 Description="Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware."
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="CompileOptions"
+                Category="Options"
                 EnumProvider="PlatformTargetEnumProvider"
                 MultipleValuesAllowed="False"/>
 
@@ -105,7 +105,7 @@
                 DisplayName="Prefer 32-bit"
                 Description="Run in 32-bit mode on systems that support both 32-bit and 64-bit applications."
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="CompileOptions">
+                Category="Options">
     <BoolProperty.Metadata>
       <NameValuePair Name="DependsOn" Value="Build::PlatformTarget" />
       <NameValuePair Name="DependsOn" Value="Application::OutputType" />
@@ -129,8 +129,9 @@
   <!-- TODO: Replace HelpUrl with a fwlink -->
   <EnumProperty Name="ImplicitConversion"
                 DisplayName="Implicit conversion"
-                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Description="Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion."
+                HelpUrl="https://docs.microsoft.com/dotnet/visual-basic/language-reference/statements/option-strict-statement#implicit-narrowing-conversion-errors"
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -138,9 +139,10 @@
 
   <!-- TODO: Replace HelpUrl with a fwlink -->
   <EnumProperty Name="LateBinding"
-                DisplayName="Late binding; call could fail at run time"
-                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                DisplayName="Late binding"
+                Description="An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time."
+                HelpUrl="https://docs.microsoft.com/dotnet/visual-basic/language-reference/statements/option-strict-statement#late-binding-errors"
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -148,9 +150,10 @@
 
   <!-- TODO: Replace HelpUrl with a fwlink -->
   <EnumProperty Name="ImplicitType"
-                DisplayName="Implicit type; object assumed"
-                HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                DisplayName="Implicit type"
+                Description="Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred."
+                HelpUrl="https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/option-strict-statement#implicit-object-type-errors"
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -160,7 +163,7 @@
   <EnumProperty Name="UseOfVariablePriorToAssignment"
                 DisplayName="Use of variable prior to assignment"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -170,7 +173,7 @@
   <EnumProperty Name="ReturningRefTypeWithoutReturnValue"
                 DisplayName="Function returning reference type without return value"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -180,7 +183,7 @@
   <EnumProperty Name="ReturningIntrinsicValueTypeWithoutReturnValue"
                 DisplayName="Function returning intrinsic value type without return value"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -190,7 +193,7 @@
   <EnumProperty Name="UnusedLocalVariable"
                 DisplayName="Unused local variable"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -200,7 +203,7 @@
   <EnumProperty Name="InstanceVariableAccessesSharedMember"
                 DisplayName="Instance variable accesses shared member"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -210,7 +213,7 @@
   <EnumProperty Name="RecursiveOperatorOrPropertyAccess"
                 DisplayName="Recursive operator or property access"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -220,7 +223,7 @@
   <EnumProperty Name="DuplicateOrOverlappingCatchBlocks"
                 DisplayName="Duplicate or overlapping catch blocks"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations">
+                Category="Warnings">
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -230,14 +233,14 @@
   <BoolProperty Name="DisableAllWarnings"
                 DisplayName="Disable all warnings"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations" />
+                Category="Warnings" />
 
   <!-- TODO: Replace HelpUrl with a fwlink -->
   <!-- TODO: Reconcile visibility with DisableAllWarnings setting -->
   <BoolProperty Name="TreatWarningsAsErrors"
                 DisplayName="Treat all warnings as errors"
                 HelpUrl="https://docs.microsoft.com/visualstudio/ide/reference/compile-page-project-designer-visual-basic#compiler-configuration-options"
-                Category="WarningConfigurations" />
+                Category="Warnings" />
 
   <!-- TODO: Update HelpUrl -->
   <StringProperty Name="PreBuildEvent"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -1,6 +1,522 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../BuildPropertyPage.VisualBasic.xaml">
-    <body />
+    <body>
+      <trans-unit id="BoolProperty|DefineDebug|DisplayName">
+        <source>Define DEBUG constant</source>
+        <target state="new">Define DEBUG constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|DisplayName">
+        <source>Degine TRACE constant</source>
+        <target state="new">Degine TRACE constant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DisableAllWarnings|DisplayName">
+        <source>Disable all warnings</source>
+        <target state="new">Disable all warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">
+        <source>Specifies whether to generate documentation information.</source>
+        <target state="new">Specifies whether to generate documentation information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
+        <source>Generate XML documentation file</source>
+        <target state="new">Generate XML documentation file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|DisplayName">
+        <source>Enable optimizations</source>
+        <target state="new">Enable optimizations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|Description">
+        <source>Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</source>
+        <target state="new">Run in 32-bit mode on systems that support both 32-bit and 64-bit applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Prefer32Bit|DisplayName">
+        <source>Prefer 32-bit</source>
+        <target state="new">Prefer 32-bit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|Description">
+        <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
+        <target state="new">Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
+        <source>Register for COM interop</source>
+        <target state="new">Register for COM interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">
+        <source>Remove integer overflow checks</source>
+        <target state="new">Remove integer overflow checks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|TreatWarningsAsErrors|DisplayName">
+        <source>Treat all warnings as errors</source>
+        <target state="new">Treat all warnings as errors</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|Description">
+        <source>Advanced settings for the application.</source>
+        <target state="new">Advanced settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Advanced|DisplayName">
+        <source>Advanced</source>
+        <target state="new">Advanced</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|CompileOptions|DisplayName">
+        <source>Compile Options</source>
+        <target state="new">Compile Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|Description">
+        <source>Configures custom events that run before and after build.</source>
+        <target state="new">Configures custom events that run before and after build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Events|DisplayName">
+        <source>Events</source>
+        <target state="new">Events</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WarningConfigurations|DisplayName">
+        <source>Warning configurations</source>
+        <target state="new">Warning configurations</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
+        <source>Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</source>
+        <target state="new">Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
+        <source>Target CPU</source>
+        <target state="new">Target CPU</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Description">
+        <source>Specifies the kind of debug symbols produced during build.</source>
+        <target state="new">Specifies the kind of debug symbols produced during build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|DisplayName">
+        <source>Debug symbols</source>
+        <target state="new">Debug symbols</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DebugType|Metadata|SearchTerms">
+        <source>debug type</source>
+        <target state="new">debug type</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|DuplicateOrOverlappingCatchBlocks|DisplayName">
+        <source>Duplicate or overlapping catch blocks</source>
+        <target state="new">Duplicate or overlapping catch blocks</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|GenerateSerializationAssemblies|DisplayName">
+        <source>Generate serialization assemblies</source>
+        <target state="new">Generate serialization assemblies</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|DisplayName">
+        <source>Implicit type; object assumed</source>
+        <target state="new">Implicit type; object assumed</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
+        <source>Instance variable accesses shared member</source>
+        <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|DisplayName">
+        <source>Late binding; call could fail at run time</source>
+        <target state="new">Late binding; call could fail at run time</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|Description">
+        <source>Specifies the type of string comparison to use.</source>
+        <target state="new">Specifies the type of string comparison to use.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionCompare|DisplayName">
+        <source>Option compare</source>
+        <target state="new">Option compare</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|Description">
+        <source>Specifies whether to require explicit declaration of variables.</source>
+        <target state="new">Specifies whether to require explicit declaration of variables.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionExplicit|DisplayName">
+        <source>Option explicit</source>
+        <target state="new">Option explicit</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|Description">
+        <source>Specifies whether to allow local type inference in variable declarations.</source>
+        <target state="new">Specifies whether to allow local type inference in variable declarations.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionInfer|DisplayName">
+        <source>Option Infer</source>
+        <target state="new">Option Infer</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|Description">
+        <source>Specifies whether to enforce strict type semantics.</source>
+        <target state="new">Specifies whether to enforce strict type semantics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|OptionStrict|DisplayName">
+        <source>Option strict</source>
+        <target state="new">Option strict</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RecursiveOperatorOrPropertyAccess|DisplayName">
+        <source>Recursive operator or property access</source>
+        <target state="new">Recursive operator or property access</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningIntrinsicValueTypeWithoutReturnValue|DisplayName">
+        <source>Function returning intrinsic value type without return value</source>
+        <target state="new">Function returning intrinsic value type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ReturningRefTypeWithoutReturnValue|DisplayName">
+        <source>Function returning reference type without return value</source>
+        <target state="new">Function returning reference type without return value</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|Description">
+        <source>Specifies under which condition the post-build event will be executed.</source>
+        <target state="new">Specifies under which condition the post-build event will be executed.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|RunPostBuildEvent|DisplayName">
+        <source>When to run the post-build event</source>
+        <target state="new">When to run the post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UnusedLocalVariable|DisplayName">
+        <source>Unused local variable</source>
+        <target state="new">Unused local variable</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|UseOfVariablePriorToAssignment|DisplayName">
+        <source>Use of variable prior to assignment</source>
+        <target state="new">Use of variable prior to assignment</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
+        <source>Embedded in DLL/EXE, portable across platforms</source>
+        <target state="new">Embedded in DLL/EXE, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.full|DisplayName">
+        <source>PDB file, current platform</source>
+        <target state="new">PDB file, current platform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.none|DisplayName">
+        <source>No symbols are emitted</source>
+        <target state="new">No symbols are emitted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DebugType.portable|DisplayName">
+        <source>PDB file, portable across platforms</source>
+        <target state="new">PDB file, portable across platforms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|DuplicateOrOverlappingCatchBlocks.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Auto|DisplayName">
+        <source>Auto</source>
+        <target state="new">Auto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|GenerateSerializationAssemblies.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|InstanceVariableAccessesSharedMember.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
+        <source>Binary</source>
+        <target state="new">Binary</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionCompare.Text|DisplayName">
+        <source>Text</source>
+        <target state="new">Text</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionExplicit.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
+        <source>(custom)</source>
+        <target state="new">(custom)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">
+        <source>Off</source>
+        <target state="new">Off</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|OptionStrict.On|DisplayName">
+        <source>On</source>
+        <target state="new">On</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RecursiveOperatorOrPropertyAccess.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningIntrinsicValueTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ReturningRefTypeWithoutReturnValue.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.Always|DisplayName">
+        <source>Always</source>
+        <target state="new">Always</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnBuildSuccess|DisplayName">
+        <source>When the build succeeds</source>
+        <target state="new">When the build succeeds</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|RunPostBuildEvent.OnOutputUpdated|DisplayName">
+        <source>When the output is updated</source>
+        <target state="new">When the output is updated</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UnusedLocalVariable.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|UseOfVariablePriorToAssignment.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|Description">
+        <source>Specifies properties that control how the project builds.</source>
+        <target state="new">Specifies properties that control how the project builds.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Rule|Build|DisplayName">
+        <source>Compile</source>
+        <target state="new">Compile</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|BaseAddress|DisplayName">
+        <source>DLL base address</source>
+        <target state="new">DLL base address</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DefineConstants|DisplayName">
+        <source>Custom constants</source>
+        <target state="new">Custom constants</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|Output path|DisplayName">
+        <source>Build output path</source>
+        <target state="new">Build output path</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|Description">
+        <source>Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</source>
+        <target state="new">Specifies commands that run after the build completes. Does not run if the build failed. Use 'call' to invoke .bat files. A non-zero exit code will fail the build.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PostBuildEvent|DisplayName">
+        <source>Post-build event</source>
+        <target state="new">Post-build event</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|Description">
+        <source>Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</source>
+        <target state="new">Specifies commands that run before the build starts. Does not run if the project is up-to-date. A non-zero exit code will fail the build before it runs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|PreBuildEvent|DisplayName">
+        <source>Pre-build event</source>
+        <target state="new">Pre-build event</target>
+        <note />
+      </trans-unit>
+    </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -72,11 +72,6 @@
         <target state="new">Advanced</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|CompileOptions|DisplayName">
-        <source>Compile Options</source>
-        <target state="new">Compile Options</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|Events|Description">
         <source>Configures custom events that run before and after build.</source>
         <target state="new">Configures custom events that run before and after build.</target>
@@ -92,9 +87,14 @@
         <target state="new">General</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|WarningConfigurations|DisplayName">
-        <source>Warning configurations</source>
-        <target state="new">Warning configurations</target>
+      <trans-unit id="Category|Options|DisplayName">
+        <source>Options</source>
+        <target state="new">Options</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Warnings|DisplayName">
+        <source>Warnings</source>
+        <target state="new">Warnings</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|PlatformTarget|Description">
@@ -132,14 +132,24 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|DisplayName">
-        <source>Implicit type; object assumed</source>
-        <target state="new">Implicit type; object assumed</target>
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
@@ -147,9 +157,14 @@
         <target state="new">Instance variable accesses shared member</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|DisplayName">
-        <source>Late binding; call could fail at run time</source>
-        <target state="new">Late binding; call could fail at run time</target>
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionCompare|Description">
@@ -178,8 +193,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionInfer|DisplayName">
-        <source>Option Infer</source>
-        <target state="new">Option Infer</target>
+        <source>Option infer</source>
+        <target state="new">Option infer</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|OptionStrict|Description">


### PR DESCRIPTION
Related to #7237.

Define the properties of the VB "Compile" page (called "Build" in C#/F#) and arrange them into categories. A couple of things to note:

- The goal is to get everything stubbed out so we have controls to interact with in future changes and so we can start to discuss the look and feel of the page. Most of these properties do not yet read and write values correctly.
- Items are likely to move around in future commits. This change puts _most_ items in the same order as the old Compile property page, with the exception of "Generate XML documentation file" and "Register for COM interop". The old page visually located these under "Warning configurations" even though they have nothing to do with warnings. Here we put them in the "General" category instead.
- I found VB to be sufficiently different from C#/F# that this page replaces the base "Build" page entirely, rather than extracting shared functionality to the base page and then extending it to add VB-specific functionality. As such, there is some amount of duplicated functionality, but not as much as you might expect. Even where the behavior is the same VB organizes the settings into different categories or uses different display names and description text. This largely precludes reusing a shared property in the base page. I think this is fine, given that I expect the VB pages to change little in the future, if at all.

Screen shot:
![VBCompilePage](https://user-images.githubusercontent.com/10506730/167493840-29e5a7c2-eeda-41a9-bb1d-0ad38585c76f.gif)



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8146)