### PR TITLE
Allow launchSettings.json to include comments

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -190,7 +190,7 @@ internal static class LaunchSettingsJsonEncoding
     {
         JsonSerializer? jsonSerializer = null;
 
-        using JsonTextReader reader = new(json);
+        using CommentSkippingJsonTextReader reader = new(json);
 
         ImmutableArray<LaunchProfile>.Builder? profiles = null;
         ImmutableArray<(string Name, object Value)>.Builder? otherSettings = null;
@@ -392,6 +392,28 @@ internal static class LaunchSettingsJsonEncoding
                 string propertyName = (string)reader.Value!;
 
                 callback(propertyName);
+            }
+        }
+    }
+
+    /// <summary>
+    /// An implementation of <see cref="JsonTextReader"/> that skips any comments found
+    /// in the JSON data.
+    /// </summary>
+    private sealed class CommentSkippingJsonTextReader : JsonTextReader
+    {
+        public CommentSkippingJsonTextReader(TextReader reader) : base(reader)
+        {
+        }
+
+        public override bool Read()
+        {
+            while (true)
+            {
+                if (!base.Read())
+                    return false;
+                if (TokenType != JsonToken.Comment)
+                    return true;
             }
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsJsonEncodingTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsJsonEncodingTests.cs
@@ -173,5 +173,39 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void FromJson_WithComments()
+        {
+            // https://github.com/dotnet/project-system/issues/8168
+            const string json =
+            """
+            {
+              "profiles": {
+                "ConsoleApp1": {
+                  "commandName": "Project"
+                  //"commandLineArgs": "1111"
+                }
+              }
+            }
+            """;
+
+            var (profiles, globalSettings) = LaunchSettingsJsonEncoding.FromJson(new StringReader(json), _providers);
+
+            var profile = Assert.Single(profiles);
+
+            Assert.Equal("ConsoleApp1", profile.Name);
+            Assert.Equal("Project", profile.CommandName);
+            Assert.False(profile.DoNotPersist);
+            Assert.Null(profile.ExecutablePath);
+            Assert.Null(profile.CommandLineArgs);
+            Assert.Null(profile.WorkingDirectory);
+            Assert.Null(profile.LaunchUrl);
+            Assert.False(profile.LaunchBrowser);
+            Assert.Empty(profile.OtherSettings);
+            Assert.False(profile.IsInMemoryObject());
+
+            Assert.Empty(globalSettings);
+        }
     }
 }


### PR DESCRIPTION
Fixes #8168

While the JSON standard does not technically allow comments, they are not uncommon.

This change allows our parsing to tolerate such comments without throwing exceptions. It achieves this by subclassing `JsonTextReader` to skip any comment JTokens it encounters.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8169)