### PR TITLE
Only escape \r\n in command line args

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.Debugger.UI.Interfaces.HotReload;
 using Microsoft.VisualStudio.IO;
@@ -261,7 +262,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
             }
 
-            string? commandLineArgs = resolvedProfile.CommandLineArgs?.Replace("\r\n", " ");
+            string? commandLineArgs = resolvedProfile.CommandLineArgs is null
+                ? null
+                : Regex.Replace(resolvedProfile.CommandLineArgs, "[\r\n]+", " ");
 
             // Is this profile just running the project? If so we ignore the exe
             if (IsRunProjectCommand(resolvedProfile))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -261,12 +261,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 }
             }
 
-            string? commandLineArgs = resolvedProfile.CommandLineArgs?
-                .Replace("\r\n", " ")
-                .Replace("\r", " ")
-                .Replace("\n", " ")
-                .Replace("\\r\\n", "\r\n")
-                .Replace("\\n", "\n");
+            string? commandLineArgs = resolvedProfile.CommandLineArgs?.Replace("\r\n", " ");
 
             // Is this profile just running the project? If so we ignore the exe
             if (IsRunProjectCommand(resolvedProfile))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -608,7 +608,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var activeProfile = new LaunchProfile("Name", "Executable", commandLineArgs: "-arg1\r\n-arg2 -arg3\n -arg4\r\n\\r\\n");
             var launchSettings = await provider.GetConsoleTargetForProfileAsync(activeProfile, DebugLaunchOptions.NoDebug, false);
 
-            Assert.Equal("-arg1 -arg2 -arg3\n -arg4 \\r\\n", launchSettings?.Arguments);
+            Assert.Equal("-arg1 -arg2 -arg3  -arg4 \\r\\n", launchSettings?.Arguments);
 
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -605,10 +605,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 debugger: null,
                 scope: null);
 
-            var activeProfile = new LaunchProfile("Name", "Executable", commandLineArgs: "-arg1\r\n-arg2 -arg3\n -arg4\r\n");
+            var activeProfile = new LaunchProfile("Name", "Executable", commandLineArgs: "-arg1\r\n-arg2 -arg3\n -arg4\r\n\\r\\n");
             var launchSettings = await provider.GetConsoleTargetForProfileAsync(activeProfile, DebugLaunchOptions.NoDebug, false);
 
-            Assert.Equal("-arg1 -arg2 -arg3  -arg4 ", launchSettings?.Arguments);
+            Assert.Equal("-arg1 -arg2 -arg3\n -arg4 \\r\\n", launchSettings?.Arguments);
 
         }
 


### PR DESCRIPTION
This fixes #8167. VS editor escapes user-input `\r\n` as `\\r\\n`, whereas newlines in the editor are `\r\n`. Since VS Windows is Windows-only, we do not need to be OS-agnostic about newlines and can assume we just need to escape `\r\n`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8188)