### PR TITLE
Make VB warning sets work

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBDisableAllWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBDisableAllWarningsValueProvider.cs
@@ -21,13 +21,11 @@ internal sealed class VBDisableAllWarningsValueProvider : InterceptingPropertyVa
 
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
-        if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, "true"))
+        if (bool.TryParse(unevaluatedPropertyValue, out bool isDisabled))
         {
-            await defaultProperties.SetPropertyValueAsync(WarningLevelPropertyName, "0", dimensionalConditions);
-        }
-        else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, "false"))
-        {
-            await defaultProperties.SetPropertyValueAsync(WarningLevelPropertyName, "1", dimensionalConditions);
+            string warningLevelValue = isDisabled ? "0" : "1";
+
+            await defaultProperties.SetPropertyValueAsync(WarningLevelPropertyName, warningLevelValue, dimensionalConditions);
         }
 
         return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBDisableAllWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBDisableAllWarningsValueProvider.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+[ExportInterceptingPropertyValueProvider(DisableAllWarningsPropertyName, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+internal sealed class VBDisableAllWarningsValueProvider : InterceptingPropertyValueProviderBase
+{
+    internal const string DisableAllWarningsPropertyName = "DisableAllWarnings";
+
+    internal const string WarningLevelPropertyName = "WarningLevel";
+
+    public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return OnGetPropertyValueAsync(defaultProperties);
+    }
+
+    public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return OnGetPropertyValueAsync(defaultProperties);
+    }
+
+    public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+    {
+        if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, "true"))
+        {
+            await defaultProperties.SetPropertyValueAsync(WarningLevelPropertyName, "0", dimensionalConditions);
+        }
+        else if (StringComparers.PropertyLiteralValues.Equals(unevaluatedPropertyValue, "false"))
+        {
+            await defaultProperties.SetPropertyValueAsync(WarningLevelPropertyName, "1", dimensionalConditions);
+        }
+
+        return null;
+    }
+
+    private async Task<string> OnGetPropertyValueAsync(IProjectProperties projectProperties)
+    {
+        string warningLevelValue = await projectProperties.GetEvaluatedPropertyValueAsync(WarningLevelPropertyName);
+
+        return warningLevelValue == "0" ? "true" : "false";
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 /// values persisted to the project file.
 /// </para>
 /// <para>
-/// Note this types stores IDs in instances of <see cref="ImmutableSortedSet{T}"/>,
+/// Note this type stores IDs in instances of <see cref="ImmutableSortedSet{T}"/>,
 /// rather a simple array or list. Two reasons:
 /// <list type="number">
 /// <item>We need to perform actual set operations (union, difference, etc.)</item>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
@@ -1,0 +1,292 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+/// <remarks>
+/// <para>
+/// The VB "Compile" property page doesn't allow you to disable individual warnings
+/// or promote individual warnings to errors. Instead, it groups related warnings
+/// into sets and lets the user adjust the severity of the whole set at once. This
+/// type is responsible for mapping between those sets and the actual property
+/// values persisted to the project file.
+/// </para>
+/// <para>
+/// Note this types stores IDs in instances of <see cref="ImmutableSortedSet{T}"/>,
+/// rather a simple array or list. Two reasons:
+/// <list type="number">
+/// <item>We need to perform actual set operations (union, difference, etc.)</item>
+/// <item>When writing IDs to the project file, we want to keep them sorted</item>
+/// </list>
+/// </para>
+/// </remarks>
+[ExportInterceptingPropertyValueProvider(
+    new[]
+    {
+        ImplicitConversionPropertyName,
+        LateBindingPropertyName,
+        ImplicitTypePropertyName,
+        UseOfVariablePriorToAssignmentPropertyName,
+        ReturningRefTypeWithoutReturnValuePropertyName,
+        ReturningIntrinsicValueTypeWithoutReturnValuePropertyName,
+        UnusedLocalVariablePropertyName,
+        InstanceVariableAccessesSharedMemberPropertyName,
+        RecursiveOperatorOrPropertyAccessPropertyName,
+        DuplicateOrOverlappingCatchBlocksPropertyName
+    },
+    ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+internal sealed class VBWarningsValueProvider : InterceptingPropertyValueProviderBase
+{
+    // The names of the property "sets" as known to the property page.
+    internal const string ImplicitConversionPropertyName = "ImplicitConversion";
+    internal const string LateBindingPropertyName = "LateBinding";
+    internal const string ImplicitTypePropertyName = "ImplicitType";
+    internal const string UseOfVariablePriorToAssignmentPropertyName = "UseOfVariablePriorToAssignment";
+    internal const string ReturningRefTypeWithoutReturnValuePropertyName = "ReturningRefTypeWithoutReturnValue";
+    internal const string ReturningIntrinsicValueTypeWithoutReturnValuePropertyName = "ReturningIntrinsicValueTypeWithoutReturnValue";
+    internal const string UnusedLocalVariablePropertyName = "UnusedLocalVariable";
+    internal const string InstanceVariableAccessesSharedMemberPropertyName = "InstanceVariableAccessesSharedMember";
+    internal const string RecursiveOperatorOrPropertyAccessPropertyName = "RecursiveOperatorOrPropertyAccess";
+    internal const string DuplicateOrOverlappingCatchBlocksPropertyName = "DuplicateOrOverlappingCatchBlocks";
+
+    // The names of the properties persisted to the project file.
+    internal const string OptionStrictPropertyName = "OptionStrict";
+    internal const string WarningLevelPropertyName = "WarningLevel";
+    internal const string TreatWarningsAsErrorsPropertyName = "TreatWarningsAsErrors";
+    internal const string NoWarnPropertyName = "NoWarn";
+    internal const string WarningsAsErrorsPropertyName = "WarningsAsErrors";
+
+    // The possible values for any given set.
+    internal const string NoneValue = "None";
+    internal const string WarningValue = "Warning";
+    internal const string ErrorValue = "Error";
+    internal const string InconsistentValue = "";
+
+    // The IDs associated with each set.
+    private static readonly ImmutableDictionary<string, ImmutableSortedSet<int>> s_diagnosticIdMap = ImmutableDictionary<string, ImmutableSortedSet<int>>.Empty
+        .Add(ImplicitConversionPropertyName,                            ImmutableSortedSet.Create(42016, 41999))
+        .Add(LateBindingPropertyName,                                   ImmutableSortedSet.Create(42017, 42018, 42019, 42032, 42036))
+        .Add(ImplicitTypePropertyName,                                  ImmutableSortedSet.Create(42020, 42021, 42022))
+        .Add(UseOfVariablePriorToAssignmentPropertyName,                ImmutableSortedSet.Create(42104, 42108, 42109, 42030))
+        .Add(ReturningRefTypeWithoutReturnValuePropertyName,            ImmutableSortedSet.Create(42105, 42106, 42107))
+        .Add(ReturningIntrinsicValueTypeWithoutReturnValuePropertyName, ImmutableSortedSet.Create(42353, 42354, 42355))
+        .Add(UnusedLocalVariablePropertyName,                           ImmutableSortedSet.Create(42024, 42099))
+        .Add(InstanceVariableAccessesSharedMemberPropertyName,          ImmutableSortedSet.Create(42025))
+        .Add(RecursiveOperatorOrPropertyAccessPropertyName,             ImmutableSortedSet.Create(41998, 42004, 42026))
+        .Add(DuplicateOrOverlappingCatchBlocksPropertyName,             ImmutableSortedSet.Create(42029, 42031));
+
+    private const string s_diagnosticIdSeparator = ",";
+    private static readonly string[] s_diagnosticIdSeparators = new[] { s_diagnosticIdSeparator };
+
+    public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return OnGetPropertyValueAsync(propertyName, defaultProperties);
+    }
+
+    public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return OnGetPropertyValueAsync(propertyName, defaultProperties);
+    }
+
+    public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+    {
+        ImmutableSortedSet<int> originalWarningsAsErrorIds = await GetWarningsAsErrorsIdsAsync(defaultProperties);
+        ImmutableSortedSet<int> originalNoWarnIds = await GetNoWarnIdsAsync(defaultProperties);
+        ImmutableSortedSet<int>? updatedWarningsAsErrorIds = null;
+        ImmutableSortedSet<int>? updatedNoWarnIds = null;
+
+        ImmutableSortedSet<int> idsInSet = s_diagnosticIdMap[propertyName];
+
+        switch (unevaluatedPropertyValue)
+        {
+            case NoneValue:
+            {
+                // Remove from WarningsAsErrors; add to NoWarn.
+                updatedWarningsAsErrorIds = originalWarningsAsErrorIds.Except(idsInSet);
+                updatedNoWarnIds = originalNoWarnIds.Union(idsInSet);
+                break;
+            }
+
+            case WarningValue:
+            {
+                // Remove from both WarningsAsErrors and NoWarn.
+                updatedWarningsAsErrorIds = originalWarningsAsErrorIds.Except(idsInSet);
+                updatedNoWarnIds = originalNoWarnIds.Except(idsInSet);
+                break;
+            }
+
+            case ErrorValue:
+            {
+                // Remove from NoWarn; add to WarningsAsErrors.
+                updatedWarningsAsErrorIds = originalWarningsAsErrorIds.Union(idsInSet);
+                updatedNoWarnIds = originalNoWarnIds.Except(idsInSet);
+                break;
+            }
+
+            default:
+                break;
+        }
+
+        if (updatedWarningsAsErrorIds is not null
+            && updatedWarningsAsErrorIds != originalWarningsAsErrorIds)
+        {
+            await SetWarningsAsErrorIdsAsync(updatedWarningsAsErrorIds, defaultProperties, dimensionalConditions);
+        }
+
+        if (updatedNoWarnIds is not null
+            && updatedNoWarnIds != originalNoWarnIds)
+        {
+            await SetNoWarnIdsAsync(updatedNoWarnIds, defaultProperties, dimensionalConditions);
+        }
+
+        return null;
+    }
+
+    private async Task<string> OnGetPropertyValueAsync(string propertyName, IProjectProperties projectProperties)
+    {
+        // <OptionStrict>On</OptionsStrict> forces certain sets of diagnostics to be errors.
+        if (propertyName is ImplicitConversionPropertyName or LateBindingPropertyName or ImplicitTypePropertyName
+            && await IsOptionStrictOnAsync(projectProperties))
+        {
+            return ErrorValue;
+        }
+
+        // If all warnings are disabled, then this set is disabled.
+        if (await IsDisableAllWarningsOnAsync(projectProperties))
+        {
+            return NoneValue;
+        }
+
+        ImmutableSortedSet<int> noWarnIdsSet = await GetNoWarnIdsAsync(projectProperties);
+        NumbersInSetResult idsInNoWarnIdsSet = NumbersInSet(noWarnIdsSet, s_diagnosticIdMap[propertyName]);
+
+        // If all active warnings are promoted to errors, and these aren't disabled, they must be errors.
+        if (await IsTreatAllWarningsAsErrorsOnAsync(projectProperties)
+            && idsInNoWarnIdsSet == NumbersInSetResult.None)
+        {
+            return ErrorValue;
+        }
+
+        // If all the diagnostics in the set are disabled, then the set is disabled.
+        if (idsInNoWarnIdsSet == NumbersInSetResult.All)
+        {
+            return NoneValue;
+        }
+
+        ImmutableSortedSet<int> warningsAsErrorsIdsSet = await GetWarningsAsErrorsIdsAsync(projectProperties);
+        NumbersInSetResult idsInWarningsAsErrorsIdsSet = NumbersInSet(warningsAsErrorsIdsSet, s_diagnosticIdMap[propertyName]);
+
+        // If all the diagnostics in the set are promoted to errors, and none are disabled, then the set is promoted to an error.
+        if (idsInWarningsAsErrorsIdsSet == NumbersInSetResult.All
+            && idsInNoWarnIdsSet == NumbersInSetResult.None)
+        {
+            return ErrorValue;
+        }
+
+        // If none of the diagnostics are disabled and none are promoted to errors, then they are all warnings.
+        if (idsInNoWarnIdsSet == NumbersInSetResult.None
+            && idsInWarningsAsErrorsIdsSet == NumbersInSetResult.None)
+        {
+            return WarningValue;
+        }
+
+        // The state of the diagnostics in the set is inconsistent.
+        return InconsistentValue;
+    }
+
+    private async Task SetNoWarnIdsAsync(ImmutableSortedSet<int> updatedNoWarnIds, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions)
+    {
+        string value = CreateIdList(updatedNoWarnIds);
+
+        await defaultProperties.SetPropertyValueAsync(NoWarnPropertyName, value, dimensionalConditions);
+    }
+
+    private async Task SetWarningsAsErrorIdsAsync(ImmutableSortedSet<int> updatedWarningsAsErrorIds, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions)
+    {
+        string value = CreateIdList(updatedWarningsAsErrorIds);
+
+        await defaultProperties.SetPropertyValueAsync(WarningsAsErrorsPropertyName, value, dimensionalConditions);
+    }
+
+    private async Task<ImmutableSortedSet<int>> GetNoWarnIdsAsync(IProjectProperties projectProperties)
+    {
+        string noWarnValue = await projectProperties.GetEvaluatedPropertyValueAsync(NoWarnPropertyName);
+
+        return ParseIdList(noWarnValue);
+    }
+
+    private static ImmutableSortedSet<int> ParseIdList(string idList)
+    {
+        ImmutableSortedSet<int> ids = ImmutableSortedSet<int>.Empty;
+        string[] idsAsStrings = idList.Split(s_diagnosticIdSeparators, StringSplitOptions.RemoveEmptyEntries);
+        foreach (string idString in idsAsStrings)
+        {
+            if (int.TryParse(idString, out int id))
+            {
+                ids = ids.Add(id);
+            }
+        }
+
+        return ids;
+    }
+
+    private static string CreateIdList(ImmutableSortedSet<int> idSet)
+    {
+        return string.Join(s_diagnosticIdSeparator, idSet);
+    }
+
+    private async Task<ImmutableSortedSet<int>> GetWarningsAsErrorsIdsAsync(IProjectProperties projectProperties)
+    {
+        string warningsAsErrorsValue = await projectProperties.GetEvaluatedPropertyValueAsync(WarningsAsErrorsPropertyName);
+
+        return ParseIdList(warningsAsErrorsValue);
+    }
+
+    private static async Task<bool> IsOptionStrictOnAsync(IProjectProperties projectProperties)
+    {
+        string optionStrictValue = await projectProperties.GetEvaluatedPropertyValueAsync(OptionStrictPropertyName);
+        bool optionStrictOn = StringComparers.PropertyLiteralValues.Equals(optionStrictValue, "On");
+
+        return optionStrictOn;
+    }
+
+    private static async Task<bool> IsDisableAllWarningsOnAsync(IProjectProperties projectProperties)
+    {
+        string warningLevelValue = await projectProperties.GetEvaluatedPropertyValueAsync(WarningLevelPropertyName);
+        bool disableAllWarningsOn = StringComparers.PropertyLiteralValues.Equals(warningLevelValue, "0");
+
+        return disableAllWarningsOn;
+    }
+
+    private static async Task<bool> IsTreatAllWarningsAsErrorsOnAsync(IProjectProperties projectProperties)
+    {
+        string treatAllWarningsAsErrorsValue = await projectProperties.GetEvaluatedPropertyValueAsync(TreatWarningsAsErrorsPropertyName);
+        bool treatAllWarningsAsErrorsOn = StringComparers.PropertyLiteralValues.Equals(treatAllWarningsAsErrorsValue, "true");
+
+        return treatAllWarningsAsErrorsOn;
+    }
+
+    private enum NumbersInSetResult
+    {
+        None,
+        Some,
+        All
+    }
+
+    private NumbersInSetResult NumbersInSet(ImmutableSortedSet<int> set, ImmutableSortedSet<int> numbersToCheck)
+    {
+        int numbersFound = set.Intersect(numbersToCheck).Count;
+
+        if (numbersFound == numbersToCheck.Count)
+        {
+            return NumbersInSetResult.All;
+        }
+        else if (numbersFound == 0)
+        {
+            return NumbersInSetResult.None;
+        }
+        else
+        {
+            return NumbersInSetResult.Some;
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -76,7 +76,6 @@
     </EnumProperty.DataSource>
     <EnumValue Name="On" DisplayName="On" />
     <EnumValue Name="Off" DisplayName="Off" />
-    <EnumValue Name="Custom" DisplayName="(custom)" />
   </EnumProperty>
 
   <!-- TODO: Replace HelpUrl with a fwlink -->
@@ -148,6 +147,37 @@
                 Description="Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion."
                 HelpUrl="https://docs.microsoft.com/dotnet/visual-basic/language-reference/statements/option-strict-statement#implicit-narrowing-conversion-errors"
                 Category="Warnings">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (not (has-evaluated-value "Build" "OptionStrict" "On"))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="ImplicitConversion_Readonly"
+                DisplayName="Implicit conversion"
+                Description="Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on."
+                HelpUrl="https://docs.microsoft.com/dotnet/visual-basic/language-reference/statements/option-strict-statement#implicit-narrowing-conversion-errors"
+                Category="Warnings"
+                ReadOnly="True">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  PersistedName="ImplicitConversion"
+                  HasConfigurationCondition="True" />
+    </EnumProperty.DataSource>
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (has-evaluated-value "Build" "OptionStrict" "On")
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -159,6 +189,37 @@
                 Description="An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time."
                 HelpUrl="https://docs.microsoft.com/dotnet/visual-basic/language-reference/statements/option-strict-statement#late-binding-errors"
                 Category="Warnings">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (not (has-evaluated-value "Build" "OptionStrict" "On"))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+  
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="LateBinding_Readonly"
+                DisplayName="Late binding"
+                Description="An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on."
+                HelpUrl="https://docs.microsoft.com/dotnet/visual-basic/language-reference/statements/option-strict-statement#late-binding-errors"
+                Category="Warnings"
+                ReadOnly="True">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  PersistedName="LateBinding"
+                  HasConfigurationCondition="True" />
+    </EnumProperty.DataSource>
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (has-evaluated-value "Build" "OptionStrict" "On")
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />
@@ -170,6 +231,37 @@
                 Description="Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred."
                 HelpUrl="https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/option-strict-statement#implicit-object-type-errors"
                 Category="Warnings">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (not (has-evaluated-value "Build" "OptionStrict" "On"))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="None" DisplayName="None" />
+    <EnumValue Name="Warning" DisplayName="Warning" />
+    <EnumValue Name="Error" DisplayName="Error" />
+  </EnumProperty>
+
+  <!-- TODO: Replace HelpUrl with a fwlink -->
+  <EnumProperty Name="ImplicitType_Readonly"
+                DisplayName="Implicit type"
+                Description="Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on."
+                HelpUrl="https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/statements/option-strict-statement#implicit-object-type-errors"
+                Category="Warnings"
+                ReadOnly="True">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  PersistedName="ImplicitType"
+                  HasConfigurationCondition="True" />
+    </EnumProperty.DataSource>
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (has-evaluated-value "Build" "OptionStrict" "On")
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
     <EnumValue Name="None" DisplayName="None" />
     <EnumValue Name="Warning" DisplayName="Warning" />
     <EnumValue Name="Error" DisplayName="Error" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -132,6 +132,16 @@
         <target state="new">Generate serialization assemblies</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|Description">
+        <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitConversion_Readonly|DisplayName">
+        <source>Implicit conversion</source>
+        <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|ImplicitConversion|Description">
         <source>Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</source>
         <target state="new">Implicit narrowing conversion occurs when there is an implicit data type conversion that is a narrowing conversion.</target>
@@ -140,6 +150,16 @@
       <trans-unit id="EnumProperty|ImplicitConversion|DisplayName">
         <source>Implicit conversion</source>
         <target state="new">Implicit conversion</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|Description">
+        <source>Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">Implicit object type errors occur when an appropriate type cannot be inferred for a declared variable, so a type of 'Object' is inferred. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ImplicitType_Readonly|DisplayName">
+        <source>Implicit type</source>
+        <target state="new">Implicit type</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ImplicitType|Description">
@@ -155,6 +175,16 @@
       <trans-unit id="EnumProperty|InstanceVariableAccessesSharedMember|DisplayName">
         <source>Instance variable accesses shared member</source>
         <target state="new">Instance variable accesses shared member</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|Description">
+        <source>An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</source>
+        <target state="new">An object is late bound when it is assigned to a property or method of a variable that is declared to be of type 'Object'. These operations could fail at run time. Cannot be changed when 'Option strict' is on.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|LateBinding_Readonly|DisplayName">
+        <source>Late binding</source>
+        <target state="new">Late binding</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|LateBinding|Description">
@@ -307,6 +337,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitConversion_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Error|DisplayName">
         <source>Error</source>
         <target state="new">Error</target>
@@ -318,6 +363,21 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ImplicitType.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ImplicitType_Readonly.Warning|DisplayName">
         <source>Warning</source>
         <target state="new">Warning</target>
         <note />
@@ -352,6 +412,21 @@
         <target state="new">Warning</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Error|DisplayName">
+        <source>Error</source>
+        <target state="new">Error</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.None|DisplayName">
+        <source>None</source>
+        <target state="new">None</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|LateBinding_Readonly.Warning|DisplayName">
+        <source>Warning</source>
+        <target state="new">Warning</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|OptionCompare.Binary|DisplayName">
         <source>Binary</source>
         <target state="new">Binary</target>
@@ -380,11 +455,6 @@
       <trans-unit id="EnumValue|OptionInfer.On|DisplayName">
         <source>On</source>
         <target state="new">On</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|OptionStrict.Custom|DisplayName">
-        <source>(custom)</source>
-        <target state="new">(custom)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OptionStrict.Off|DisplayName">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProviderTests.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+public class VBWarningsValueProviderTests
+{
+    [Theory]                         // Property                                          Option  Warning  All as   NoWarn         Warnings as    Expected
+                                     //                                                   Strict  Level    Errors                  Errors
+    [InlineData(VBWarningsValueProvider.ImplicitConversionPropertyName,                   "On",   "0",     "",      "",            "",            VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.ImplicitConversionPropertyName,                   "On",   "0",     "false", "",            "",            VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.ImplicitConversionPropertyName,                   "On",   "0",     "",      "42016,41999", "",            VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.LateBindingPropertyName,                          "On",   "0",     "",      "",            "",            VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.ImplicitTypePropertyName,                         "On",   "0",     "",      "",            "",            VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "On",   "1",     "",      "",            "",            VBWarningsValueProvider.WarningValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "0",     "",      "",            "",            VBWarningsValueProvider.NoneValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "1",     "",      "",            "",            VBWarningsValueProvider.WarningValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "0",     "true",  "",            "",            VBWarningsValueProvider.NoneValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "1",     "true",  "",            "",            VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "1",     "true",  "42024,42099", "",            VBWarningsValueProvider.NoneValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "1",     "",      "42024,42099", "",            VBWarningsValueProvider.NoneValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "1",     "",      "",            "42024,42099", VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.UnusedLocalVariablePropertyName,                  "",     "1",     "",      "42024",       "42099",       VBWarningsValueProvider.InconsistentValue)]
+    [InlineData(VBWarningsValueProvider.InstanceVariableAccessesSharedMemberPropertyName, "",     "1",     "",      "42025",       "",            VBWarningsValueProvider.NoneValue)]
+    [InlineData(VBWarningsValueProvider.InstanceVariableAccessesSharedMemberPropertyName, "",     "1",     "",      "",            "42025",       VBWarningsValueProvider.ErrorValue)]
+    [InlineData(VBWarningsValueProvider.InstanceVariableAccessesSharedMemberPropertyName, "",     "1",     "",      "",            "",            VBWarningsValueProvider.WarningValue)]
+    public async Task GetPropertyValueTests(string propertyName, string optionStrict, string warningLevel, string treatWarningsAsErrors, string noWarn, string specificWarningsAsErrors, string expectedValue)
+    {
+        var provider = new VBWarningsValueProvider();
+
+        var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>()
+        {
+            { VBWarningsValueProvider.OptionStrictPropertyName, optionStrict },
+            { VBWarningsValueProvider.WarningLevelPropertyName, warningLevel  },
+            { VBWarningsValueProvider.TreatWarningsAsErrorsPropertyName, treatWarningsAsErrors },
+            { VBWarningsValueProvider.NoWarnPropertyName, noWarn },
+            { VBWarningsValueProvider.WarningsAsErrorsPropertyName, specificWarningsAsErrors }
+        });
+
+        var result = await provider.OnGetEvaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue: "", defaultProperties);
+
+        Assert.Equal(expectedValue, result);
+    }
+}


### PR DESCRIPTION
The VB "Compile" property page doesn't allow you to disable individual warnings or promote individual warnings to errors. Instead, it groups related warnings into sets and lets the user adjust the severity of the whole set at once. This commit adds the `VBWarningsValueProvider` interceptor, which converts back and forth from the "None", "Warning", and "Error" values for the various warning sets displayed on the VB compile page, and the values of the "NoWarn" and "WarningsAsErrors" properties (among others) persisted to the project file.

This also adds the `VBDisableAllWarningsValueProvider`, a simpler interceptor that maps between the "Disable all warnings" checkbox on the property page, and the "WarningLevel" property in the project file.

Related to #7237.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8177)