### PR TITLE
Expose a mechanism to apply custom hot reload updates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionInternal.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionInternal.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    /// <summary>
+    /// Internal interface which Hot Reload sessions implement to provide access to the IDeltaApplier
+    /// </summary>
+    internal interface IProjectHotReloadSessionInternal
+    {
+        /// <summary>
+        /// Returns the delta applier for this session
+        /// </summary>
+        IDeltaApplier? DeltApplier { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionInternal.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadSessionInternal.cs
@@ -12,6 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         /// <summary>
         /// Returns the delta applier for this session
         /// </summary>
-        IDeltaApplier? DeltApplier { get; }
+        IDeltaApplier? DeltaApplier { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadUpdateApplier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadUpdateApplier.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    /// <summary>
+    /// Provides a mechanism to apply custom updates to the running hot reload sessions. Assumes all updates can be applied via the 
+    /// IDeltaApplier created for this session
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.System, Cardinality = Composition.ImportCardinality.ExactlyOne)]
+    public interface IProjectHotReloadUpdateApplier
+    {
+        /// <summary>
+        /// Returns true if there is at least one hot reload session active in the project
+        /// </summary>
+        bool HasActiveHotReloadSessions { get; }
+
+        /// <summary>
+        /// Called to apply a custom update via the IDeltaApplier. The applyFunction will be called once for every active session, and passed the IDeltaApplier
+        /// for that session. In the case of multiple sessions, updates will stop being applied on the first call to an applyFunction that throws an exception, and 
+        /// that exception propagates back to the caller.
+        /// </summary>
+        Task ApplyHotReloadUpdateAsync(Func<IDeltaApplier, CancellationToken, Task> applyFunction, CancellationToken cancelToken);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {
-    internal class ProjectHotReloadSession : IManagedHotReloadAgent, IProjectHotReloadSession
+    internal class ProjectHotReloadSession : IManagedHotReloadAgent, IProjectHotReloadSession, IProjectHotReloadSessionInternal
     {
         private readonly string _variant;
         private readonly string _runtimeVersion;
@@ -38,6 +38,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         // IProjectHotReloadSession
 
         public string Name { get; }
+
+        /// <inheritdoc />
+        public IDeltaApplier? DeltApplier
+        {
+            get
+            {
+                EnsureDeltaApplierforSession();
+                return _deltaApplier;
+            }
+        }
 
         public async Task ApplyChangesAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -40,14 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         public string Name { get; }
 
         /// <inheritdoc />
-        public IDeltaApplier? DeltApplier
-        {
-            get
-            {
-                EnsureDeltaApplierforSession();
-                return _deltaApplier;
-            }
-        }
+        public IDeltaApplier? DeltaApplier => _deltaApplier;
 
         public async Task ApplyChangesAsync(CancellationToken cancellationToken)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -39,7 +39,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
         public string Name { get; }
 
-        /// <inheritdoc />
         public IDeltaApplier? DeltaApplier => _deltaApplier;
 
         public async Task ApplyChangesAsync(CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -381,7 +381,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         /// <inheritdoc />
         public async Task ApplyHotReloadUpdateAsync(Func<IDeltaApplier, CancellationToken, Task> applyFunction, CancellationToken cancelToken)
         {
-            using AsyncSemaphore.Releaser semaphoreRelease = await _semaphore.EnterAsync();
+            using AsyncSemaphore.Releaser semaphoreRelease = await _semaphore.EnterAsync(cancelToken);
 
             // Run the updates in parallel
             List<Task> updateTasks = new List<Task>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 Assumes.NotNull(sessionState.Session);
                 if (sessionState.Session is IProjectHotReloadSessionInternal sessionInternal)
                 {
-                    IDeltaApplier? deltaApplier = sessionInternal.DeltApplier;
+                    IDeltaApplier? deltaApplier = sessionInternal.DeltaApplier;
                     if (deltaApplier is not null)
                     {
                         await applyFunction(deltaApplier, cancelToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -388,7 +388,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             foreach (HotReloadState sessionState in _activeSessions.Values)
             {
                 cancelToken.ThrowIfCancellationRequested();
-                Assumes.NotNull(sessionState.Session);
                 if (sessionState.Session is IProjectHotReloadSessionInternal sessionInternal)
                 {
                     IDeltaApplier? deltaApplier = sessionInternal.DeltaApplier;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -414,3 +414,10 @@ virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollec
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.ValueHeader.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.WorkingDirectory.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.WorkingDirectoryWatermark.get -> string
+
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadApplier
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadApplier.ApplyHotReloadUpdateAsync(System.Func<Microsoft.VisualStudio.HotReload.Components.DeltaApplier.IDeltaApplier!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! applyFunction, System.Threading.CancellationToken cancelToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadApplier.HasActiveHotReloadSessions.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadUpdateApplier
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadUpdateApplier.ApplyHotReloadUpdateAsync(System.Func<Microsoft.VisualStudio.HotReload.Components.DeltaApplier.IDeltaApplier!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! applyFunction, System.Threading.CancellationToken cancelToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadUpdateApplier.HasActiveHotReloadSessions.get -> bool

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -414,10 +414,6 @@ virtual Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollec
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.ValueHeader.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.WorkingDirectory.get -> string
 ~static Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages.PropertyPageResources.WorkingDirectoryWatermark.get -> string
-
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadApplier
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadApplier.ApplyHotReloadUpdateAsync(System.Func<Microsoft.VisualStudio.HotReload.Components.DeltaApplier.IDeltaApplier!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! applyFunction, System.Threading.CancellationToken cancelToken) -> System.Threading.Tasks.Task!
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadApplier.HasActiveHotReloadSessions.get -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadUpdateApplier
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadUpdateApplier.ApplyHotReloadUpdateAsync(System.Func<Microsoft.VisualStudio.HotReload.Components.DeltaApplier.IDeltaApplier!, System.Threading.CancellationToken, System.Threading.Tasks.Task!>! applyFunction, System.Threading.CancellationToken cancelToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadUpdateApplier.HasActiveHotReloadSessions.get -> bool

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
@@ -163,27 +163,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             Assert.False(manager.HasActiveHotReloadSessions);
         }
 
-        [Fact]
-        public async Task WhenActiveSession_HasSessionsReturnsTrue()
-        {
-            var capabilities = new[] { "SupportsHotReload" };
-            var propertyNamesAndValues = new Dictionary<string, string?>()
-            {
-                { "TargetFrameworkVersion", "v6.0" },
-                { "DebugSymbols", "true" },
-                // Note: "Optimize" is not included here. The compilers do not optimize by default;
-                // so if the property isn't set that's OK.
-            };
-
-            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
-            var manager = CreateHotReloadSessionManager(activeConfiguredProject);
-
-            var environmentVariables = new Dictionary<string, string>();
-            await manager.TryCreatePendingSessionAsync(environmentVariables);
-
-            Assert.False(manager.HasActiveHotReloadSessions);
-        }
-
         private static ProjectHotReloadSessionManager CreateHotReloadSessionManager(ConfiguredProject activeConfiguredProject, Action? outputServiceCallback = null)
         {
             var activeDebugFrameworkServices = new IActiveDebugFrameworkServicesMock()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
@@ -145,6 +145,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             Assert.False(sessionCreated);
         }
 
+        [Fact]
+        public void WhenNoActiveSession_HasSessionsReturnsFalse()
+        {
+            var capabilities = new[] { "SupportsHotReload" };
+            var propertyNamesAndValues = new Dictionary<string, string?>()
+            {
+                { "TargetFrameworkVersion", "v6.0" },
+                { "DebugSymbols", "true" },
+                // Note: "Optimize" is not included here. The compilers do not optimize by default;
+                // so if the property isn't set that's OK.
+            };
+
+            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
+            var manager = CreateHotReloadSessionManager(activeConfiguredProject);
+
+            Assert.False(manager.HasActiveHotReloadSessions);
+        }
+
+        [Fact]
+        public async Task WhenActiveSession_HasSessionsReturnsTrue()
+        {
+            var capabilities = new[] { "SupportsHotReload" };
+            var propertyNamesAndValues = new Dictionary<string, string?>()
+            {
+                { "TargetFrameworkVersion", "v6.0" },
+                { "DebugSymbols", "true" },
+                // Note: "Optimize" is not included here. The compilers do not optimize by default;
+                // so if the property isn't set that's OK.
+            };
+
+            var activeConfiguredProject = CreateConfiguredProject(capabilities, propertyNamesAndValues);
+            var manager = CreateHotReloadSessionManager(activeConfiguredProject);
+
+            var environmentVariables = new Dictionary<string, string>();
+            await manager.TryCreatePendingSessionAsync(environmentVariables);
+
+            Assert.False(manager.HasActiveHotReloadSessions);
+        }
+
         private static ProjectHotReloadSessionManager CreateHotReloadSessionManager(ConfiguredProject activeConfiguredProject, Action? outputServiceCallback = null)
         {
             var activeDebugFrameworkServices = new IActiveDebugFrameworkServicesMock()


### PR DESCRIPTION
- In order to support static asset file updates in Winforms and WPF projects, I added a new interface which provides a generic mechanism to apply those updates to all running hot reload sessions, without exposing internal details of the project system.
- The IProjectHotReloadUpdateApplier interface is exported from IProjectHotReloadSessionManager since this is the object which track hot reload sessions. It has a boolean method which returns true if sessions are active, and a second method to apply updates.
- The apply update function takes an async delegate which will be called once for each active session.  The delegate is passed the active IDeltaApplier for that session, and the assumption is the delegate can apply its update via that object.
- Doing it this way means the manage project system is shielded from these more specific updates by providing access to its connection to the running application.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8198)