### PR TITLE
Add WPF-related properties

### DIFF
--- a/build/import/VisualStudio.props
+++ b/build/import/VisualStudio.props
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />    
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" />

--- a/build/import/VisualStudioDesigner.props
+++ b/build/import/VisualStudioDesigner.props
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Data.Services" />
     <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" />
-    <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
     <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <PackageReference Include="Microsoft.VisualStudio.XmlEditor" />
     <PackageReference Include="Microsoft.VSDesigner" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
@@ -170,20 +170,14 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
     /// Finds the value of the given property inside the xaml file.  If
     /// the property is not set in the xaml, an empty string is returned.
     /// </summary>
-    private string GetApplicationPropertyValue(string propertyName)
+    private string? GetApplicationPropertyValue(string propertyName)
     {
         using BufferLock bufferLock = new(_vsTextLines, this);
 
         XmlTextReader reader = CreateXmlTextReader();
         XamlProperty? prop = FindApplicationPropertyInXaml(reader, propertyName);
-        if (prop is not null)
-        {
-            return prop.UnescapedValue;
-        }
-        else
-        {
-            return string.Empty;
-        }
+
+        return prop?.UnescapedValue;
     }
 
     /// <summary>
@@ -628,12 +622,12 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
     /// Finds the value of the StartupUri property inside the xaml file.  If
     /// the property is not set in the xaml, an empty string is returned.
     /// </summary>
-    private string GetStartupUri()
+    public string? GetStartupUri()
     {
         return GetApplicationPropertyValue(StartupUriPropertyName);
     }
 
-    private void SetStartupUri(string value)
+    public void SetStartupUri(string value)
     {
         SetApplicationPropertyValue(StartupUriPropertyName, value);
     }
@@ -642,12 +636,12 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
     /// Finds the value of the ShutdownMode property inside the xaml file.  If
     /// the property is not set in the xaml, an empty string is returned.
     /// </summary>
-    private string GetShutdownMode()
+    public string? GetShutdownMode()
     {
         return GetApplicationPropertyValue(ShutdownModePropertyName);
     }
 
-    private void SetShutdownMode(string value)
+    public void SetShutdownMode(string value)
     {
         SetApplicationPropertyValue(ShutdownModePropertyName, value);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/ApplicationXamlFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/ApplicationXamlFileAccessor.cs
@@ -81,11 +81,6 @@ internal class ApplicationXamlFileAccessor : IApplicationXamlFileAccessor
         }
     }
 
-    public async Task<bool> ApplicationXamlFileExistsAsync()
-    {
-        return !string.IsNullOrEmpty(await GetFilePathAsync(create: false));
-    }
-
     private async Task<AppDotXamlDocument?> TryGetApplicationXamlFileAsync(bool create)
     {
         if (_applicationDotXamlDocument is null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/ApplicationXamlFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/ApplicationXamlFileAccessor.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.WPF;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Design.Serialization;
 using Microsoft.VisualStudio.Shell.Interop;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/ApplicationXamlFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/ApplicationXamlFileAccessor.cs
@@ -1,0 +1,190 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Design.Serialization;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WPF;
+
+[Export(typeof(IApplicationXamlFileAccessor))]
+[AppliesTo(ProjectCapability.DotNet)]
+internal class ApplicationXamlFileAccessor : IApplicationXamlFileAccessor
+{
+    private readonly UnconfiguredProject _project;
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IVsUIService<IVsRunningDocumentTable> _runningDocumentTable;
+    private readonly IProjectThreadingService _threadingService;
+
+    private DocData? _applicationXamlDocdata;
+    private AppDotXamlDocument? _applicationDotXamlDocument;
+
+    [ImportingConstructor]
+    public ApplicationXamlFileAccessor(
+        UnconfiguredProject project,
+        [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
+        IVsUIService<IVsRunningDocumentTable> runningDocumentTable,
+        IProjectThreadingService threadingService)
+    {
+        _project = project;
+        _serviceProvider = serviceProvider;
+        _runningDocumentTable = runningDocumentTable;
+        _threadingService = threadingService;
+    }
+
+    public async Task<string?> GetStartupUriAsync()
+    {
+        await _threadingService.SwitchToUIThread();
+
+        if (await TryGetApplicationXamlFileAsync(create: false) is not AppDotXamlDocument xamlDocument)
+        {
+            return null;
+        }
+
+        return xamlDocument.GetStartupUri();
+    }
+
+    public async Task SetStartupUriAsync(string startupUri)
+    {
+        await _threadingService.SwitchToUIThread();
+
+        AppDotXamlDocument? xamlDocument = await TryGetApplicationXamlFileAsync(create: true);
+
+        if (xamlDocument is not null)
+        {
+            xamlDocument.SetStartupUri(startupUri);
+            SaveDocDataIfOnlyEditor();
+        }
+    }
+
+    public async Task<string?> GetShutdownModeAsync()
+    {
+        await _threadingService.SwitchToUIThread();
+
+        AppDotXamlDocument? xamlDocument = await TryGetApplicationXamlFileAsync(create: false);
+
+        return xamlDocument?.GetShutdownMode();
+    }
+
+    public async Task SetShutdownModeAsync(string shutdownMode)
+    {
+        await _threadingService.SwitchToUIThread();
+
+        AppDotXamlDocument? xamlDocument = await TryGetApplicationXamlFileAsync(create: true);
+
+        if (xamlDocument is not null)
+        {
+            xamlDocument.SetShutdownMode(shutdownMode);
+            SaveDocDataIfOnlyEditor();
+        }
+    }
+
+    public async Task<bool> ApplicationXamlFileExistsAsync()
+    {
+        return !string.IsNullOrEmpty(await GetFilePathAsync(create: false));
+    }
+
+    private async Task<AppDotXamlDocument?> TryGetApplicationXamlFileAsync(bool create)
+    {
+        if (_applicationDotXamlDocument is null)
+        {
+            DocData? docData = await GetDocDataAsync(create);
+
+            if (docData is not null)
+            {
+                if (docData.Buffer is IVsTextLines vsTextLines)
+                {
+                    _applicationDotXamlDocument = new AppDotXamlDocument(vsTextLines);
+                }
+            }
+        }
+
+        return _applicationDotXamlDocument;
+    }
+
+    private void SaveDocDataIfOnlyEditor()
+    {
+        if (_applicationXamlDocdata is null)
+        {
+            return;
+        }
+
+        IntPtr unknownDocData = IntPtr.Zero;
+        uint cookie;
+
+        try
+        {
+            ErrorHandler.ThrowOnFailure(_runningDocumentTable.Value.FindAndLockDocument(
+                (uint)_VSRDTFLAGS.RDT_NoLock,
+                _applicationXamlDocdata.Name,
+                out _,
+                out _,
+                out unknownDocData,
+                out cookie));
+        }
+        finally
+        {
+            if (!unknownDocData.Equals(IntPtr.Zero))
+            {
+                Marshal.Release(unknownDocData);
+            }
+        }
+
+        IVsHierarchy hierarchy;
+        uint itemId;
+        uint editLocks;
+
+        try
+        {
+            ErrorHandler.ThrowOnFailure(_runningDocumentTable.Value.GetDocumentInfo(
+                cookie,
+                out _,
+                out _,
+                out editLocks,
+                out _,
+                out hierarchy,
+                out itemId,
+                out unknownDocData));
+        }
+        finally
+        {
+            if (!unknownDocData.Equals(IntPtr.Zero))
+            {
+                Marshal.Release(unknownDocData);
+            }
+        }
+
+        if (editLocks == 1)
+        {
+            // We're the only ones with it open; save the document.
+            ErrorHandler.ThrowOnFailure(_runningDocumentTable.Value.SaveDocuments((uint)__VSRDTSAVEOPTIONS.RDTSAVEOPT_SaveIfDirty, hierarchy, itemId, cookie));
+        }
+    }
+
+    private async Task<DocData?> GetDocDataAsync(bool create)
+    {
+        if (_applicationXamlDocdata is null)
+        {
+            string? filePath = await GetFilePathAsync(create);
+            if (filePath is not null)
+            {
+                _applicationXamlDocdata = new DocData(_serviceProvider, filePath);
+            }
+        }
+
+        return _applicationXamlDocdata;
+    }
+
+    private async Task<string?> GetFilePathAsync(bool create)
+    {
+        SpecialFileFlags flags = SpecialFileFlags.FullPath | SpecialFileFlags.CheckoutIfExists;
+        if (create)
+        {
+            flags |= SpecialFileFlags.CreateIfNotExist;
+        }
+
+        return await _project.GetSpecialFilePathAsync(SpecialFiles.AppXaml, flags);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -43,14 +43,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
         }
 
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            return await GetPropertyValueAsync(defaultProperties);
+            return GetPropertyValueAsync(defaultProperties);
         }
 
-        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            return await GetPropertyValueAsync(defaultProperties);
+            return GetPropertyValueAsync(defaultProperties);
         }
 
         private async Task<string> GetPropertyValueAsync(IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     [ExportInterceptingPropertyValueProvider("UseApplicationFramework", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
@@ -9,8 +11,102 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private const string ApplicationFrameworkMSBuildProperty = "MyType";
         private const string EnabledValue = "WindowsForms";
         private const string DisabledValue = "WindowsFormsWithCustomSubMain";
+        
+        private const string UseWPFMSBuildProperty = "UseWPF";
+        private const string OutputTypeMSBuildProperty = "OutputType";
+        private const string WinExeOutputType = "WinExe";
+        private const string StartupObjectMSBuildProperty = "StartupObject";
+        private const string NoneItemType = "None";
+        private const string ApplicationDefinitionItemType = "ApplicationDefinition";
+
+        private readonly UnconfiguredProject _project;
+        private readonly IProjectItemProvider _sourceItemsProvider;
+
+        [ImportingConstructor]
+        public ApplicationFrameworkValueProvider(
+            UnconfiguredProject project,
+            [Import(ExportContractNames.ProjectItemProviders.SourceFiles)] IProjectItemProvider sourceItemsProvider)
+        {
+            _project = project;
+            _sourceItemsProvider = sourceItemsProvider;
+        }
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        {
+            if (await IsWPFApplicationAsync(defaultProperties))
+            {
+                return await SetPropertyValueForWPFApplicationAsync(unevaluatedPropertyValue, defaultProperties);
+            }
+            else
+            {
+                return await SetPropertyValueForDefaultProjectTypesAsync(unevaluatedPropertyValue, defaultProperties);
+            }
+        }
+
+        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            return await GetPropertyValueAsync(defaultProperties);
+        }
+
+        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        {
+            return await GetPropertyValueAsync(defaultProperties);
+        }
+
+        private async Task<string> GetPropertyValueAsync(IProjectProperties defaultProperties)
+        {
+            if (await IsWPFApplicationAsync(defaultProperties))
+            {
+                return await GetPropertyValueForWPFApplicationAsync(defaultProperties);
+            }
+            else
+            {
+                return await GetPropertyValueForDefaultProjectTypesAsync(defaultProperties);
+            }
+        }
+
+        private async Task<string> GetPropertyValueForWPFApplicationAsync(IProjectProperties defaultProperties)
+        {
+            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+            if (!string.IsNullOrEmpty(startupObject))
+            {
+                // A start-up object is specified for this project. This takes precedence over the Startup URI, so set Use Application Framework to "false".
+                return "false";
+            }
+
+            string? appXamlFilePath = await GetAppXamlRelativeFilePathAsync(create: false);
+            if (string.IsNullOrEmpty(appXamlFilePath))
+            {
+                // No Application.xaml file; set Use Application Framework to "false".
+                return "false";
+            }
+
+            return "true";
+        }
+
+        private static async Task<string> GetPropertyValueForDefaultProjectTypesAsync(IProjectProperties defaultProperties)
+        {
+            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+
+            return value switch
+            {
+                EnabledValue => "true",
+                DisabledValue => "false",
+                _ => string.Empty
+            };
+        }
+
+        private static async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
+        {
+            string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWPFMSBuildProperty);
+            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypeMSBuildProperty);
+
+            return bool.TryParse(useWPFString, out bool useWPF)
+                && useWPF
+                && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputType);
+        }
+
+        private static async Task<string?> SetPropertyValueForDefaultProjectTypesAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             if (bool.TryParse(unevaluatedPropertyValue, out bool value))
             {
@@ -25,31 +121,70 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, DisabledValue);
                 }
             }
+
             return null;
         }
 
-        public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+        private async Task<string?> GetAppXamlRelativeFilePathAsync(bool create)
         {
-            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+            SpecialFileFlags flags = create ? SpecialFileFlags.CreateIfNotExist : 0;
 
-            return value switch
-            {
-                EnabledValue => "true",
-                DisabledValue => "false",
-                _ => string.Empty
-            };
+            return await _project.GetSpecialFilePathAsync(SpecialFiles.AppXaml, flags);
         }
 
-        public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        private async Task<string?> SetPropertyValueForWPFApplicationAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string? value = await defaultProperties.GetUnevaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
-
-            return value switch
+            if (bool.TryParse(unevaluatedPropertyValue, out bool value))
             {
-                EnabledValue => "true",
-                DisabledValue => "false",
-                _ => string.Empty
-            };
+                if (value)
+                {
+                    // Enabled
+
+                    // Create the Application.xaml if it doesn't exist. We don't care about the path, we just need it to be created.
+                    string? appXamlFilePath = await GetAppXamlRelativeFilePathAsync(create: true);
+                    if (appXamlFilePath is not null)
+                    {
+                        IEnumerable<IProjectItem> matchingItems = await _sourceItemsProvider.GetItemsAsync(NoneItemType, appXamlFilePath);
+                        IProjectItem? appXamlItem = matchingItems.FirstOrDefault();
+                        if (appXamlItem is not null)
+                        {
+                            await appXamlItem.SetItemTypeAsync(ApplicationDefinitionItemType);
+                        }
+                    }
+
+                    // Clear out the StartupObject if it has a value.
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    if (!string.IsNullOrEmpty(startupObject))
+                    {
+                        await defaultProperties.DeletePropertyAsync(StartupObjectMSBuildProperty);
+                    }
+                }
+                else
+                {
+                    // Disabled
+
+                    // Set the StartupObject if it doesn't already have a value.
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    if (string.IsNullOrEmpty(startupObject))
+                    {
+                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, "Sub Main");
+                    }
+
+                    // Set the Application.xaml file's build action to None.
+                    string? appXamlFilePath = await GetAppXamlRelativeFilePathAsync(create: false);
+                    if (appXamlFilePath is not null)
+                    {
+                        IEnumerable<IProjectItem> matchingItems = await _sourceItemsProvider.GetItemsAsync(ApplicationDefinitionItemType, appXamlFilePath);
+                        IProjectItem? appXamlItem = matchingItems.FirstOrDefault();
+                        if (appXamlItem is not null)
+                        {
+                            await appXamlItem.SetItemTypeAsync(NoneItemType);
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CreateOrOpenApplicationXamlValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CreateOrOpenApplicationXamlValueProvider.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+[ExportInterceptingPropertyValueProvider("CreateOrOpenApplicationXaml", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+internal sealed class CreateOrOpenApplicationXamlValueProvider : NoOpInterceptingPropertyValueProvider
+{
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -66,8 +66,6 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
 [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ExactlyOne)]
 internal interface IApplicationXamlFileAccessor
 {
-    Task<bool> ApplicationXamlFileExistsAsync();
-
     Task<string?> GetStartupUriAsync();
     Task SetStartupUriAsync(string startupUri);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+[ExportInterceptingPropertyValueProvider(
+    new[]
+    {
+        StartupURIPropertyName,
+        ShutdownModePropertyName
+    },
+    ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+internal class WPFValueProvider : InterceptingPropertyValueProviderBase
+{
+    private const string StartupURIPropertyName = "StartupURI";
+    private const string ShutdownModePropertyName = "ShutdownMode_WPF";
+
+    private readonly IApplicationXamlFileAccessor _applicationXamlFileAccessor;
+
+    [ImportingConstructor]
+    public WPFValueProvider(IApplicationXamlFileAccessor applicationXamlFileAccessor)
+    {
+        _applicationXamlFileAccessor = applicationXamlFileAccessor;
+    }
+
+    public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return await GetPropertyValueAsync(propertyName);
+    }
+
+    public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return await GetPropertyValueAsync(propertyName);
+    }
+
+    public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+    {
+        switch (propertyName)
+        {
+            case StartupURIPropertyName:
+                await _applicationXamlFileAccessor.SetStartupUriAsync(unevaluatedPropertyValue);
+                break;
+
+            case ShutdownModePropertyName:
+                await _applicationXamlFileAccessor.SetShutdownModeAsync(unevaluatedPropertyValue);
+                break;
+
+            default:
+                throw new InvalidOperationException($"The {nameof(WPFValueProvider)} does not support the '{propertyName}' property.");
+        }
+
+        return null;
+    }
+
+    private async Task<string> GetPropertyValueAsync(string propertyName)
+    {
+        return propertyName switch
+        {
+            StartupURIPropertyName => await _applicationXamlFileAccessor.GetStartupUriAsync() ?? string.Empty,
+            ShutdownModePropertyName => await _applicationXamlFileAccessor.GetShutdownModeAsync() ?? "OnLastWindowClose",
+
+            _ => throw new InvalidOperationException($"The {nameof(WPFValueProvider)} does not support the '{propertyName}' property.")
+        };
+    }
+}
+
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ExactlyOne)]
+internal interface IApplicationXamlFileAccessor
+{
+    Task<bool> ApplicationXamlFileExistsAsync();
+
+    Task<string?> GetStartupUriAsync();
+    Task SetStartupUriAsync(string startupUri);
+
+    Task<string?> GetShutdownModeAsync();
+    Task SetShutdownModeAsync(string shutdownMode);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -24,31 +24,25 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
         _applicationXamlFileAccessor = applicationXamlFileAccessor;
     }
 
-    public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
     {
-        return await GetPropertyValueAsync(propertyName);
+        return GetPropertyValueAsync(propertyName);
     }
 
-    public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
     {
-        return await GetPropertyValueAsync(propertyName);
+        return GetPropertyValueAsync(propertyName);
     }
 
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
-        switch (propertyName)
+        await (propertyName switch
         {
-            case StartupURIPropertyName:
-                await _applicationXamlFileAccessor.SetStartupUriAsync(unevaluatedPropertyValue);
-                break;
+            StartupURIPropertyName => _applicationXamlFileAccessor.SetStartupUriAsync(unevaluatedPropertyValue),
+            ShutdownModePropertyName => _applicationXamlFileAccessor.SetShutdownModeAsync(unevaluatedPropertyValue),
 
-            case ShutdownModePropertyName:
-                await _applicationXamlFileAccessor.SetShutdownModeAsync(unevaluatedPropertyValue);
-                break;
-
-            default:
-                throw new InvalidOperationException($"The {nameof(WPFValueProvider)} does not support the '{propertyName}' property.");
-        }
+            _ => throw new InvalidOperationException($"The {nameof(WPFValueProvider)} does not support the '{propertyName}' property.")
+        });
 
         return null;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.WPF;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 
 [ExportInterceptingPropertyValueProvider(
@@ -61,14 +63,4 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
             _ => throw new InvalidOperationException($"The {nameof(WPFValueProvider)} does not support the '{propertyName}' property.")
         };
     }
-}
-
-[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ExactlyOne)]
-internal interface IApplicationXamlFileAccessor
-{
-    Task<string?> GetStartupUriAsync();
-    Task SetStartupUriAsync(string startupUri);
-
-    Task<string?> GetShutdownModeAsync();
-    Task SetShutdownModeAsync(string shutdownMode);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PageItemEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PageItemEnumProvider.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Rules;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+/// <summary>
+/// Provides the available <c>Page</c> items that may be set as the "Startup URI"
+/// for a WPF application.
+/// </summary>
+[ExportDynamicEnumValuesProvider(nameof(PageItemEnumProvider))]
+[AppliesTo(ProjectCapability.DotNet)]
+internal class PageItemEnumProvider : SingleRuleSupportedValuesProvider
+{
+    [ImportingConstructor]
+    public PageItemEnumProvider(
+        ConfiguredProject project,
+        IProjectSubscriptionService subscriptionService)
+        : base(project, subscriptionService, PageItemRuleProvider.RuleName, useNoneValue: false)
+    {
+    }
+
+    protected override int SortValues(IEnumValue a, IEnumValue b)
+    {
+        return StringComparers.Paths.Compare(a.DisplayName, b.DisplayName);
+    }
+
+    protected override IEnumValue ToEnumValue(KeyValuePair<string, IImmutableDictionary<string, string>> item)
+    {
+        // TODO: Only include items that are defined under the project root, that is, the
+        // ones that can be expressed as a relative path from the project directory.
+        string value = ContainingProject!.TryMakeRelativeToProjectDirectory(item.Key, out string? relativePath)
+            ? relativePath
+            : item.Key;
+
+        return new PageEnumValue(new EnumValue()
+        {
+            Name = value
+        });
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PageItemRuleProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PageItemRuleProvider.cs
@@ -1,0 +1,48 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Rules;
+
+/// <summary>
+/// Defines a <see cref="Rule"/> to extract information to support the <see cref="PageItemEnumProvider"/>.
+/// </summary>
+[ExportRuleObjectProvider(nameof(PageItemRuleProvider), PropertyPageContexts.Project)]
+[AppliesTo(ProjectCapability.DotNet)]
+[Order(0)]
+internal sealed class PageItemRuleProvider : IRuleObjectProvider
+{
+    internal const string RuleName = "PageItemRule";
+
+    private readonly Lazy<List<Rule>> rules = new(CreateRules);
+
+    private static List<Rule> CreateRules()
+    {
+        Rule rule = new();
+
+        rule.BeginInit();
+
+        rule.Name = RuleName;
+        rule.PageTemplate = "generic";
+
+        rule.DataSource = new()
+        {
+            Persistence = "ProjectFile",
+            ItemType = "Page",
+            SourceOfDefaultValue = DefaultValueSourceLocation.AfterContext,
+            HasConfigurationCondition = false
+        };
+
+        rule.EndInit();
+
+        List<Rule> rules = new(capacity: 1) { rule };
+
+        return rules;
+    }
+
+    public IReadOnlyCollection<Rule> GetRules()
+    {
+        return rules.Value;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -8,6 +8,10 @@
     <Category Name="ApplicationFramework"
               DisplayName="Application Framework"
               Description="Application Framework settings." />
+
+    <Category Name="WPF"
+              DisplayName="WPF"
+              Description="Settings specific to WPF applications." />
   </Rule.Categories>
 
   <!-- TODO: Add a hyperlink/button to open the app.manifest. Previously, we had a View Windows Settings button. -->
@@ -172,5 +176,74 @@
         </NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
+  </StringProperty>
+
+  <DynamicEnumProperty Name="StartupURI"
+                       DisplayName="Startup URI"
+                       Description="Specifies the window that will open when the application loads."
+                       EnumProvider="PageItemEnumProvider"
+                       Category="WPF">
+    <DynamicEnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </DynamicEnumProperty.DataSource>
+    <DynamicEnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (and
+            (has-evaluated-value "Application" "UseWPF" true)
+            (has-evaluated-value "Application" "UseApplicationFramework" true)
+            (has-evaluated-value "Application" "OutputType" "WinExe"))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </DynamicEnumProperty.Metadata>
+  </DynamicEnumProperty>
+
+  <EnumProperty Name="ShutdownMode_WPF"
+                DisplayName="Shutdown mode"
+                Description="Specifies when the application should close automatically."
+                Category="WPF">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </EnumProperty.DataSource>
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (and
+            (has-evaluated-value "Application" "UseWPF" true)
+            (has-evaluated-value "Application" "UseApplicationFramework" true)
+            (has-evaluated-value "Application" "OutputType" "WinExe"))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <!-- Note these match the values of the System.Windows.ShutdownMode enum. -->
+    <EnumValue Name="OnLastWindowClose" DisplayName="On last window close" />
+    <EnumValue Name="OnMainWindowClose" DisplayName="On main window close" />
+    <EnumValue Name="OnExplicitShutdown" DisplayName="On explicit shutdown" />
+  </EnumProperty>
+
+  <StringProperty Name="CreateOrOpenApplicationXaml"
+                  DisplayName="Edit XAML"
+                  Description="Open the Application.xaml file"
+                  Category="WPF">
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (and
+            (has-evaluated-value "Application" "UseWPF" true)
+            (has-evaluated-value "Application" "UseApplicationFramework" true)
+            (has-evaluated-value "Application" "OutputType" "WinExe"))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="LinkAction">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="Action" Value="Command" />
+          <NameValuePair Name="Command" Value="CreateOrOpenApplicationXaml" />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
   </StringProperty>
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="new">Application Framework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|WPF|Description">
+        <source>Settings specific to WPF applications.</source>
+        <target state="new">Settings specific to WPF applications.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|WPF|DisplayName">
+        <source>WPF</source>
+        <target state="new">WPF</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DynamicEnumProperty|SplashScreen|Description">
         <source>Sets the form to be used as a splash screen for the application.</source>
         <target state="new">Sets the form to be used as a splash screen for the application.</target>
@@ -60,6 +70,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="new">Splash screen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|Description">
+        <source>Specifies the window that will open when the application loads.</source>
+        <target state="new">Specifies the window that will open when the application loads.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupURI|DisplayName">
+        <source>Startup URI</source>
+        <target state="new">Startup URI</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|AuthenticationMode|Description">
@@ -80,6 +100,16 @@
       <trans-unit id="EnumProperty|HighDpiMode|DisplayName">
         <source>High DPI mode</source>
         <target state="new">High DPI mode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|Description">
+        <source>Specifies when the application should close automatically.</source>
+        <target state="new">Specifies when the application should close automatically.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|ShutdownMode_WPF|DisplayName">
+        <source>Shutdown mode</source>
+        <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|ShutdownMode|Description">
@@ -135,6 +165,31 @@
       <trans-unit id="EnumValue|ShutdownMode.AfterMainFormCloses|DisplayName">
         <source>Shut down when the main form closes.</source>
         <target state="new">Shut down when the main form closes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnExplicitShutdown|DisplayName">
+        <source>On explicit shutdown</source>
+        <target state="new">On explicit shutdown</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnLastWindowClose|DisplayName">
+        <source>On last window close</source>
+        <target state="new">On last window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
+        <source>On main window close</source>
+        <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">
+        <source>Open the Application.xaml file</source>
+        <target state="new">Open the Application.xaml file</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|DisplayName">
+        <source>Edit XAML</source>
+        <target state="new">Edit XAML</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WPF/IApplicationXamlFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WPF/IApplicationXamlFileAccessor.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.WPF;
+
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ExactlyOne)]
+internal interface IApplicationXamlFileAccessor
+{
+    Task<string?> GetStartupUriAsync();
+    Task SetStartupUriAsync(string startupUri);
+
+    Task<string?> GetShutdownModeAsync();
+    Task SetShutdownModeAsync(string shutdownMode);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WPF/IApplicationXamlFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WPF/IApplicationXamlFileAccessor.cs
@@ -2,12 +2,31 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.WPF;
 
+/// <summary>
+/// Provides access to interesting properties of the Application.xaml file.
+/// </summary>
 [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Extension, Cardinality = Composition.ImportCardinality.ExactlyOne)]
 internal interface IApplicationXamlFileAccessor
 {
+    /// <summary>
+    /// Returns the current value of the <see cref="System.Windows.Application.StartupUri"/> property as stored in the Application.xaml file.
+    /// </summary>
+    /// <returns><see langword="null"/> if the Application.xaml does not exist or the property is not specified; the current value otherwise.</returns>
     Task<string?> GetStartupUriAsync();
+
+    /// <summary>
+    /// Sets the current value of the <see cref="System.Windows.Application.StartupUri"/> property in the Application.xaml file. Attempts to create the Application.xaml file if it does not exist.
+    /// </summary>
     Task SetStartupUriAsync(string startupUri);
 
+    /// <summary>
+    /// Returns the current value of the <see cref="System.Windows.Application.ShutdownMode"/> property as stored in the Application.xaml file.
+    /// </summary>
+    /// <returns><see langword="null"/> if the Application.xaml does not exist or the property is not specified; the current value otherwise.</returns>
     Task<string?> GetShutdownModeAsync();
+
+    /// <summary>
+    /// Sets the current value of the <see cref="System.Windows.Application.ShutdownMode"/> property as stored in the Application.xaml file.
+    /// </summary>
     Task SetShutdownModeAsync(string shutdownMode);
 }


### PR DESCRIPTION
Related to #7379.

1. Update the `AppDotXamlDocument` type to support reading and writing the "Startup URI" and "Shutdown Mode" properties. This also involves a change to return `null` when one of these properties is not set in the file, rather than the empty string. This lets the caller distinguish between the value not being set, and being set to an actual empty value.
2. Introduce an `IApplicationXamlFileAccessor` interface and related implementation to manage access to a project's Application.xaml file. This type handles loading the Application.xaml file into a `DocData`, managing the lifetime of the `DocData`, and creating the `AppDotXamlDocument` as needed.
3. Add the `WPFValueProvider` interceptor that uses the `IApplicationXamlFileAccessor` to expose "Startup URI" and "Shutdown Mode" as properties.
4. Update the VB Application property page to include the WPF-related properties, but only show them for projects that produce executables, use WPF, and use the Application Framework.
5. Update the `ApplicationFrameworkValueProvider` to support WPF projects. Checking or unchecking the "Use Application Framework" check box has a much different effect in WPF than other projects; we need to toggle the "StartupObject" property between "Sub Main" (when the application framework is off) and undefined (when it is), and toggle whether or not the Application.xaml file is handled as an "ApplicationDefinition" item type or not. In this commit we basically create two totally different code paths for reading/writing: one for WPF projects, and one for everything else. We may want to revisit this to clean it up.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8220)