### PR TITLE
ApplicationFramework property interceptor.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -30,25 +30,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            var value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
 
-            if (value == EnabledValue)
+            return value switch
             {
-                return "true";
-            }
-            else if (value == DisabledValue)
-            {
-                return "false";
-            }
-            else
-            {
-                return string.Empty;
-            }
+                EnabledValue => "true",
+                DisabledValue => "false",
+                _ => string.Empty
+            };
         }
 
         public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            var value = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+            string? value = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
 
             return value switch
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    [ExportInterceptingPropertyValueProvider("UseApplicationFramework", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+    [AppliesTo(ProjectCapability.VisualBasic)]
+    internal sealed class ApplicationFrameworkValueProvider : InterceptingPropertyValueProviderBase
+    {
+        private const string ApplicationFrameworkMSBuildProperty = "MyType";
+        private const string EnabledValue = "WindowsForms";
+        private const string DisabledValue = "WindowsFormsWithCustomSubMain";
+
+        public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            if (bool.TryParse(unevaluatedPropertyValue, out bool value))
+            {
+                if (value)
+                {
+                    // Enabled: <MyType>WindowsForms</MyType>
+                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, EnabledValue);
+                }
+                else
+                {
+                    // Disabled: <MyType>WindowsFormsWithCustomSubMain</MyType>
+                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, DisabledValue);
+                }
+            }
+            return null;
+        }
+
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            var value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+
+            if (value == EnabledValue)
+            {
+                return "true";
+            }
+            else if (value == DisabledValue)
+            {
+                return "false";
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+
+        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            var value = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+
+            if (value == EnabledValue)
+            {
+                return "true";
+            }
+            else if (value == DisabledValue)
+            {
+                return "false";
+            }
+            else
+            {
+                return string.Empty;
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -50,18 +50,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             var value = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
 
-            if (value == EnabledValue)
+            return value switch
             {
-                return "true";
-            }
-            else if (value == DisabledValue)
-            {
-                return "false";
-            }
-            else
-            {
-                return string.Empty;
-            }
+                EnabledValue => "true",
+                DisabledValue => "false",
+                _ => string.Empty
+            };
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -20,6 +20,10 @@
                 Description="Enable the Visual Basic Application Framework for this project. In general, these settings get serialized into the myapp file."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195444"
                 Category="ApplicationFramework">
+    <BoolProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>


### PR DESCRIPTION
Related to https://github.com/dotnet/project-system/issues/7379 and https://github.com/dotnet/project-system/issues/7236.

The `UseApplicationFramework` property gets saved to the project file as `<MyType>`; when enabled, the value `WindowsForms` is saved; when disabled, the value `WindowsFormsWithCustomSubMain` is saved.

To test it, enable the `ProjectPropertiesEditor` ProjectCapability in the Ms.VisualBasic.DesignTime.targets file.

Note: changes to this property also ipact the myapp file; I'll bring this up in an upcoming PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8197)