### PR TITLE
Track project configurations during rebuilds

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -764,7 +764,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _lastBuildStartTimeUtc = buildStartTimeUtc;
         }
 
-        async Task IBuildUpToDateCheckProviderInternal.NotifyBuildCompletedAsync(bool wasSuccessful)
+        async Task IBuildUpToDateCheckProviderInternal.NotifyBuildCompletedAsync(bool wasSuccessful, bool isRebuild)
         {
             if (_lastBuildStartTimeUtc == default)
             {
@@ -778,7 +778,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 ISubscription subscription = Volatile.Read(ref _subscription);
 
-                await subscription.UpdateLastSuccessfulBuildStartTimeUtcAsync(_lastBuildStartTimeUtc);
+                await subscription.UpdateLastSuccessfulBuildStartTimeUtcAsync(_lastBuildStartTimeUtc, isRebuild);
             }
 
             _lastBuildStartTimeUtc = default;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckProviderInternal.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckProviderInternal.cs
@@ -39,6 +39,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// <remarks>
         /// Must also be called for rebuilds.
         /// </remarks>
-        Task NotifyBuildCompletedAsync(bool wasSuccessful);
+        Task NotifyBuildCompletedAsync(bool wasSuccessful, bool isRebuild);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -156,8 +156,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             subscription.Setup(s => s.EnsureInitialized());
 
             subscription
-                .Setup(s => s.UpdateLastSuccessfulBuildStartTimeUtcAsync(It.IsAny<DateTime>()))
-                .Callback((DateTime timeUtc) => _lastSuccessfulBuildStartTime = timeUtc)
+                .Setup(s => s.UpdateLastSuccessfulBuildStartTimeUtcAsync(It.IsAny<DateTime>(), It.IsAny<bool>()))
+                .Callback((DateTime timeUtc, bool isRebuild) => _lastSuccessfulBuildStartTime = timeUtc)
                 .Returns(Task.CompletedTask);
 
             subscription
@@ -719,14 +719,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             // Build (t2)
             ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildStarting(buildStartTimeUtc: t2);
-            await ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompletedAsync(wasSuccessful: true);
+            await ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompletedAsync(wasSuccessful: true, isRebuild: false);
 
             // Modify input (t3)
             _fileSystem.AddFile(_inputPath, t3);
 
             // Rebuild (t4)
             ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildStarting(buildStartTimeUtc: t4);
-            await ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompletedAsync(wasSuccessful: true);
+            await ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompletedAsync(wasSuccessful: true, isRebuild: true);
 
             // Update output (t5)
             _fileSystem.AddFile(_builtPath, t5);
@@ -774,7 +774,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             // Rebuild (t1)
             ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildStarting(buildStartTimeUtc: t1);
-            await ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompletedAsync(wasSuccessful: true);
+            await ((IBuildUpToDateCheckProviderInternal)_buildUpToDateCheck).NotifyBuildCompletedAsync(wasSuccessful: true, isRebuild: true);
 
             // Run test (t2)
             await AssertUpToDateAsync(


### PR DESCRIPTION
Fixes #8231
Fixes [AB#1550661](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1550661)

The fast up-to-date check tracks the set of configurations that are built, in order to remember the time of the last successful build in each configuration.

This needs to be tracked per-configuration because we support single-target builds, for MAUI for example.

Previously, we weren't tracking the last set of configurations in the case of rebuilds. This change corrects that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8232)