### PR TITLE
Prevent NFE in UpToDateCheckStatePersistence

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
@@ -236,6 +236,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
                         _cacheFilePath = null;
                         _dataByConfiguredProject = null;
+                        _hasUnsavedChange = false;
 
                         return Task.CompletedTask;
                     });


### PR DESCRIPTION
Fixes [AB#1543048](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1543048)

CPS's NFE reporting shows the previous `Assert.NotNull` call in `StoreStateAsync` could fail.

This change does two things:

- Handles a null in this position gracefully.
- Replaces the semaphore with the locking mechanism from `OnceInitializedOnceDisposedUnderLockAsync` so that we have a single lock around initialisation, dispose, and critical operations.

The diff is easier to read if you hide white space changes.