### PR TITLE
Add extension for awaiting tuples of tasks

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -852,7 +852,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 globalProperties.TryGetValue(FastUpToDateCheckIgnoresKindsGlobalPropertyName, out string? ignoreKindsString);
 
-                (LogLevel requestedLogLevel, Guid projectGuid) = await(
+                (LogLevel requestedLogLevel, Guid projectGuid) = await (
                     _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token),
                     _guidService.GetProjectGuidAsync(token));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -852,7 +852,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 globalProperties.TryGetValue(FastUpToDateCheckIgnoresKindsGlobalPropertyName, out string? ignoreKindsString);
 
-                (LogLevel requestedLogLevel, Guid projectGuid) = await WhenAll(
+                (LogLevel requestedLogLevel, Guid projectGuid) = await(
                     _projectSystemOptions.GetFastUpToDateLoggingLevelAsync(token),
                     _guidService.GetProjectGuidAsync(token));
 
@@ -939,13 +939,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     _lastFailureReason = logger.FailureReason ?? "";
                 }
-            }
-
-            static async Task<(T1, T2)> WhenAll<T1, T2>(Task<T1> t1, Task<T2> t2)
-            {
-                await Task.WhenAll(t1, t2);
-
-                return (await t1, await t2);
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/TupleTaskExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/TupleTaskExtensions.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Security;
+
+namespace Microsoft.VisualStudio.ProjectSystem;
+
+internal static class TupleTaskExtensions
+{
+    /// <summary>
+    /// Runs the tasks in the tuple concurrently, returning their values as a tuple.
+    /// </summary>
+    /// <typeparam name="T1">Return type of the first task's result.</typeparam>
+    /// <typeparam name="T2">Return type of the second task's result.</typeparam>
+    /// <param name="tasks">A tuple of tasks to return an awaiter for.</param>
+    /// <returns>An awaiter for the tasks in the tuple.</returns>
+    public static TupleTaskAwaiter<T1, T2> GetAwaiter<T1, T2>(this (Task<T1>, Task<T2>) tasks)
+    {
+        return new(tasks);
+    }
+
+    public readonly struct TupleTaskAwaiter<T1, T2> : ICriticalNotifyCompletion
+    {
+        private readonly (Task<T1>, Task<T2>) _tasks;
+
+        private readonly TaskAwaiter _whenAllAwaiter;
+
+        public TupleTaskAwaiter((Task<T1>, Task<T2>) tasks)
+        {
+            _tasks = tasks;
+            _whenAllAwaiter = Task.WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
+        }
+
+        public bool IsCompleted => _whenAllAwaiter.IsCompleted;
+
+        public void OnCompleted(Action continuation)
+        {
+            _whenAllAwaiter.OnCompleted(continuation);
+        }
+
+        [SecurityCritical]
+        public void UnsafeOnCompleted(Action continuation)
+        {
+            _whenAllAwaiter.UnsafeOnCompleted(continuation);
+        }
+
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+        public (T1, T2) GetResult()
+        {
+            _whenAllAwaiter.GetResult();
+
+            return (_tasks.Item1.Result, _tasks.Item2.Result);
+        }
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+    }
+}


### PR DESCRIPTION
Following discussion: https://github.com/dotnet/project-system/pull/8216#pullrequestreview-992880814

When two async tasks can be run concurrently, we should run them that way to reduce overall time. The usual way of doing this is not very ergonomic (see below). Allowing a tuple to be awaited is quite nice. Examples follow.

### Serially

This is slower than it needs to be as the second task cannot start until the first completes.

```c#
var result1 = await DoSomethingAsync();
var result2 = await DoAnotherTaskAsync();
```

### Concurrent (BCL only)

This runs both tasks concurrently, but is harder to read than before.

```c#
var task1 = DoSomethingAsync();
var task2 = DoAnotherTaskAsync();
await Task.WhenAll(task1, task2);
var result1 = await task1;
var result2 = await task2;
```

### Concurrent (With tuples of tasks)

This commit enables awaiting a tuple of tasks. The tasks run run concurrently, and the result of those tasks is a tuple.

```c#
var (result1, result2) = await (DoSomethingAsync(), DoAnotherTaskAsync());
```

---

In future, we may extend this, for example to support more than two items in the tuple, or to support cases where not all tasks return a value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8223)