### PR TITLE
Add milliseconds to fast up-to-date check log timestamps

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (value is DateTime time)
                 {
-                    value = time.ToLocalTime();
+                    value = time.ToLocalTime().ToString("yyyyMMdd HH:mm:ss.fff");
                 }
             }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
-                The set of project items was changed more recently ({itemChangedTime.ToLocalTime()}) than the last successful build start time ({lastBuildTime.ToLocalTime()}), not up-to-date.
+                The set of project items was changed more recently ({ToLocalTime(itemChangedTime)}) than the last successful build start time ({ToLocalTime(lastBuildTime)}), not up-to-date.
                     Content item added 'ItemPath1' (CopyToOutputDirectory=Never, TargetPath='')
                     Content item added 'ItemPath2' (CopyToOutputDirectory=Never, TargetPath='')
                 """,
@@ -326,10 +326,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             Adding Compile inputs:
                                 C:\Dev\Solution\Project\CopyMe
                                 C:\Dev\Solution\Project\OtherInput
-                            No inputs are newer than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}). Newest input is '{inputPath}' ({inputTime.ToLocalTime()}).
+                            No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{inputPath}' ({ToLocalTime(inputTime)}).
                             Checking {itemType} item with CopyToOutputDirectory="Always" '{sourcePath}':
-                                Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                                Destination {targetTime.ToLocalTime()}: '{targetPath}'
+                                Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                                Destination {ToLocalTime(targetTime)}: '{targetPath}'
                                 Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".
                             Project is up-to-date.
                             """);
@@ -348,10 +348,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 C:\Dev\Solution\Project\CopyMe
                             Adding Compile inputs:
                                 C:\Dev\Solution\Project\OtherInput
-                            No inputs are newer than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}). Newest input is '{inputPath}' ({inputTime.ToLocalTime()}).
+                            No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{inputPath}' ({ToLocalTime(inputTime)}).
                             Checking {itemType} item with CopyToOutputDirectory="Always" '{sourcePath}':
-                                Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                                Destination {targetTime.ToLocalTime()}: '{targetPath}'
+                                Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                                Destination {ToLocalTime(targetTime)}: '{targetPath}'
                                 Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".
                             Project is up-to-date.
                             """);
@@ -368,10 +368,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 {_projectPath}
                             Adding Compile inputs:
                                 C:\Dev\Solution\Project\OtherInput
-                            No inputs are newer than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}). Newest input is '{inputPath}' ({inputTime.ToLocalTime()}).
+                            No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{inputPath}' ({ToLocalTime(inputTime)}).
                             Checking {itemType} item with CopyToOutputDirectory="Always" '{sourcePath}':
-                                Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                                Destination {targetTime.ToLocalTime()}: '{targetPath}'
+                                Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                                Destination {ToLocalTime(targetTime)}: '{targetPath}'
                                 Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".
                             Project is up-to-date.
                             """);
@@ -389,7 +389,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             {_projectPath}
                         Adding Compile inputs:
                             C:\Dev\Solution\Project\OtherInput
-                        No inputs are newer than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}). Newest input is '{inputPath}' ({inputTime.ToLocalTime()}).
+                        No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{inputPath}' ({ToLocalTime(inputTime)}).
                         Project is up-to-date.
                         """);
                 }
@@ -491,7 +491,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                No inputs are newer than earliest output '{_builtPath}' ({builtTime.ToLocalTime()}). Newest input is '{_inputPath}' ({inputTime.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(builtTime)}). Newest input is '{_inputPath}' ({ToLocalTime(inputTime)}).
                 Project is up-to-date.
                 """);
 
@@ -508,7 +508,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
-                The set of project items was changed more recently ({itemChangeTime.ToLocalTime()}) than the last successful build start time ({lastBuildTime.ToLocalTime()}), not up-to-date.
+                The set of project items was changed more recently ({ToLocalTime(itemChangeTime)}) than the last successful build start time ({ToLocalTime(lastBuildTime)}), not up-to-date.
                     Compile item removed 'Input.cs' (CopyToOutputDirectory=Never, TargetPath='')
                 """,
                 "ProjectItemsChangedSinceLastSuccessfulBuildStart");
@@ -591,7 +591,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                Input Compile item '{_inputPath}' is newer ({inputTime.ToLocalTime()}) than earliest output '{_builtPath}' ({builtTime.ToLocalTime()}), not up-to-date.
+                Input Compile item '{_inputPath}' is newer ({ToLocalTime(inputTime)}) than earliest output '{_builtPath}' ({ToLocalTime(builtTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -636,7 +636,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                Input Compile item '{_inputPath}' is newer ({t1.ToLocalTime()}) than earliest output '{_builtPath}' ({t0.ToLocalTime()}), not up-to-date.
+                Input Compile item '{_inputPath}' is newer ({ToLocalTime(t1)}) than earliest output '{_builtPath}' ({ToLocalTime(t0)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
 
@@ -657,7 +657,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                Input Compile item '{_inputPath}' ({t3.ToLocalTime()}) has been modified since the last successful build started ({t2.ToLocalTime()}), not up-to-date.
+                Input Compile item '{_inputPath}' ({ToLocalTime(t3)}) has been modified since the last successful build started ({ToLocalTime(t2)}), not up-to-date.
                 """,
                 "InputModifiedSinceLastSuccessfulBuildStart");
         }
@@ -702,7 +702,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                Input Compile item '{_inputPath}' is newer ({t1.ToLocalTime()}) than earliest output '{_builtPath}' ({t0.ToLocalTime()}), not up-to-date.
+                Input Compile item '{_inputPath}' is newer ({ToLocalTime(t1)}) than earliest output '{_builtPath}' ({ToLocalTime(t0)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
 
@@ -731,7 +731,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                No inputs are newer than earliest output '{_builtPath}' ({t5.ToLocalTime()}). Newest input is '{_inputPath}' ({t3.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(t5)}). Newest input is '{_inputPath}' ({ToLocalTime(t3)}).
                 Project is up-to-date.
                 """);
         }
@@ -776,7 +776,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                No inputs are newer than earliest output '{_builtPath}' ({t1.ToLocalTime()}). Newest input is '{_inputPath}' ({t0.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(t1)}). Newest input is '{_inputPath}' ({ToLocalTime(t0)}).
                 Project is up-to-date.
                 """);
         }
@@ -818,7 +818,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding Compile inputs:
                     {_inputPath}
-                Input Compile item '{_inputPath}' is newer ({compileItemTime.ToLocalTime()}) than earliest output 'C:\Dev\Solution\Project\Output' ({outputTime.ToLocalTime()}), not up-to-date.
+                Input Compile item '{_inputPath}' is newer ({ToLocalTime(compileItemTime)}) than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(outputTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -861,8 +861,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     Reference1MarkerPath
                 Adding output reference copy marker:
                     C:\Dev\Solution\Project\Marker
-                Latest write timestamp on input marker is {originalTime.ToLocalTime()} on 'Reference1OriginalPath'.
-                Write timestamp on output marker is {outputTime.ToLocalTime()} on 'C:\Dev\Solution\Project\Marker'.
+                Latest write timestamp on input marker is {ToLocalTime(originalTime)} on 'Reference1OriginalPath'.
+                Write timestamp on output marker is {ToLocalTime(outputTime)} on 'C:\Dev\Solution\Project\Marker'.
                 Input marker is newer than output marker, not up-to-date.
                 """,
                 "InputMarkerNewerThanOutputMarker");
@@ -902,7 +902,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding ResolvedAnalyzerReference inputs:
                     {analyzerItem}
-                Input ResolvedAnalyzerReference item '{analyzerItem}' is newer ({inputTime.ToLocalTime()}) than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}), not up-to-date.
+                Input ResolvedAnalyzerReference item '{analyzerItem}' is newer ({ToLocalTime(inputTime)}) than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -948,7 +948,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding ResolvedCompilationReference inputs:
                     {resolvedReferencePath}
-                Input ResolvedCompilationReference item 'C:\Dev\Solution\Project\Reference1ResolvedPath' is newer ({inputTime.ToLocalTime()}) than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}), not up-to-date.
+                Input ResolvedCompilationReference item 'C:\Dev\Solution\Project\Reference1ResolvedPath' is newer ({ToLocalTime(inputTime)}) than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -986,7 +986,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding UpToDateCheckInput inputs:
                     C:\Dev\Solution\Project\Item1
-                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Item1' is newer ({inputTime.ToLocalTime()}) than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}), not up-to-date.
+                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Item1' is newer ({ToLocalTime(inputTime)}) than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -1023,13 +1023,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
-                No inputs are newer than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}). Newest input is '{_projectPath}' ({_projectFileTimeUtc.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
                 Comparing timestamps of inputs and outputs in Set="Set1":
                     Adding UpToDateCheckOutput outputs in Set="Set1":
                         C:\Dev\Solution\Project\Output1
                     Adding UpToDateCheckInput inputs in Set="Set1":
                         C:\Dev\Solution\Project\Input1
-                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input1' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\Dev\Solution\Project\Output1' ({outputTime.ToLocalTime()}), not up-to-date.
+                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input1' is newer ({ToLocalTime(inputTime)}) than earliest output 'C:\Dev\Solution\Project\Output1' ({ToLocalTime(outputTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -1070,19 +1070,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
-                No inputs are newer than earliest output '{_builtPath}' ({outputTime1.ToLocalTime()}). Newest input is '{_projectPath}' ({_projectFileTimeUtc.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime1)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
                 Comparing timestamps of inputs and outputs in Set="Set1":
                     Adding UpToDateCheckOutput outputs in Set="Set1":
                         C:\Dev\Solution\Project\Output1
                     Adding UpToDateCheckInput inputs in Set="Set1":
                         C:\Dev\Solution\Project\Input1
-                    In Set="Set1", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\Dev\Solution\Project\Input1' ({inputTime1.ToLocalTime()}).
+                    In Set="Set1", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output1' ({ToLocalTime(outputTime1)}). Newest input is 'C:\Dev\Solution\Project\Input1' ({ToLocalTime(inputTime1)}).
                 Comparing timestamps of inputs and outputs in Set="Set2":
                     Adding UpToDateCheckOutput outputs in Set="Set2":
                         C:\Dev\Solution\Project\Output2
                     Adding UpToDateCheckInput inputs in Set="Set2":
                         C:\Dev\Solution\Project\Input2
-                    In Set="Set2", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output2' ({outputTime2.ToLocalTime()}). Newest input is 'C:\Dev\Solution\Project\Input2' ({inputTime2.ToLocalTime()}).
+                    In Set="Set2", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output2' ({ToLocalTime(outputTime2)}). Newest input is 'C:\Dev\Solution\Project\Input2' ({ToLocalTime(inputTime2)}).
                 Project is up-to-date.
                 """);
         }
@@ -1122,19 +1122,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
-                No inputs are newer than earliest output '{_builtPath}' ({outputTime1.ToLocalTime()}). Newest input is '{_projectPath}' ({_projectFileTimeUtc.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime1)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
                 Comparing timestamps of inputs and outputs in Set="Set1":
                     Adding UpToDateCheckOutput outputs in Set="Set1":
                         C:\Dev\Solution\Project\Output1
                     Adding UpToDateCheckInput inputs in Set="Set1":
                         C:\Dev\Solution\Project\Input1
-                    In Set="Set1", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output1' ({outputTime1.ToLocalTime()}). Newest input is 'C:\Dev\Solution\Project\Input1' ({inputTime1.ToLocalTime()}).
+                    In Set="Set1", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output1' ({ToLocalTime(outputTime1)}). Newest input is 'C:\Dev\Solution\Project\Input1' ({ToLocalTime(inputTime1)}).
                 Comparing timestamps of inputs and outputs in Set="Set2":
                     Adding UpToDateCheckOutput outputs in Set="Set2":
                         C:\Dev\Solution\Project\Output2
                     Adding UpToDateCheckInput inputs in Set="Set2":
                         C:\Dev\Solution\Project\Input2
-                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input2' is newer ({inputTime2.ToLocalTime()}) than earliest output 'C:\Dev\Solution\Project\Output2' ({outputTime2.ToLocalTime()}), not up-to-date.
+                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input2' is newer ({ToLocalTime(inputTime2)}) than earliest output 'C:\Dev\Solution\Project\Output2' ({ToLocalTime(outputTime2)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -1172,19 +1172,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
-                No inputs are newer than earliest output '{_builtPath}' ({outputTime1.ToLocalTime()}). Newest input is '{_projectPath}' ({_projectFileTimeUtc.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime1)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
                 Comparing timestamps of inputs and outputs in Set="Set1":
                     Adding UpToDateCheckOutput outputs in Set="Set1":
                         C:\Dev\Solution\Project\Output1
                     Adding UpToDateCheckInput inputs in Set="Set1":
                         C:\Dev\Solution\Project\Input.cs
-                    In Set="Set1", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output1' ({outputTime1.ToLocalTime()}). Newest input is '{_inputPath}' ({inputTime.ToLocalTime()}).
+                    In Set="Set1", no inputs are newer than earliest output 'C:\Dev\Solution\Project\Output1' ({ToLocalTime(outputTime1)}). Newest input is '{_inputPath}' ({ToLocalTime(inputTime)}).
                 Comparing timestamps of inputs and outputs in Set="Set2":
                     Adding UpToDateCheckOutput outputs in Set="Set2":
                         C:\Dev\Solution\Project\Output2
                     Adding UpToDateCheckInput inputs in Set="Set2":
                         C:\Dev\Solution\Project\Input.cs
-                Input UpToDateCheckInput item '{_inputPath}' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\Dev\Solution\Project\Output2' ({outputTime2.ToLocalTime()}), not up-to-date.
+                Input UpToDateCheckInput item '{_inputPath}' is newer ({ToLocalTime(inputTime)}) than earliest output 'C:\Dev\Solution\Project\Output2' ({ToLocalTime(outputTime2)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput");
         }
@@ -1219,7 +1219,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
-                No inputs are newer than earliest output '{_builtPath}' ({buildTime.ToLocalTime()}). Newest input is '{_projectPath}' ({_projectFileTimeUtc.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(buildTime)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
                 Comparing timestamps of inputs and outputs in Set="Set1":
                     No build outputs defined in Set="Set1".
                 Project is up-to-date.
@@ -1255,7 +1255,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
-                No inputs are newer than earliest output '{_builtPath}' ({outputTime.ToLocalTime()}). Newest input is '{_projectPath}' ({_projectFileTimeUtc.ToLocalTime()}).
+                No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
                 Comparing timestamps of inputs and outputs in Set="Set1":
                     Adding UpToDateCheckOutput outputs in Set="Set1":
                         C:\Dev\Solution\Project\Output1
@@ -1303,7 +1303,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {_projectPath}
                 Adding UpToDateCheckInput inputs:
                     C:\Dev\Solution\Project\Input
-                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input' is newer ({inputTime.ToLocalTime()}) than earliest output 'C:\Dev\Solution\Project\Output' ({outputTime.ToLocalTime()}), not up-to-date.
+                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input' is newer ({ToLocalTime(inputTime)}) than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(outputTime)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput",
                 ignoreKinds: "Ignored");
@@ -1353,7 +1353,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Adding UpToDateCheckInput inputs:
                     C:\Dev\Solution\Project\TaggedInput
                     C:\Dev\Solution\Project\Input
-                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input' is newer ({input1Time.ToLocalTime()}) than earliest output 'C:\Dev\Solution\Project\Output' ({output1Time.ToLocalTime()}), not up-to-date.
+                Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input' is newer ({ToLocalTime(input1Time)}) than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(output1Time)}), not up-to-date.
                 """,
                 "InputNewerThanEarliestOutput",
                 ignoreKinds: "");
@@ -1399,7 +1399,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Adding UpToDateCheckInput inputs:
                     C:\Dev\Solution\Project\Input
                         Skipping 'C:\Dev\Solution\Project\IgnoredInput' with ignored Kind="Ignored"
-                No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({outputTime.ToLocalTime()}). Newest input is 'C:\Dev\Solution\Project\Input' ({inputTime.ToLocalTime()}).
+                No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(outputTime)}). Newest input is 'C:\Dev\Solution\Project\Input' ({ToLocalTime(inputTime)}).
                 Project is up-to-date.
                 """,
                 ignoreKinds: "Ignored");
@@ -1450,7 +1450,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Adding UpToDateCheckInput inputs:
                     C:\Dev\Solution\Project\TaggedInput
                     C:\Dev\Solution\Project\Input
-                No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({output4Time.ToLocalTime()}). Newest input is 'C:\Dev\Solution\Project\TaggedInput' ({inputTime.ToLocalTime()}).
+                No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(output4Time)}). Newest input is 'C:\Dev\Solution\Project\TaggedInput' ({ToLocalTime(inputTime)}).
                 Project is up-to-date.
                 """,
                 ignoreKinds: "");
@@ -1484,8 +1484,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                    Destination {ToLocalTime(destinationTime)}: '{destinationPath}'
                 Source is newer than build output destination, not up-to-date.
                 """,
                 "CopySourceNewer");
@@ -1539,8 +1539,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     $"""
                     No build outputs defined.
                     Checking {itemType} item with CopyToOutputDirectory="PreserveNewest" '{sourcePath}':
-                        Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                        Destination {destinationTime.ToLocalTime()}: '{destinationPath}'
+                        Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                        Destination {ToLocalTime(destinationTime)}: '{destinationPath}'
                     {itemType} item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date.
                     """,
                     "CopyToOutputDirectorySourceNewer");
@@ -1599,7 +1599,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking copied output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
                 Destination '{destinationPath}' does not exist for copy from '{sourcePath}', not up-to-date.
                 """,
                 "CopyDestinationNotFound");
@@ -1633,8 +1633,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking Content item with CopyToOutputDirectory="PreserveNewest" '{sourcePath}':
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                    Destination {ToLocalTime(destinationTime)}: '{destinationPath}'
                 Content item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date.
                 """,
                 "CopyToOutputDirectorySourceNewer");
@@ -1668,8 +1668,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking Content item with CopyToOutputDirectory="PreserveNewest" '{sourcePath}':
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                    Destination {ToLocalTime(destinationTime)}: '{destinationPath}'
                 Content item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date.
                 """,
                 "CopyToOutputDirectorySourceNewer");
@@ -1703,8 +1703,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking Content item with CopyToOutputDirectory="PreserveNewest" '{sourcePath}':
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                    Destination {ToLocalTime(destinationTime)}: '{destinationPath}'
                 Content item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date.
                 """,
                 "CopyToOutputDirectorySourceNewer");
@@ -1740,8 +1740,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking Content item with CopyToOutputDirectory="PreserveNewest" '{sourcePath}':
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
-                    Destination {destinationTime.ToLocalTime()}: '{destinationPath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
+                    Destination {ToLocalTime(destinationTime)}: '{destinationPath}'
                 Content item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath}' is newer than destination '{destinationPath}', not up-to-date.
                 """,
                 "CopyToOutputDirectorySourceNewer");
@@ -1804,7 +1804,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 $"""
                 No build outputs defined.
                 Checking Content item with CopyToOutputDirectory="PreserveNewest" '{sourcePath}':
-                    Source {sourceTime.ToLocalTime()}: '{sourcePath}'
+                    Source {ToLocalTime(sourceTime)}: '{sourcePath}'
                 Destination '{destinationPath}' does not exist, not up-to-date.
                 """,
                 "CopyToOutputDirectoryDestinationNotFound");
@@ -1881,6 +1881,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         }
 
         #region Test helpers
+
+        private static string ToLocalTime(DateTime time)
+        {
+            return time.ToLocalTime().ToString("yyyyMMdd HH:mm:ss.fff");
+        }
 
         private async Task AssertNotUpToDateAsync(string? expectedLogOutput = null, string? telemetryReason = null, BuildAction buildAction = BuildAction.Build, string ignoreKinds = "", string targetFramework = "")
         {


### PR DESCRIPTION
Fixes #8211

Previously we used the default `DateTime` formatting, which shows whole seconds. Some kinds of investigation benefit from seeing millisecond level timing information.

---

Note, for some reason on my local machine several tests in `BuildUpToDateCheckTests` are failing due to a different enumeration order of internal immutable collections. I'm unclear on what changed to cause this problem, and am equally unclear on whether we'll see these failures in CI.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8214)