### PR TITLE
Require valuedefinedincontext property for launch profile page

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -73,10 +73,10 @@
     <PackageReference Include="StreamJsonRpc"                                                         Version="2.11.32-alpha" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.3.63-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.3.63-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.3.63-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.3.63-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.3.195-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.3.195-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.3.195-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.3.195-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
@@ -79,6 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             s_requestedValueProperties.RequireProperty(UIPropertyValueType.EvaluatedValuePropertyName);
             s_requestedValueProperties.RequireProperty(UIPropertyValueType.SupportedValuesPropertyName);
             s_requestedValueProperties.RequireProperty(UIPropertyValueType.UnevaluatedValuePropertyName);
+            s_requestedValueProperties.RequireProperty(UIPropertyValueType.ValueDefinedInContextPropertyName);
             s_requestedValueProperties.Freeze();
 
             s_requestedSupportedValueProperties = new SupportedValuePropertiesAvailableStatus();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -87,8 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
         {
             return await _sourceItemsProvider.GetItemAsync(Content.SchemaName, ci =>
                 // If the filename of this item and the filename of the property's value match, consider those to be related to one another.
-                ci.PropertiesContext.IsProjectFile &&
-                    Path.GetFileName(ci.EvaluatedInclude).Equals(Path.GetFileName(existingPropertyValue), StringComparisons.PropertyLiteralValues));
+                ci.PropertiesContext is { IsProjectFile: true } && Path.GetFileName(ci.EvaluatedInclude).Equals(Path.GetFileName(existingPropertyValue), StringComparisons.PropertyLiteralValues));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageFilePropertyValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageFilePropertyValueProviderBase.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             }
 
             // None items outside of the project file cannot be updated.
-            if (existingItem?.PropertiesContext.IsProjectFile ?? false)
+            if (existingItem?.PropertiesContext?.IsProjectFile ?? false)
             {
                 if (!isEmptyValue)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
@@ -215,6 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public Task RemoveAsync(IProjectItem item, DeleteOptions deleteOptions = DeleteOptions.None)
         {
+            Assumes.NotNull(item.ItemType);
             return RemoveAsync(item.ItemType, item.UnevaluatedInclude, deleteOptions);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
@@ -570,7 +570,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 launchSettingsProvider);
 
             var projectItem = await itemProvider.FindItemByNameAsync("Profile2");
-            var propertiesContext = projectItem!.PropertiesContext;
+            var propertiesContext = projectItem!.PropertiesContext!;
 
             Assert.Equal(expected: @"C:\alpha\beta\gamma.csproj", actual: propertiesContext.File);
             Assert.True(propertiesContext.IsProjectFile);


### PR DESCRIPTION
This is to fix an issue where the property is not obtained in the launch profile page.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8206)