### PR TITLE
Improve incremental build failure message

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IIncrementalBuildFailureReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IIncrementalBuildFailureReporter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
         ///   Gets whether this reporter is enabled or not.
         /// </summary>
         /// <remarks>
-        ///   When this method returns <see langword="false"/>, <see cref="ReportFailureAsync(string, TimeSpan, CancellationToken)"/>
+        ///   When this method returns <see langword="false"/>, <see cref="ReportFailureAsync(string, string, TimeSpan, CancellationToken)"/>
         ///   will not be called. If all exports of <see cref="IIncrementalBuildFailureReporter"/> return false, the incremental
         ///   build failure check is not performed at all.
         /// </remarks>
@@ -24,9 +24,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
         ///   Reports an incremental build failure for the project in the current scope.
         /// </summary>
         /// <param name="failureReason">A string that identifies the reason for the failure.</param>
+        /// <param name="failureDescription">A detailed description of the failure. May include file paths and timestamps.</param>
         /// <param name="checkDuration">The duration spent performing the incremental build failure check.</param>
         /// <param name="cancellationToken">A token whose cancellation marks lost interest in the result of this task.</param>
         /// <returns>A task that completes when reporting is done.</returns>
-        Task ReportFailureAsync(string failureReason, TimeSpan checkDuration, CancellationToken cancellationToken);
+        Task ReportFailureAsync(string failureReason, string failureDescription, TimeSpan checkDuration, CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.ProjectChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.ProjectChecker.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                         return;
                     }
 
-                    (bool isUpToDate, string? failureReason) = await validator.ValidateUpToDateAsync(cancellationToken);
+                    (bool isUpToDate, string? failureReason, string? failureDescription) = await validator.ValidateUpToDateAsync(cancellationToken);
 
                     if (isUpToDate)
                     {
@@ -82,12 +82,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                     }
 
                     Assumes.NotNull(failureReason);
+                    Assumes.NotNull(failureDescription);
 
                     TimeSpan checkDuration = sw.Elapsed;
 
                     foreach (IIncrementalBuildFailureReporter reporter in reporters)
                     {
-                        await reporter.ReportFailureAsync(failureReason, checkDuration, cancellationToken);
+                        await reporter.ReportFailureAsync(failureReason, failureDescription, checkDuration, cancellationToken);
                     }
 
                     return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             return featureFlagsService.IsFeatureEnabled("ManagedProjectSystem.EnableIncrementalBuildFailureOutputLogging", defaultValue: false);
         }
 
-        public async Task ReportFailureAsync(string failureReason, TimeSpan checkDuration, CancellationToken cancellationToken)
+        public async Task ReportFailureAsync(string failureReason, string failureDescription, TimeSpan checkDuration, CancellationToken cancellationToken)
         {
             // Report telemetry indicating that we showed this message. This will allow us to compare the number of times this is shown
             // with the click-through rate for more information.
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
 
             if (_outputWindow.Value.GetPane(ref outputPaneGuid, out IVsOutputWindowPane? outputPane) == HResult.OK && outputPane != null)
             {
-                string message = string.Format(VSResources.IncrementalBuildFailureWarningMessage, Path.GetFileName(_project.FullPath));
+                string message = string.Format(VSResources.IncrementalBuildFailureWarningMessage_2, Path.GetFileName(_project.FullPath), failureDescription.TrimEnd(Delimiter.Period));
 
                 outputPane.OutputStringNoPump(message);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureTelemetryReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureTelemetryReporter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             return featureFlagsService.IsFeatureEnabled("ManagedProjectSystem.EnableIncrementalBuildFailureTelemetry", defaultValue: false);
         }
 
-        public Task ReportFailureAsync(string failureReason, TimeSpan checkDuration, CancellationToken cancellationToken)
+        public Task ReportFailureAsync(string failureReason, string failureDescription, TimeSpan checkDuration, CancellationToken cancellationToken)
         {
             Assumes.False(_hasBeenReported);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     Assumes.NotNull(_dataByConfiguredProject);
 
                     if (_dataByConfiguredProject.TryGetValue((projectPath, configurationDimensions), out (int ItemHash, DateTime? ItemsChangedAtUtc, DateTime? LastSuccessfulBuildStartedAtUtc) storedData)
-                        && storedData.LastSuccessfulBuildStartedAtUtc is not null)
+                        && storedData.LastSuccessfulBuildStartedAtUtc is not null and { Ticks: > 0 })
                     {
                         return storedData.LastSuccessfulBuildStartedAtUtc;
                     }
@@ -133,6 +133,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
         public Task StoreLastSuccessfulBuildStateAsync(string projectPath, IImmutableDictionary<string, string> configurationDimensions, DateTime lastSuccessfulBuildStartedAtUtc, CancellationToken cancellationToken)
         {
+            Requires.Argument(lastSuccessfulBuildStartedAtUtc != DateTime.MinValue, nameof(lastSuccessfulBuildStartedAtUtc), "Must not be DateTime.MinValue.");
+
             return ExecuteUnderLockAsync(
                 token =>
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -313,11 +313,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WARNING: Potential incremental build failure in &apos;{0}&apos;. See: https://aka.ms/incremental-build-failure.
+        ///   Looks up a localized string similar to WARNING: Potential incremental build failure in &apos;{0}&apos;. {1}. See https://aka.ms/incremental-build-failure..
         /// </summary>
-        internal static string IncrementalBuildFailureWarningMessage {
+        internal static string IncrementalBuildFailureWarningMessage_2 {
             get {
-                return ResourceManager.GetString("IncrementalBuildFailureWarningMessage", resourceCulture);
+                return ResourceManager.GetString("IncrementalBuildFailureWarningMessage_2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -281,9 +281,9 @@ In order to debug this project, add an executable project to this solution which
   <data name="ProjectHotReloadSessionManager_StartupHooksDisabled" xml:space="preserve">
     <value>Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</value>
   </data>
-  <data name="IncrementalBuildFailureWarningMessage" xml:space="preserve">
-    <value>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</value>
-    <comment>{0} is the file name of the project.</comment>
+  <data name="IncrementalBuildFailureWarningMessage_2" xml:space="preserve">
+    <value>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</value>
+    <comment>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</comment>
   </data>
   <data name="UpdateNamespacePromptMessage" xml:space="preserve">
     <value>Adjust namespaces for moved files?</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} – import pochází z cílového souboru. Tento import nelze odebrat.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">UPOZORNĚNÍ: Potenciální přírůstkové selhání sestavení v {0}. Další informace: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} – Import kommt von der Zieldatei. Dieser Import kann nicht entfernt werden.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">WARNUNG: Potenzieller inkrementeller Buildfehler in "{0}". Siehe: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0}: la importación procede del archivo de destino. Esta importación no se puede quitar.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">ADVERTENCIA: posible error de compilación incremental en “{0}”. Consultar: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - L'importation provient du fichier cible. Impossible de supprimer cette importation.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">AVERTISSEMENT : échec potentiel de build incrémentielle dans '{0}'. Voir : https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - L'importazione proviene dal file di destinazione e non può essere rimossa.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">AVVISO: possibile errore di compilazione incrementale in '{0}'. Vedere: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - インポートは、ターゲット ファイルからのものです。このインポートは削除できません。</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">警告: '{0}' での潜在的な増分ビルド エラー。参照: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - 대상 파일에서 가져옵니다. 이 가져오기는 제거할 수 없습니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">경고: '{0}'에서 증분 빌드 실패가 발생할 수 있습니다. 참조: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} — import pochodzi z pliku docelowego. Nie można usunąć importu.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">OSTRZEŻENIE: Potencjalny przyrostowy błąd kompilacji w „{0}”. Zobacz: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} – a importação é proveniente do arquivo de destino. Essa importação não pode ser removida.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">AVISO: possível falha de build incremental em '{0}'. Consulte: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} — источником импорта является целевой файл. Удалить этот импорт невозможно.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">ПРЕДУПРЕЖДЕНИЕ. Возможный сбой добавочной сборки в "{0}". Сведения: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - İçeri aktarım hedef dosyadan geliyor. Bu içeri aktarım kaldırılamaz.</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">UYARI: '{0}' içinde olası artımlı derleme hatası oluştu. Bkz. https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - 导入项来自目标文件。无法删除此导入。</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">警告:“{0}”中可能的增量生成失败。请参阅: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -110,10 +110,10 @@
         <target state="translated">{0} - 匯入來自目標檔案。此項匯入無法移除。</target>
         <note />
       </trans-unit>
-      <trans-unit id="IncrementalBuildFailureWarningMessage">
-        <source>WARNING: Potential incremental build failure in '{0}'. See: https://aka.ms/incremental-build-failure</source>
-        <target state="translated">警告: '{0}'可能發生累加建置失敗。請參閱: https://aka.ms/incremental-build-failure</target>
-        <note>{0} is the file name of the project.</note>
+      <trans-unit id="IncrementalBuildFailureWarningMessage_2">
+        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Delimiter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Delimiter.cs
@@ -8,9 +8,14 @@ namespace Microsoft.VisualStudio
     internal static class Delimiter
     {
         /// <summary>
-        /// Single, static instance of an array that contains a semi-colon ';', which is used to split strings.
+        /// Single, static instance of an array that contains a semi-colon ';', which is used to split strings, etc.
         /// </summary>
         internal static readonly char[] Semicolon = new char[] { ';' };
+
+        /// <summary>
+        /// Single, static instance of an array that contains a period '.', which is used to split strings, etc.
+        /// </summary>
+        internal static readonly char[] Period = new char[] { '.' };
 
         /// <summary>
         /// Single, static instance of an array that contains '+' and '-' characters.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             public int Indent { get; set; }
 
             public string? FailureReason { get; private set; }
+            public string? FailureDescription { get; private set; }
 
             public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, Guid projectGuid, ITelemetryService? telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput, string? ignoreKinds, int checkNumber)
             {
@@ -168,8 +169,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     (TelemetryPropertyName.UpToDateCheckIgnoreKinds, _ignoreKinds ?? "")
                 });
 
-                // Remember the failure reason for use in IncrementalBuildFailureDetector.
+                // Remember the failure reason and description for use in IncrementalBuildFailureDetector.
                 FailureReason = reason;
+                FailureDescription = string.Format(GetResourceString(resourceName), values);
 
                 return false;
             }
@@ -177,6 +179,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             public void UpToDate()
             {
                 Assumes.Null(FailureReason);
+                Assumes.Null(FailureDescription);
 
                 _stopwatch.Stop();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -52,7 +52,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private readonly IUpToDateCheckHost _upToDateCheckHost;
 
         private IImmutableDictionary<string, string> _lastGlobalProperties = ImmutableStringDictionary<string>.EmptyOrdinal;
-        private string _lastFailureReason = "";
+        private string? _lastFailureReason;
+        private string? _lastFailureDescription;
         private DateTime _lastBuildStartTimeUtc = DateTime.MinValue;
 
         private ISubscription _subscription;
@@ -787,13 +788,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return IsUpToDateAsync(buildAction, logWriter, ImmutableDictionary<string, string>.Empty, cancellationToken);
         }
 
-        async Task<(bool IsUpToDate, string? FailureReason)> IBuildUpToDateCheckValidator.ValidateUpToDateAsync(CancellationToken cancellationToken)
+        async Task<(bool IsUpToDate, string? FailureReason, string? FailureDescription)> IBuildUpToDateCheckValidator.ValidateUpToDateAsync(CancellationToken cancellationToken)
         {
             bool isUpToDate = await IsUpToDateInternalAsync(TextWriter.Null, _lastGlobalProperties, isValidationRun: true, cancellationToken);
 
-            string failureReason = isUpToDate ? "" : _lastFailureReason;
+            string? failureReason = isUpToDate ? null : _lastFailureReason;
+            string? failureDescription = isUpToDate ? null : _lastFailureDescription;
 
-            return (isUpToDate, failureReason);
+            return (isUpToDate, failureReason, failureDescription);
         }
 
         public Task<bool> IsUpToDateAsync(
@@ -929,7 +931,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     logger.Verbose(nameof(Resources.FUTD_Completed), sw.Elapsed.TotalMilliseconds);
 
-                    _lastFailureReason = logger.FailureReason ?? "";
+                    _lastFailureReason = logger.FailureReason;
+                    _lastFailureDescription = logger.FailureDescription;
                 }
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckValidator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/IBuildUpToDateCheckValidator.cs
@@ -18,6 +18,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </remarks>
         /// <param name="cancellationToken">A token that is cancelled if the caller loses interest in the result.</param>
         /// <returns></returns>
-        Task<(bool IsUpToDate, string? FailureReason)> ValidateUpToDateAsync(CancellationToken cancellationToken = default);
+        Task<(bool IsUpToDate, string? FailureReason, string? FailureDescription)> ValidateUpToDateAsync(CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
The previous incremental build failure warning message did not include a detailed reason for not being up-to-date. This change adds that description to assist diagnosis.

### Before

> WARNING: Potential incremental build failure in 'WebApplication52.csproj'. See: https://aka.ms/incremental-build-failure

### After (example)

> WARNING: Potential incremental build failure in 'WebApplication52.csproj'. Input 'C:\Users\drnoakes\source\repos\WebApplication52\WebApplication52\WebApplication52.csproj.user' (2022-06-10 22:23:38.773) has been modified since the last successful build started (2022-06-10 22:23:38.695), not up-to-date. See https://aka.ms/incremental-build-failure.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8236)