### PR TITLE
Add LinkActions properties for opening app.manifest and ApplicationEv…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/OpenAppManifestValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/OpenAppManifestValueProvider.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider("CreateOrOpenAppManifest", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class CreateOrOpenAppManifestValueProvider : NoOpInterceptingPropertyValueProvider
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/OpenApplicationEventsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/OpenApplicationEventsValueProvider.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider("CreateOrOpenApplicationEvents", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    internal sealed class CreateOrOpenApplicationEventsValueProvider : NoOpInterceptingPropertyValueProvider
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -144,4 +144,31 @@
     <EnumValue Name="AfterAllFormsClose"
                DisplayName="Shut down only after the last form closes." />
   </EnumProperty>
+
+  <StringProperty Name="CreateOrOpenAppManifest"
+                  DisplayName="Create or open app manifest for Windows Settings."
+                  Category="General">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="LinkAction">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="Action" Value="Command" />
+          <NameValuePair Name="Command" Value="CreateOrOpenAppManifest" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+
+  <StringProperty Name="CreateOrOpenApplicationEvents"
+                  DisplayName="Create or open Application Events."
+                  Category="General">
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="LinkAction">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="Action" Value="Command" />
+          <NameValuePair Name="Command" Value="CreateOrOpenApplicationEvents" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+  
 </Rule>


### PR DESCRIPTION
Follows https://github.com/dotnet/project-system/pull/8164.

In this PR we introduce 2 LinkAction properties to open the `app.manifest` and `ApplicationEvents.vb` files in VB projects. Previously we had:
![image](https://user-images.githubusercontent.com/8518253/168168227-9acbafbb-bae2-4114-ba78-7f0296435604.png)

This is similar to how the Resources and Settings files are opened; I'm open to change these links to buttons if we see fit.

[CPS PR](https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/398903) with the LinkAction's handlers.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8173)