### PR TITLE
Add project capability for the property system

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -92,6 +92,7 @@
     <ProjectCapability Include="ProjectImportsTree" />
     <ProjectCapability Include="LaunchProfiles" />
     <ProjectCapability Include="NoGeneralDependentFileIcon"/>
+    <ProjectCapability Include="ProjectPropertyInterception" />
     <ProjectCapability Include="PackageReferences" Condition="'$(RestoreProjectStyle)' == 'PackageReference'"/>
     
     <!--

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapability.cs
@@ -33,6 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public const string DotNetLanguageService = DotNet + " & " + LanguageService;
         public const string UseProjectEvaluationCache = ProjectCapabilities.UseProjectEvaluationCache;
         public const string SingleTargetBuildForStartupProjects = nameof(SingleTargetBuildForStartupProjects);
+        public const string ProjectPropertyInterception = nameof(ProjectPropertyInterception);
 
         /// <summary>
         /// Instructs CPS to order tree items according to the <see cref="IProjectTree2.DisplayOrder"/> property first.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("ProjectFileWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "ProjectFileWithInterception")]
-    [AppliesTo(ProjectCapability.DotNet)]
+    [AppliesTo(ProjectCapability.ProjectPropertyInterception)]
     internal sealed class ProjectFileInterceptedProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedViaSnapshotProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedViaSnapshotProjectPropertiesProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "ProjectFileWithInterceptionViaSnapshot")]
     [ExportMetadata("HasEquivalentProjectInstancePropertiesProvider", true)]
-    [AppliesTo(ProjectCapability.DotNet)]
+    [AppliesTo(ProjectCapability.ProjectPropertyInterception)]
     internal sealed class ProjectFileInterceptedViaSnapshotProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
         [ImportingConstructor]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("UserFileWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "UserFileWithInterception")]
-    [AppliesTo(ProjectCapability.DotNet)]
+    [AppliesTo(ProjectCapability.ProjectPropertyInterception)]
     internal class UserFileInterceptedProjectPropertiesProvider : InterceptedProjectPropertiesProviderBase
     {
         private const string UserSuffix = ".user";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export("UserFileWithXamlDefaultsWithInterception", typeof(IProjectInstancePropertiesProvider))]
     [Export(typeof(IProjectInstancePropertiesProvider))]
     [ExportMetadata("Name", "UserFileWithXamlDefaultsWithInterception")]
-    [AppliesTo(ProjectCapability.DotNet)]
+    [AppliesTo(ProjectCapability.ProjectPropertyInterception)]
     internal sealed class UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider : UserFileInterceptedProjectPropertiesProvider
     {
         [ImportingConstructor]


### PR DESCRIPTION
Non-.NET projects want to be able to use the property infrastructure, such as .esproj.

Today, they're unable to use property interception because they don't define the .NET project capability.

This change introduces a new capability for these features, and adds that capability to managed projects. This allows other (non-.NET) project types to add this capability to their own design-time targets.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8217)