### PR TITLE
Port AppDotXamlDocument

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
@@ -925,9 +925,11 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
             // Replace the empty tag in the buffer with a start/end element tag
             // and the new value
             string newText =
-$@"<{_fullyQualifiedPropertyName}>
-{EscapeXmlString(value)}
-</{_fullyQualifiedPropertyName}>";
+                $"""
+                <{_fullyQualifiedPropertyName}>
+                {EscapeXmlString(value)}
+                </{_fullyQualifiedPropertyName}>
+                """;
 
             // We know where to replace, so go ahead and do it.
             replaceTextInstance.ReplaceText(DefinitionStart, DefinitionEndPlusOne, newText);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
@@ -1,0 +1,944 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Xml;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WPF;
+
+/// <summary>
+/// When reading and writing the Application.xaml file, we have a requirement that
+/// we do not change the user's formatting, comments, etc.  Thus we can't simply
+/// read in the XML, modify it, and write it back out.  Instead, we have to
+/// modify just the parts we need to directly in the text buffer.  This class
+/// handles that surprisingly complex job.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Ported from the class of the same name in Microsoft.VisualStudio.Editors.
+/// </para>
+/// <para>
+/// References:
+/// <list type="bullet">
+/// <item>XAML Overviews: http://windowssdk.msdn.microsoft.com/en-us/library/ms744825.aspx</item>
+/// <item>Property element syntax: http://windowssdk.msdn.microsoft.com/en-us/library/ms788723(VS.80).aspx#PESyntax</item>
+/// </list>
+/// </para>
+/// </remarks>
+internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXamlDocument.IReplaceText
+{
+    private const string ApplicationElementName = "Application";
+    private const string StartupUriPropertyName = "StartupUri";
+    private const string ShutdownModePropertyName = "ShutdownMode";
+
+    private readonly IVsTextLines _vsTextLines;
+
+    private int _debugBufferLockCount = 0;
+
+    public AppDotXamlDocument(IVsTextLines vsTextLines)
+    {
+        _vsTextLines = vsTextLines;
+    }
+
+    /// <summary>
+    /// Retrieves the text between the given buffer line/char points
+    /// </summary>
+    private string GetText(int startLine, int startIndex, int endLine, int endIndex)
+    {
+        ErrorHandler.ThrowOnFailure(_vsTextLines.GetLineText(startLine, startIndex, endLine, endIndex, out string text));
+        return text;
+    }
+
+    /// <summary>
+    /// Retrieves the text starting at the given point and with the given length
+    /// </summary>
+    private string GetText(int startLine, int startIndex, int count)
+    {
+        ErrorHandler.ThrowOnFailure(_vsTextLines.GetLineText(startLine, startIndex, startLine, startIndex + count, out string text));
+        return text;
+    }
+
+    /// <summary>
+    /// Retrieves the text between the given buffer line/char points
+    /// </summary>
+    private string GetText(Location startLocation, Location endLocation)
+    {
+        return GetText(startLocation.LineIndex, startLocation.CharIndex, endLocation.LineIndex, endLocation.CharIndex);
+    }
+
+    /// <summary>
+    /// Retrieves the text starting at the given point and with the given length
+    /// </summary>
+    private string GetText(Location startLocation, int count)
+    {
+        return GetText(startLocation.LineIndex, startLocation.CharIndex, count);
+    }
+
+    /// <summary>
+    /// Retrieves all of the text in the buffer
+    /// </summary>
+    private string GetAllText()
+    {
+        ErrorHandler.ThrowOnFailure(_vsTextLines.GetLastLineIndex(out int lastLine, out int lastIndex));
+        return GetText(startLine: 0, startIndex: 0, lastLine, lastIndex);
+    }
+
+    /// <summary>
+    /// Escape a string in XML format, including double and single quotes
+    /// </summary>
+    private static string EscapeXmlString(string value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        StringBuilder sb = new();
+        XmlWriterSettings settings = new() { ConformanceLevel = ConformanceLevel.Fragment };
+        XmlWriter xmlWriter = XmlWriter.Create(sb, settings);
+        xmlWriter.WriteString(value);
+        xmlWriter.Close();
+        string escapedString = sb.ToString();
+
+        // Now escape double and single quotes
+        return escapedString.Replace("\"", "&quot;").Replace("'", "&apos;");
+    }
+
+    /// <summary>
+    /// Unescapes an element's content value from escaped XML format.
+    /// </summary>
+    private static string UnescapeXmlString(string value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        // Escape any double quotes
+
+        // Make as content of an element
+        string xml = "<a>" + value + "</a>";
+        StringReader stringReader = new(xml);
+        XmlReaderSettings settings = new() { ConformanceLevel = ConformanceLevel.Fragment };
+        XmlReader xmlReader = XmlReader.Create(stringReader, settings);
+        xmlReader.ReadToFollowing("a");
+
+        string content = xmlReader.ReadElementContentAsString();
+        return content;
+    }
+
+    /// <summary>
+    /// Finds the Application element that all application.xaml files must include as
+    /// the single root node.
+    /// </summary>
+    private static void MoveToApplicationRootElement(XmlTextReader reader)
+    {
+        // XAML files must have only one root element.  For app.xaml, it must be "Application"
+        if (reader.MoveToContent() == XmlNodeType.Element
+            && reader.Name == ApplicationElementName)
+        {
+            // Okay
+            return;
+        }
+
+        throw new XamlReadWriteException(string.Format(VSResources.WPFApp_Xaml_CouldntFindRootElement_1, ApplicationElementName));
+    }
+
+    /// <summary>
+    /// Creates an XmlTextReader for the text
+    /// in the buffer.
+    /// </summary>
+    private XmlTextReader CreateXmlTextReader()
+    {
+        System.Diagnostics.Debug.Assert(_debugBufferLockCount > 0, "Should be using BufferLock!");
+        StringReader stringReader = new(GetAllText());
+        // Required by Fxcop rule CA3054 - DoNotAllowDTDXmlTextReader
+        XmlTextReader xmlTextReader = new(stringReader) { DtdProcessing = DtdProcessing.Prohibit };
+        return xmlTextReader;
+    }
+
+    /// <summary>
+    /// Finds the value of the given property inside the xaml file.  If
+    /// the property is not set in the xaml, an empty string is returned.
+    /// </summary>
+    private string GetApplicationPropertyValue(string propertyName)
+    {
+        using BufferLock bufferLock = new(_vsTextLines, this);
+
+        XmlTextReader reader = CreateXmlTextReader();
+        XamlProperty? prop = FindApplicationPropertyInXaml(reader, propertyName);
+        if (prop is not null)
+        {
+            return prop.UnescapedValue;
+        }
+        else
+        {
+            return string.Empty;
+        }
+    }
+
+    /// <summary>
+    /// Find the closing angle bracket on a single line.
+    /// See comments on FindClosingAngleBracket.
+    /// </summary>
+    /// <returns>The index on the line where the closing angle bracket is found, or -1 if not found.</returns>
+    private static int FindClosingAngleBracketHelper(string line)
+    {
+        int index = 0;
+
+        const char singleQuote = '\'';
+        const char doubleQuote = '"';
+        while (index < line.Length)
+        {
+            // Find the next character of interest
+            index = line.IndexOfAny(new[] { singleQuote, doubleQuote, '/', '>' }, index);
+            if (index < 0)
+            {
+                return -1;
+            }
+
+            char characterOfInterest = line[index];
+            switch (characterOfInterest)
+            {
+                case singleQuote:
+                case doubleQuote:
+                    // We have a string.  Skip past it.
+                    int closingQuote = line.IndexOf(characterOfInterest, index + 1);
+                    if (closingQuote < 0)
+                    {
+                        return -1;
+                    }
+                    else
+                    {
+                        index = closingQuote + 1;
+                    }
+                    break;
+                case '>':
+                    // Found '>'
+                    return index;
+                case '/':
+                    if (line.Substring(index).StartsWith("/>"))
+                    {
+                        // Found "/>"
+                        return index;
+                    }
+                    else
+                    {
+                        // Keep searching past the '/'
+                        index += 1;
+                    }
+                    break;
+                default:
+                    System.Diagnostics.Debug.Fail("We shouldn't reach here");
+                    break;
+            }
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Searches forward from the given location, skipping quoted strings
+    /// (single and double quoted), until it finds a closing angle
+    /// bracket (">" or "/">).
+    /// </summary>
+    /// <param name="startLocation"></param>
+    /// <returns>The location of the found ">" or "/>".  If it is not found, returns <see langword="null"/>.</returns>
+    private Location? FindClosingAngleBracket(Location startLocation)
+    {
+        ErrorHandler.ThrowOnFailure(_vsTextLines.GetLastLineIndex(out int iLastLine, out int iLastIndex));
+
+        for (int iLine = startLocation.LineIndex; iLine <= iLastLine; iLine++)
+        {
+            int iStartIndexForLine;
+            int iEndIndexForLine;
+
+            if (iLine == startLocation.LineIndex)
+            {
+                iStartIndexForLine = startLocation.CharIndex;
+            }
+            else
+            {
+                iStartIndexForLine = 0;
+            }
+
+            if (iLine == iLastLine)
+            {
+                iEndIndexForLine = iLastIndex;
+            }
+            else
+            {
+                ErrorHandler.ThrowOnFailure(_vsTextLines.GetLengthOfLine(iLine, out int iLineLength));
+                iEndIndexForLine = iLineLength;
+            }
+
+            string lineText = GetText(iLine, iStartIndexForLine, iLine, iEndIndexForLine);
+
+            int foundIndex = FindClosingAngleBracketHelper(lineText);
+            if (foundIndex >= 0)
+            {
+                return new Location(iLine, iStartIndexForLine + foundIndex);
+            }
+        }
+
+        // Not found
+        return null;
+    }
+
+    /// <summary>
+    /// From the root of a document, finds the given attribute inside the Application
+    /// element, if it exists.  If not, returns Nothing.
+    /// </summary>
+    private XamlProperty? FindApplicationPropertyInXaml(XmlTextReader reader, string propertyName)
+    {
+        MoveToApplicationRootElement(reader);
+        XamlProperty? prop = FindPropertyAsAttributeInCurrentElement(reader, ApplicationElementName, propertyName);
+        if (prop is null)
+        {
+            prop = FindPropertyAsChildElementInCurrentElement(reader, ApplicationElementName, propertyName);
+        }
+
+        return prop;
+    }
+
+    private XamlPropertyInAttributeSyntax? FindPropertyAsAttributeInCurrentElement(XmlTextReader reader, string optionalPropertyQualifier, string propertyName)
+    {
+        // Look for either simple attribute syntax (StartupUri=xxx) or
+        // fully-qualified attribute syntax (Application.StartupUri=xxx)
+        string? fullyQualifiedPropertyName = string.Empty;
+        if (optionalPropertyQualifier.Length != 0)
+        {
+            fullyQualifiedPropertyName = optionalPropertyQualifier + "." + propertyName;
+        }
+
+        string? foundPropertyName;
+        if (reader.MoveToAttribute(propertyName))
+        {
+            foundPropertyName = propertyName;
+        }
+        else if (fullyQualifiedPropertyName.Length != 0
+            && reader.MoveToAttribute(fullyQualifiedPropertyName))
+        {
+            foundPropertyName = fullyQualifiedPropertyName;
+        }
+        else
+        {
+            // Not found
+            return null;
+        }
+
+        Location startLocation = new(reader);
+        Location boundedEndLocation;
+
+        // Remember the quote character actually found in the XML
+        string quoteCharacterUsedByAttribute = new(reader.QuoteChar, count: 1);
+
+        // Remember the actual value of the property
+        string unescapedValue = reader.Value;
+
+        // Find the end location of the attribute
+        if (reader.MoveToNextAttribute())
+        {
+            boundedEndLocation = new Location(reader);
+        }
+        else
+        {
+            reader.Read();
+            boundedEndLocation = new Location(reader);
+            System.Diagnostics.Debug.Assert(boundedEndLocation.LineIndex >= startLocation.LineIndex);
+            System.Diagnostics.Debug.Assert(boundedEndLocation.LineIndex > startLocation.LineIndex || boundedEndLocation.CharIndex > startLocation.CharIndex);
+        }
+
+        // Now we have an approximate location.  Find the exact location.
+        if (_vsTextLines is not IVsTextFind vsTextFind)
+        {
+            System.Diagnostics.Debug.Fail("IVsTextFind not supported?");
+            throw new InvalidOperationException();
+        }
+        else
+        {
+            // startLocation should be pointing to the attribute name.  Verify that.
+            Location afterAttributeName = new(startLocation.LineIndex, startLocation.CharIndex + foundPropertyName.Length);
+
+            // Find the equals sign ('=')
+            string equalsSign = "=";
+            if (ErrorHandler.Failed(vsTextFind.Find(equalsSign, afterAttributeName.LineIndex, afterAttributeName.CharIndex, boundedEndLocation.LineIndex, boundedEndLocation.CharIndex, 0, out int equalsLine, out int equalsIndex)))
+            {
+                ThrowUnexpectedFormatException(startLocation);
+            }
+            System.Diagnostics.Debug.Assert(equalsSign.Equals(GetText(equalsLine, equalsIndex, 1), StringComparison.Ordinal));
+
+            // Find the starting quote
+            if (ErrorHandler.Failed(vsTextFind.Find(quoteCharacterUsedByAttribute, equalsLine, equalsIndex, boundedEndLocation.LineIndex, boundedEndLocation.CharIndex, 0, out int startQuoteLine, out int startQuoteIndex)))
+            {
+                ThrowUnexpectedFormatException(startLocation);
+            }
+            System.Diagnostics.Debug.Assert(quoteCharacterUsedByAttribute.Equals(GetText(startQuoteLine, startQuoteIndex, 1), StringComparison.Ordinal));
+
+            // Find the ending quote, assuming it's on the same line
+            if (ErrorHandler.Failed(vsTextFind.Find(quoteCharacterUsedByAttribute, startQuoteLine, startQuoteIndex + 1, boundedEndLocation.LineIndex, boundedEndLocation.CharIndex, 0, out int endQuoteLine, out int endQuoteIndex)))
+            {
+                ThrowUnexpectedFormatException(startLocation);
+            }
+            System.Diagnostics.Debug.Assert(quoteCharacterUsedByAttribute.Equals(GetText(endQuoteLine, endQuoteIndex, 1), StringComparison.Ordinal));
+
+            // Now we have the start and end of the attribute's value definition
+            Location valueStart = new(startQuoteLine, startQuoteIndex);
+            Location valueEnd = new(endQuoteLine, endQuoteIndex + 1);
+            return new XamlPropertyInAttributeSyntax(_vsTextLines, valueStart, valueEnd, unescapedValue);
+        }
+    }
+
+    /// <summary>
+    /// From the root of a document, finds the given attribute inside the Application
+    /// element, using property element syntax, if it exists.  If not, returns <see langword="null"/>.
+    /// </summary>
+    private XamlPropertyInPropertyElementSyntax? FindPropertyAsChildElementInCurrentElement(XmlTextReader reader, string propertyQualifier, string propertyName)
+    {
+        // See http://windowssdk.msdn.microsoft.com/en-us/library/ms788723(VS.80).aspx#PESyntax
+        //
+        // Looking for something of this form:
+        // <Application xmlns=...>
+        //   <Application.StartupUri>MainWindow.xaml</Application.StartupUri>
+        // </Application>
+
+        // In this case, the "Application." prefix is required, not optional.
+        string fullyQualifiedPropertyName = propertyQualifier + "." + propertyName;
+
+        if (reader.ReadToDescendant(fullyQualifiedPropertyName))
+        {
+            // Found
+
+            Location tagStart = new(reader);
+            Location tagEnd = new(reader);
+
+            Location? startTagEndingBracketLocation = FindClosingAngleBracket(tagStart);
+            if (startTagEndingBracketLocation is null)
+            {
+                ThrowUnexpectedFormatException(tagStart);
+            }
+
+            if (reader.IsEmptyElement)
+            {
+                // It's an empty tag of the form <xyz/>.  The reader is at the 'x' in "xyz", so the
+                // beginning is at -1 from that location.
+                Location elementTagStart = new Location(reader).Shift(-1);
+
+                // Read through the start tag
+                if (!reader.Read())
+                {
+                    ThrowUnexpectedFormatException(tagStart);
+                }
+
+                // The reader is now right after the empty element tag
+                Location elementTagEndPlusOne = new(reader);
+                return new XamlPropertyInPropertyElementSyntaxWithEmptyTag(_vsTextLines, fullyQualifiedPropertyName, elementTagStart, elementTagEndPlusOne);
+            }
+            else
+            {
+                Location? valueStart;
+                string unescapedValue;
+
+                // Find the start of the content (reader's location after doing a Read through
+                // the element will not give us reliable results, since it depends on the type of
+                // node following the start tag).
+                valueStart = FindClosingAngleBracket(new Location(reader).Shift(1)); // +1 to get past the ">"
+                if (valueStart is null)
+                {
+                    ThrowUnexpectedFormatException(tagStart);
+                }
+
+                // Read through the start tag
+                if (!reader.Read())
+                {
+                    ThrowUnexpectedFormatException(tagStart);
+                }
+
+                // Unfortunately, simply doing a ReadInnerXml() will take us too far.  We need to know
+                // exactly where the value ends in the text, so we'll read manually.
+
+                while (reader.NodeType != XmlNodeType.EndElement
+                       || !fullyQualifiedPropertyName.Equals(reader.Name, StringComparison.Ordinal))
+                {
+                    if (!reader.Read())
+                    {
+                        // End tag not found
+                        ThrowUnexpectedFormatException(tagStart);
+                    }
+                }
+
+                // Reader is at location 'x' of </xyz>.  So we want -2 from this location.
+                Location currentPosition2 = new(reader);
+                Location valueEndPlusOne = new Location(reader).Shift(-2);
+
+                // Get the inner text and unescape it.
+                string innerText = GetText(valueStart, valueEndPlusOne);
+                unescapedValue = UnescapeXmlString(innerText).Trim();
+
+                return new XamlPropertyInPropertyElementSyntax(_vsTextLines, valueStart, valueEndPlusOne, unescapedValue);
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the location where a new attribute can be added to the
+    /// Application root element.  Returns <see langword="null"/> if can't find the
+    /// correct position.
+    /// </summary>
+    private Location? FindLocationToAddNewApplicationAttribute()
+    {
+        using BufferLock bufferLock = new(_vsTextLines, this);
+
+        XmlTextReader reader = CreateXmlTextReader();
+        MoveToApplicationRootElement(reader);
+        return FindClosingAngleBracket(new Location(reader));
+    }
+
+    private void SetApplicationPropertyValue(string propertyName, string? value)
+    {
+        if (value is null)
+        {
+            value = string.Empty;
+        }
+
+        using BufferLock bufferLock = new(_vsTextLines, this);
+
+        XmlTextReader reader = CreateXmlTextReader();
+        XamlProperty? prop = FindApplicationPropertyInXaml(reader, propertyName);
+
+        if (prop is not null)
+        {
+            // The property is already in the .xaml.
+            prop.SetProperty(this, value);
+        }
+        else
+        {
+            // It's not in the .xaml yet.  We'll add this xxx=yyy definition
+            // as the last attribute in the Application element.
+            if (value.Length == 0)
+            {
+                // The new value is blank, just like the current value.
+                // Don't change anything.
+                return;
+            }
+
+            Location? replaceStart = FindLocationToAddNewApplicationAttribute();
+            if (replaceStart is null)
+            {
+                ThrowUnexpectedFormatException(new Location(0, 0));
+            }
+            Location replaceEnd = replaceStart;
+            string newText = propertyName + "=\"" + EscapeXmlString(value) + "\"";
+
+            // Is the anything non-whitespace on the line where we're adding the
+            // new code?  If so, put in a CR/LF pair before it.
+            if (replaceStart.CharIndex > 0)
+            {
+                string lineTextBeforeInsertion = GetText(replaceStart.LineIndex, 0, replaceStart.LineIndex, replaceStart.CharIndex);
+                if (lineTextBeforeInsertion.Trim().Length > 0)
+                {
+                    newText = "\r\n" + newText;
+                }
+            }
+
+            // We know where to replace, so go ahead and do it.
+            ((IReplaceText)this).ReplaceText(replaceStart, replaceEnd, newText);
+        }
+    }
+
+    /// <summary>
+    /// Replace the text at the given location in the buffer with new text.
+    /// </summary>
+    private void ReplaceText(Location sourceStart, int sourceLength, string newText)
+    {
+        ((IReplaceText)this).ReplaceText(sourceStart, new Location(sourceStart.LineIndex, sourceStart.CharIndex + sourceLength), newText);
+    }
+
+    /// <summary>
+    /// Replace the text at the given location in the buffer with new text.
+    /// </summary>
+    void IReplaceText.ReplaceText(Location sourceStart, Location sourceEnd, string newText)
+    {
+        IntPtr bstrNewText = Marshal.StringToBSTR(newText);
+        try
+        {
+            ErrorHandler.ThrowOnFailure(_vsTextLines.ReplaceLines(
+                sourceStart.LineIndex, sourceStart.CharIndex,
+                sourceEnd.LineIndex, sourceEnd.CharIndex,
+                bstrNewText, newText.Length, null));
+        }
+        finally
+        {
+            Marshal.FreeBSTR(bstrNewText);
+        }
+    }
+
+    /// <summary>
+    /// Given the location of the start of an element tag, makes sure that it has an end tag.
+    /// If the element tag is closed by "/>" instead of an end element, it is expanded
+    /// into a start and end tag.
+    /// </summary>
+    /// <param name="tagStartLocation"></param>
+    /// <param name="elementName">The name of the element at the given location</param>
+    private void MakeSureElementHasStartAndEndTag(Location tagStartLocation, string elementName)
+    {
+        if (!"<".Equals(GetText(tagStartLocation, 1), StringComparison.Ordinal))
+        {
+            System.Diagnostics.Debug.Fail("MakeSureElementHasStartAndEndTags: The start location doesn't point to the start of an element tag");
+            ThrowUnexpectedFormatException(tagStartLocation);
+        }
+
+        Location? startTagEndingBracketLocation = FindClosingAngleBracket(tagStartLocation);
+        if (startTagEndingBracketLocation is null)
+        {
+            ThrowUnexpectedFormatException(tagStartLocation);
+        }
+
+        if (">".Equals(GetText(startTagEndingBracketLocation, 1), StringComparison.Ordinal))
+        {
+            // The element tag is of the <xxx> form.  We assume that there is an ending </xxx> tag, and
+            // we don't need to do anything.
+        }
+        else
+        {
+            // It must be an empty tag of the <xxx/> form.
+            string slashAndEndBracket = "/>";
+            if (!slashAndEndBracket.Equals(GetText(startTagEndingBracketLocation, slashAndEndBracket.Length), StringComparison.Ordinal))
+            {
+                System.Diagnostics.Debug.Fail("FindClosingAngleBracket returned the wrong location?");
+                ThrowUnexpectedFormatException(startTagEndingBracketLocation);
+            }
+
+            // We need to change <xxx attributes/> into <xxx attributes></xxx>
+            string newText = "></" + elementName + ">";
+            ReplaceText(startTagEndingBracketLocation, slashAndEndBracket.Length, newText);
+        }
+    }
+
+    /// <summary>
+    /// Finds the value of the StartupUri property inside the xaml file.  If
+    /// the property is not set in the xaml, an empty string is returned.
+    /// </summary>
+    private string GetStartupUri()
+    {
+        return GetApplicationPropertyValue(StartupUriPropertyName);
+    }
+
+    private void SetStartupUri(string value)
+    {
+        SetApplicationPropertyValue(StartupUriPropertyName, value);
+    }
+
+    /// <summary>
+    /// Finds the value of the ShutdownMode property inside the xaml file.  If
+    /// the property is not set in the xaml, an empty string is returned.
+    /// </summary>
+    private string GetShutdownMode()
+    {
+        return GetApplicationPropertyValue(ShutdownModePropertyName);
+    }
+
+    private void SetShutdownMode(string value)
+    {
+        SetApplicationPropertyValue(ShutdownModePropertyName, value);
+    }
+
+    /// <summary>
+    /// Throw an exception for an unexpected format, with line/col information
+    /// </summary>
+    [DoesNotReturn]
+    private static void ThrowUnexpectedFormatException(Location location)
+    {
+        throw new XamlReadWriteException(string.Format(VSResources.WPFApp_Xaml_UnexpectedFormat_2, location.LineIndex + 1, location.CharIndex + 1));
+    }
+
+    /// <summary>
+    /// Verify the validity of the Application.xaml file, and throw an exception if
+    /// problems are found.
+    /// </summary>
+    private void VerifyAppXamlIsValidAndThrowIfNot()
+    {
+        using BufferLock bufferLock = new(_vsTextLines, this);
+
+        XmlTextReader reader = CreateXmlTextReader();
+        MoveToApplicationRootElement(reader);
+
+        // Read through the Application element, including any child elements, to
+        // ensure everything is properly closed.
+        // The name of the element to find is irrelevant, as there shouldn't be
+        // any elements following Application.
+        reader.ReadToFollowing("Dummy Element");
+
+        // If we made it to here, the .xaml file should be well-formed enough for us to read
+        // it properly.  As a final check, though, try getting some common properties.
+        GetStartupUri();
+        GetShutdownMode();
+    }
+
+    void IDebugLockCheck.OnBufferLock()
+    {
+        _debugBufferLockCount++;
+    }
+
+    void IDebugLockCheck.OnBufferUnlock()
+    {
+        _debugBufferLockCount--;
+        System.Diagnostics.Debug.Assert(_debugBufferLockCount >= 0, "Extra buffer unlock");
+    }
+
+    /// <summary>
+    /// Represents a position in a text buffer.
+    /// </summary>
+    private class Location
+    {
+        /// <summary>
+        /// Zero-based line #
+        /// </summary>
+        public int LineIndex;
+        /// <summary>
+        /// Zero-based character on line
+        /// </summary>
+        public int CharIndex;
+
+        public Location(int lineIndex, int charIndex)
+        {
+            Requires.Range(lineIndex >= 0, nameof(lineIndex));
+            Requires.Range(charIndex >= 0, nameof(charIndex));
+
+            LineIndex = lineIndex;
+            CharIndex = charIndex;
+        }
+
+        /// <summary>
+        /// Creates a location corresponding to the current location of the
+        /// XmlReader
+        /// </summary>
+        public Location(XmlReader reader)
+            : this(((IXmlLineInfo)reader).LineNumber - 1, ((IXmlLineInfo)reader).LinePosition - 1)
+        {
+        }
+
+        public Location Shift(int charIndexToAdd)
+        {
+            return new Location(LineIndex, CharIndex + charIndexToAdd);
+        }
+    }
+
+    /// <summary>
+    /// A simple interface to allow XamlProperty to ask the AppDotXamlDocument to
+    /// make text replacements.
+    /// </summary>
+    private interface IReplaceText
+    {
+        /// <summary>
+        /// Replace the text at the given location in the buffer with new text.
+        /// </summary>
+        void ReplaceText(Location sourceStart, Location sourceEnd, string newText);
+    }
+
+    /// <summary>
+    /// Used by the document to verify BufferLock is used when it's needed
+    /// </summary>
+    private interface IDebugLockCheck
+    {
+        void OnBufferLock();
+        void OnBufferUnlock();
+    }
+
+    /// <summary>
+    /// We need to make sure the buffer doesn't change while we're looking up properties
+    /// and changing them.  Our XmlReader() needs to be in sync with the actual text
+    /// in the buffer. This class keeps the buffer locked until it is disposed.
+    /// </summary>
+    private class BufferLock : IDisposable
+    {
+        private bool _isDisposed;
+        private IVsTextLines? _buffer;
+        private readonly IDebugLockCheck _debugLockCheck;
+
+        public BufferLock(IVsTextLines buffer, IDebugLockCheck debugLockCheck)
+        {
+            Requires.NotNull(buffer, nameof(buffer));
+            Requires.NotNull(debugLockCheck, nameof(debugLockCheck));
+
+            _buffer = buffer;
+            _debugLockCheck = debugLockCheck;
+
+            _buffer.LockBuffer();
+            _debugLockCheck.OnBufferLock();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                if (disposing)
+                {
+                    _buffer?.UnlockBuffer();
+                    _debugLockCheck.OnBufferUnlock();
+                    _buffer = null;
+                }
+
+                _isDisposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+    /// <summary>
+    /// Represents a property value found in the XAML file.
+    /// </summary>
+    [DebuggerDisplay("{ActualDefinitionText}, Value={UnescapedValue}")]
+    private abstract class XamlProperty
+    {
+        protected IVsTextLines VsTextLines;
+
+        private readonly bool _definitionIncludesQuotes;
+        /// <summary>
+        /// Unescaped, translated value of the property from the XmlReader
+        /// </summary>
+        private readonly string _unescapedValue;
+        private readonly Location _startLocation;
+        /// <summary>
+        /// Points to the index *after* the last character in the range, just like IVsTextLines expects
+        /// </summary>
+        private readonly Location _endLocationPlusOne;
+
+        public XamlProperty(IVsTextLines vsTextLines, Location startLocation, Location endLocation, string? unescapedValue, bool definitionIncludesQuotes)
+        {
+            Requires.NotNull(vsTextLines, nameof(vsTextLines));
+            Requires.NotNull(startLocation, nameof(startLocation));
+            Requires.NotNull(endLocation, nameof(endLocation));
+
+            unescapedValue ??= string.Empty;
+
+            _startLocation = startLocation;
+            _endLocationPlusOne = endLocation;
+            _unescapedValue = unescapedValue;
+            VsTextLines = vsTextLines;
+            _definitionIncludesQuotes = definitionIncludesQuotes;
+        }
+
+        /// <summary>
+        /// Retrieves the actual text for the value of the property, unescaped, as it
+        /// appears in the .xaml file.  If DefinitionIncludesQuotes=True, then this
+        /// includes the beginning/ending quote
+        /// </summary>
+        public virtual string ActualDefinitionText
+        {
+            get
+            {
+                ErrorHandler.ThrowOnFailure(VsTextLines.GetLineText(DefinitionStart.LineIndex, DefinitionStart.CharIndex, DefinitionEndPlusOne.LineIndex, DefinitionEndPlusOne.CharIndex, out string buffer));
+                return buffer;
+            }
+        }
+
+        public string UnescapedValue => _unescapedValue;
+        public Location DefinitionStart => _startLocation;
+        public Location DefinitionEndPlusOne => _endLocationPlusOne;
+
+        /// <summary>
+        /// Replace the property's value in the XAML
+        /// </summary>
+        public virtual void SetProperty(IReplaceText replaceTextInstance, string value)
+        {
+            if (UnescapedValue.Equals(value, StringComparison.Ordinal))
+            {
+                // The property value is not changing. Leave things alone.
+                return;
+            }
+
+            // Replace just the string in the buffer with the new value.
+            Location replaceStart = DefinitionStart;
+            Location replaceEnd = DefinitionEndPlusOne;
+            string newText = EscapeXmlString(value);
+            if (_definitionIncludesQuotes)
+            {
+                newText = "\"" + newText + "\"";
+            }
+
+            // We know where to replace, so go ahead and do it.
+            replaceTextInstance.ReplaceText(replaceStart, replaceEnd, newText);
+        }
+    }
+
+    /// <summary>
+    /// Represents a property that was found in the XAML file in attribute syntax
+    /// </summary>
+    private class XamlPropertyInAttributeSyntax : XamlProperty
+    {
+        public XamlPropertyInAttributeSyntax(IVsTextLines vsTextLines, Location definitionStart, Location definitionEnd, string unescapedValue)
+            : base(vsTextLines, definitionStart, definitionEnd, unescapedValue, definitionIncludesQuotes: true)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Represents a property that was found in property element syntax with a start and end tag.
+    /// </summary>
+    private class XamlPropertyInPropertyElementSyntax : XamlProperty
+    {
+        public XamlPropertyInPropertyElementSyntax(IVsTextLines vsTextLines, Location valueStart, Location valueEnd, string unescapedValue)
+            : base(vsTextLines, valueStart, valueEnd, unescapedValue, definitionIncludesQuotes: false)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Represents a property that was found in property element syntax with an empty tag,
+    /// e.g. &lt;Application.StartupUri/>
+    /// </summary>
+    private class XamlPropertyInPropertyElementSyntaxWithEmptyTag : XamlPropertyInPropertyElementSyntax
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        private readonly string _fullyQualifiedPropertyName;
+
+        public XamlPropertyInPropertyElementSyntaxWithEmptyTag(IVsTextLines vsTextLines, string fullyQualifiedPropertyName, Location elementStart, Location elementEnd)
+            : base(vsTextLines, elementStart, elementEnd, unescapedValue: string.Empty)
+        {
+            _fullyQualifiedPropertyName = fullyQualifiedPropertyName;
+        }
+
+        public override string ActualDefinitionText => string.Empty;
+
+        public override void SetProperty(IReplaceText replaceTextInstance, string value)
+        {
+            if (UnescapedValue.Equals(value, StringComparison.Ordinal))
+            {
+                // The property value is not changing. Leave things alone.
+                return;
+            }
+
+            // Replace the empty tag in the buffer with a start/end element tag
+            // and the new value
+            string newText =
+$@"<{_fullyQualifiedPropertyName}>
+{EscapeXmlString(value)}
+</{_fullyQualifiedPropertyName}>";
+
+            // We know where to replace, so go ahead and do it.
+            replaceTextInstance.ReplaceText(DefinitionStart, DefinitionEndPlusOne, newText);
+        }
+    }
+
+    private class XamlReadWriteException : Exception
+    {
+        public XamlReadWriteException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -367,20 +367,8 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error while attaching to process &apos;{1}&apos;:
-        ///{2}
-        ///{3}.
-        /// </summary>
-        internal static string ProjectHotReloadSessionManager_ErrorAttachingToProcess {
-            get {
-                return ResourceManager.GetString("ProjectHotReloadSessionManager_ErrorAttachingToProcess", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to {0}: Error while stopping the session:
-        ///{1}
-        ///{2}.
+        ///   Looks up a localized string similar to Error while stopping the session: {0}
+        ///{1}.
         /// </summary>
         internal static string ProjectHotReloadSessionManager_ErrorStoppingTheSession {
             get {
@@ -389,7 +377,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: Unable to start Hot Reload session: no active process..
+        ///   Looks up a localized string similar to Unable to start Hot Reload session: no active process..
         /// </summary>
         internal static string ProjectHotReloadSessionManager_NoActiveProcess {
             get {
@@ -407,7 +395,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}: The process has exited..
+        ///   Looks up a localized string similar to The process has exited..
         /// </summary>
         internal static string ProjectHotReloadSessionManager_ProcessExited {
             get {
@@ -540,6 +528,24 @@ namespace Microsoft.VisualStudio {
         internal static string WorkingDirecotryInvalid {
             get {
                 return ResourceManager.GetString("WorkingDirecotryInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not find the expected root element &quot;{0}&quot; in the application definition file..
+        /// </summary>
+        internal static string WPFApp_Xaml_CouldntFindRootElement_1 {
+            get {
+                return ResourceManager.GetString("WPFApp_Xaml_CouldntFindRootElement_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The .xaml file was in an unexpected format, near line {0} column {1}..
+        /// </summary>
+        internal static string WPFApp_Xaml_UnexpectedFormat_2 {
+            get {
+                return ResourceManager.GetString("WPFApp_Xaml_UnexpectedFormat_2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -288,4 +288,11 @@ In order to debug this project, add an executable project to this solution which
   <data name="UpdateNamespacePromptMessage" xml:space="preserve">
     <value>Adjust namespaces for moved files?</value>
   </data>
+  <data name="WPFApp_Xaml_CouldntFindRootElement_1" xml:space="preserve">
+    <value>Could not find the expected root element "{0}" in the application definition file.</value>
+  </data>
+  <data name="WPFApp_Xaml_UnexpectedFormat_2" xml:space="preserve">
+    <value>The .xaml file was in an unexpected format, near line {0} column {1}.</value>
+    <comment>{0} is the line number of the problematic XAML, and {1} is the column.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -201,6 +201,16 @@ Pokud chcete projekt ladit, přidejte do řešení spustitelný projekt, který 
         <target state="translated">Chcete upravit obory názvů pro přesunuté soubory?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Pracovní adresář {0} zadaný v ladicím profilu {1} neexistuje.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -201,6 +201,16 @@ Um das Projekt zu debuggen, fügen Sie dieser Projektmappe ein ausführbares Pro
         <target state="translated">Namespaces für verschobene Dateien anpassen?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Das im Debugprofil "{1}" angegebene Arbeitsverzeichnis "{0}" ist nicht vorhanden.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -201,6 +201,16 @@ Para depurar este proyecto, agregue un proyecto ejecutable a esta solución con 
         <target state="translated">¿Desea ajustar los espacios de nombres para los archivos movidos?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">El directorio de trabajo '{0}' especificado en el perfil de depuración '{1}' no existe.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -201,6 +201,16 @@ Pour déboguer ce projet, ajoutez à cette solution un projet exécutable qui fa
         <target state="translated">Ajuster les espaces de noms pour les fichiers déplacés ?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Le répertoire de travail '{0}' spécifié dans le profil de débogage '{1}' n'existe pas.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -201,6 +201,16 @@ Per eseguire il debug del progetto, aggiungere a questa soluzione un progetto es
         <target state="translated">Regolare gli spazi dei nomi per i file spostati??</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">La directory di lavoro '{0}' specificata nel profilo di debug '{1}' non esiste.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -201,6 +201,16 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">移動したファイルの名前空間を調整しますか?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' デバッグ プロファイルに指定した作業ディレクトリ '{0}' が存在しません。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -201,6 +201,16 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">이동된 파일에 대한 네임스페이스를 조정하시겠습니까?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' 디버그 프로필에 지정된 작업 디렉터리 '{0}'이(가) 없습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -201,6 +201,16 @@ Aby debugować ten projekt, dodaj projekt wykonywalny do tego rozwiązania, któ
         <target state="translated">Dostosować przestrzenie nazw dla przeniesionych plików?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Katalog roboczy „{0}” określony w profilu debugowania „{1}” nie istnieje.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -201,6 +201,16 @@ Para depurar esse projeto, adicione um projeto executável a essa solução que 
         <target state="translated">Ajustar namespaces para arquivos movidos?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">O diretório de trabalho '{0}' especificado no perfil de depuração '{1}' não existe.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -201,6 +201,16 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">Настроить пространства имен для перемещенных файлов?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">Рабочий каталог "{0}", указанный в профиле отладки "{1}", не существует.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -201,6 +201,16 @@ Bu projede hata ayıklamak için bu çözüme, kitaplık projesine başvuran bir
         <target state="translated">Taşınan dosyalar için ad alanları ayarlansın mı?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' hata ayıklama profilinde belirtilen '{0}' çalışma dizini yok.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -201,6 +201,16 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">是否调整移动文件的命名空间?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">“{1}”调试配置文件中指定的工作目录“{0}”不存在。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -201,6 +201,16 @@ In order to debug this project, add an executable project to this solution which
         <target state="translated">調整移動檔案的命名空間?</target>
         <note />
       </trans-unit>
+      <trans-unit id="WPFApp_Xaml_CouldntFindRootElement_1">
+        <source>Could not find the expected root element "{0}" in the application definition file.</source>
+        <target state="new">Could not find the expected root element "{0}" in the application definition file.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WPFApp_Xaml_UnexpectedFormat_2">
+        <source>The .xaml file was in an unexpected format, near line {0} column {1}.</source>
+        <target state="new">The .xaml file was in an unexpected format, near line {0} column {1}.</target>
+        <note>{0} is the line number of the problematic XAML, and {1} is the column.</note>
+      </trans-unit>
       <trans-unit id="WorkingDirecotryInvalid">
         <source>The working directory '{0}' specified in the '{1}' debug profile does not exist.</source>
         <target state="translated">'{1}' 偵錯設定檔中指定的工作目錄 '{0}' 不存在。</target>


### PR DESCRIPTION
Port AppDotXamlDocument.vb in Microsoft.VisualStudio.Editors to Microsoft.VisualStudio.ProjectSystem.Managed.VS. In the old property pages for WPF projects, this type supports getting and setting the "Startup URI" and "Shutdown Mode" properties by reading and writing to the Application.xaml via an `IVsTextLines` instance. We will need the same functionality in the new property pages, but also the option to make changes that are not backwards compatible with the old pages. So rather than trying to understand and re-create the behavior in new code I've opted for a straight port of the existing code to C#.

I've opted to move it to C# with only minor changes so we can get the WPF properties working end-to-end as soon as possible, and then we have the option of iterating on the implemenation. So it's not pretty, and not how we would write it now, but we can refactor it later.

As yet nothing consumes this code.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8203)