### PR TITLE
Detect runtimes outside vs

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IRegistry.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IRegistry.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Microsoft.VisualStudio.IO
+{
+    /// <summary>
+    ///     Provides methods for reading values from the registry.
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+    internal interface IRegistry
+    {
+        /// <summary>
+        /// Opens a registry key denoted by <paramref name="keyPath"/> for the current user,
+        /// and returns the value (if any) associated with <paramref name="name"/>. Returns
+        /// <see langword="null"/> if the registry key or value do not exist, or if an error
+        /// occurs while reading the value.
+        /// </summary>
+        object? ReadValueForCurrentUser(string keyPath, string name);
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IMissingSetupComponentRegistrationService.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         void RegisterMissingWorkloads(Guid projectGuid, ConfiguredProject project, ISet<WorkloadDescriptor> workloadDescriptors);
 
-        void RegisterSdkRuntimeComponentId(Guid projectGuid, ConfiguredProject project, string? runtimeComponentId);
+        void RegisterPossibleMissingSdkRuntimeVersion(Guid projectGuid, ConfiguredProject project, string runtimeVersion);
 
         void RegisterProjectConfiguration(Guid projectGuid, ConfiguredProject project);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
@@ -10,11 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         private static readonly string s_netCoreTargetFrameworkIdentifier = ".NETCoreApp";
 
-        private static readonly ImmutableDictionary<string, string> s_packageVersionToComponentId = ImmutableDictionary.Create<string, string>(StringComparer.OrdinalIgnoreCase)
-            .Add("v2.1", "Microsoft.Net.Core.Component.SDK.2.1")
-            .Add("v3.1", "Microsoft.NetCore.Component.Runtime.3.1")
-            .Add("v5.0", "Microsoft.NetCore.Component.Runtime.5.0");
-
         private Guid _projectGuid;
         private bool _enabled;
 
@@ -70,22 +65,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
                 string? targetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
 
-                string? componentId = GetComponentId(targetFrameworkIdentifier, targetFrameworkVersion);
-                
-                _missingSetupComponentRegistrationService.RegisterSdkRuntimeComponentId(_projectGuid, project, componentId);
-            }
-
-            static string? GetComponentId(string targetFrameworkIdentifier, string targetFrameworkVersion)
-            {
-                string? componentId = null;
-
-                if (string.Equals(targetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) &&
-                    !string.IsNullOrEmpty(targetFrameworkVersion))
+                if (!string.Equals(targetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) ||
+                    string.IsNullOrEmpty(targetFrameworkVersion))
                 {
-                    s_packageVersionToComponentId.TryGetValue(targetFrameworkVersion, out componentId);
+                    targetFrameworkVersion = string.Empty;
                 }
-
-                return componentId;
+                
+                _missingSetupComponentRegistrationService.RegisterPossibleMissingSdkRuntimeVersion(_projectGuid, project, targetFrameworkVersion);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/RegistryReaderRuntimesVersions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/RegistryReaderRuntimesVersions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.IO;
+using Microsoft.Win32;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Runtimes
+{
+    internal class RegistryReaderRuntimesVersions : IRegistry
+    {
+        public object? ReadValueForCurrentUser(string keyPath, string name)
+        {
+            var regkey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+            var subKey = regkey.OpenSubKey(keyPath + name);
+
+            HashSet<string>? netCoreRegistryKeyValues = new(StringComparer.OrdinalIgnoreCase);
+
+            foreach (string valueName in subKey.GetValueNames())
+            {
+                // There is guarantee to always have $(Major).$(Minor)
+                string versionNumber = valueName.Substring(0, valueName.LastIndexOf('.'));
+                netCoreRegistryKeyValues.Add($"v{versionNumber}");
+            }
+
+            return netCoreRegistryKeyValues;
+        }
+    }
+}


### PR DESCRIPTION
Scenario to fix [AB#1460328](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1460328) : A user installs a standalone package downloaded from the msft website, then after that the user installs VS and creates a project using a specific runtime version. VS will not be able to detect if a runtime is already installed, so VS might prompt the gold bar in the solution explorer suggesting to install the missing runtime even thought it might be already installed.

One way to detect the packages installed in a machine is with deep detection, but it is complex and costly in terms of the size of the implementation and performance. Even if we cached the results, we might see a regression on Perf DDRITs.

A workaround is to rely on `HKLM\SOFTWARE\WOW6432Node\dotnet\Setup\InstalledVersions\x64\sharedfx\Microsoft.NETCore.App` and enumerate the value names. This path applies for x86, x64 and arm.

This pr implements the workaround. It reads the Registry Key to get the list of packages installed and cache it.
For every runtime detected in a project we always check if the runtime version is in the list and if not then we check the installed packages in the VS Setup before trying to prompt the gold bar.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8171)