### PR TITLE
Reduce allocations during value substitutions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/EnvironmentHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/EnvironmentHelper.cs
@@ -15,6 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
 
         public string ExpandEnvironmentVariables(string name)
         {
+            if (name.IndexOf('%') == -1)
+            {
+                // There cannot be any environment variables in this string.
+                // Avoid several allocations in the .NET Framework's implementation
+                // of Environment.ExpandEnvironmentVariables.
+                return name;
+            }
+
             return Environment.ExpandEnvironmentVariables(name);
         }
     }


### PR DESCRIPTION
`launchSettings.json` may contain both `%VAR%` for environment variable and `$(Prop)` for MSBuild properties, and these values are substituted at runtime.

The vast majority of values do not use substitution, so often we can avoid allocating new strings and data structures and just re-use the previous, immutable instances.

It turns out that [`Environment.ExpandEnvironmentVariables`](https://docs.microsoft.com/en-us/dotnet/api/system.environment.expandenvironmentvariables?view=net-6.0) allocates a new string, [even when no replacement occurs](https://sharplab.io/#v2:EYLgtghglgdgNAFxAJwK4wD4AEBMBGAWAChiA3CZAAgHtkoBzSgXkoCIAJAUwBtvrWA3GQqUAzqmCiEUBKgScAJs0oBRGKSjJqMMJxgIAdCoAeABwgwFajVp16EANQpQIwbp1EAKWgwCUQkiIsPABOTwAlTgAzTmQ9AGNOFQBHVAhuLx96ODEJKRk5RV9/IA). This was allocating new strings, which in turn was triggering allocations for new data structures.

By returning when no substitution character exists, we avoid allocating a new string, meaning our calling code will avoid allocating new data structures.

---

In the following code you can see where we optimize when replacement returns the original object:

https://github.com/dotnet/project-system/blob/a07969db1ef2be0ce2e607e76587df9e61168c49/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs#L104-L126

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8174)