### PR TITLE
Only access App.xaml in WPF apps

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplicationXamlFileAccessorFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IApplicationXamlFileAccessorFactory.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.WPF;
+
+namespace Microsoft.VisualStudio.ProjectSystem;
+
+internal class IApplicationXamlFileAccessorFactory
+{
+    public static IApplicationXamlFileAccessor Create(
+        string? startupUri = null,
+        string? shutdownMode = null,
+        Func<Task<string?>>? getStartupUri = null,
+        Func<Task<string?>>? getShutdownMode = null,
+        Func<string, Task>? setStartupUri = null,
+        Func<string, Task>? setShutdownMode = null)
+    {
+        var mock = new Mock<IApplicationXamlFileAccessor>();
+
+        if (getStartupUri is not null)
+        {
+            mock.Setup(m => m.GetStartupUriAsync())
+                .Returns(getStartupUri);
+        }
+        else
+        {
+            mock.Setup(m => m.GetStartupUriAsync())
+                .ReturnsAsync(startupUri);
+        }
+
+        if (getShutdownMode is not null)
+        {
+            mock.Setup(m => m.GetShutdownModeAsync())
+                .Returns(getShutdownMode);
+        }
+        else
+        {
+            mock.Setup(m => m.GetShutdownModeAsync())
+                .ReturnsAsync(shutdownMode);
+        }
+
+        if (setStartupUri is not null)
+        {
+            mock.Setup(m => m.SetStartupUriAsync(It.IsAny<string>()))
+                .Returns(setStartupUri);
+        }
+
+        if (setShutdownMode is not null)
+        {
+            mock.Setup(m => m.SetShutdownModeAsync(It.IsAny<string>()))
+                .Returns(setShutdownMode);
+        }
+
+        return mock.Object;
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+public class WPFValueProviderTests
+{
+    [Theory]
+    [InlineData(WPFValueProvider.StartupURIPropertyName, "true", WPFValueProvider.WinExeOutputTypeValue, true, false)]
+    [InlineData(WPFValueProvider.ShutdownModePropertyName, "true", WPFValueProvider.WinExeOutputTypeValue, false, true)]
+    [InlineData(WPFValueProvider.StartupURIPropertyName, "false", WPFValueProvider.WinExeOutputTypeValue, false, false)]
+    [InlineData(WPFValueProvider.StartupURIPropertyName, "true", "Exe", false, false)]
+    [InlineData(WPFValueProvider.ShutdownModePropertyName, "false", WPFValueProvider.WinExeOutputTypeValue, false, false)]
+    [InlineData(WPFValueProvider.ShutdownModePropertyName, "true", "Exe", false, false)]
+    public async Task WhenGettingAProperty_ValidateTheCorrectMethodsAreCalled(string propertyName, string useWPFPropertyValue, string outputTypeValue, bool getStartupUriShouldBeCalled, bool getShutdownModeShouldBeCalled)
+    {
+        string startupUriValue = "Alpha.xaml";
+        string shutdownModeValue = "Beta";
+
+        bool getStartupUriCalled = false;
+        bool getShutdownModeCalled = false;
+
+        var applicationXamlFileAccessor = IApplicationXamlFileAccessorFactory.Create(
+            getStartupUri: () =>
+            {
+                getStartupUriCalled = true;
+                return Task.FromResult<string?>(startupUriValue);
+            },
+            getShutdownMode: () =>
+            {
+                getShutdownModeCalled = true;
+                return Task.FromResult<string?>(shutdownModeValue);
+            });
+
+        var provider = new WPFValueProvider(applicationXamlFileAccessor);
+
+        var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
+        {
+            { WPFValueProvider.UseWPFPropertyName, useWPFPropertyValue },
+            { WPFValueProvider.OutputTypePropertyName, outputTypeValue }
+        });
+
+        var result = await provider.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue: "Doesn't matter", defaultProperties);
+
+        Assert.Equal(expected: getStartupUriShouldBeCalled, actual: getStartupUriCalled);
+        Assert.Equal(expected: getShutdownModeShouldBeCalled, actual: getShutdownModeCalled);
+
+        if (getStartupUriShouldBeCalled)
+        {
+            Assert.Equal(expected: startupUriValue, actual: result);
+        }
+
+        if (getShutdownModeShouldBeCalled)
+        {
+            Assert.Equal(expected: shutdownModeValue, actual: result);
+        }
+    }
+
+    [Theory]
+    [InlineData(WPFValueProvider.StartupURIPropertyName, "true", WPFValueProvider.WinExeOutputTypeValue, true, false)]
+    [InlineData(WPFValueProvider.ShutdownModePropertyName, "true", WPFValueProvider.WinExeOutputTypeValue, false, true)]
+    [InlineData(WPFValueProvider.StartupURIPropertyName, "false", WPFValueProvider.WinExeOutputTypeValue, false, false)]
+    [InlineData(WPFValueProvider.StartupURIPropertyName, "true", "Exe", false, false)]
+    [InlineData(WPFValueProvider.ShutdownModePropertyName, "false", WPFValueProvider.WinExeOutputTypeValue, false, false)]
+    [InlineData(WPFValueProvider.ShutdownModePropertyName, "true", "Exe", false, false)]
+    public async Task WhenSettingAProperty_ValidateTheCorrectMethodsAreCalled(string propertyName, string useWPFPropertyValue, string outputTypeValue, bool setStartupUriShouldBeCalled, bool setShutdownModeShouldBeCalled)
+    {
+        bool setStartupUriCalled = false;
+        bool setShutdownModeCalled = false;
+
+        string? setValue = null;
+
+        var applicationXamlFileAccessor = IApplicationXamlFileAccessorFactory.Create(
+            setStartupUri: (newStartupUri) =>
+            {
+                setStartupUriCalled = true;
+                setValue = newStartupUri;
+                return Task.CompletedTask;
+            },
+            setShutdownMode: (newShutdownMode) =>
+            {
+                setShutdownModeCalled = true;
+                setValue = newShutdownMode;
+                return Task.CompletedTask;
+            });
+
+        var provider = new WPFValueProvider(applicationXamlFileAccessor);
+
+        var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
+        {
+            { WPFValueProvider.UseWPFPropertyName, useWPFPropertyValue },
+            { WPFValueProvider.OutputTypePropertyName, outputTypeValue }
+        });
+
+        var result = await provider.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue: "NewValue", defaultProperties);
+
+        Assert.Null(result);
+
+        Assert.Equal(expected: setStartupUriShouldBeCalled, actual: setStartupUriCalled);
+        Assert.Equal(expected: setShutdownModeShouldBeCalled, actual: setShutdownModeCalled);
+
+        if (setStartupUriShouldBeCalled || setShutdownModeCalled)
+        {
+            Assert.Equal(expected: "NewValue", actual: setValue);
+        }
+    }
+}


### PR DESCRIPTION
Fixes AB#1553442.

In #8220 we added VB property page support for WPF-related properties, like "Startup URI" and "Shutdown Mode". Ultimately these properties are read from the Application.xaml file--which generally only exists in WPF projects. The properties themselves are always present in the .xaml file, which means we end up trying to retrieve their values whenever the .xaml file is in use--we just hide the controls unless the project is a WPF application. Unfortunately the current interceptor for this property always tries to access the Application.xaml file, which will fail with an exception if the file isn't present.

To fix this, the interceptor first checks if this is a WPF application before trying to get the values from the Application.xaml. Specifically, we check if "UseWPF" is true, and that the output type of the project is "WinExe".

This also adds a number of unit tests to enforce that the Application.xaml is only accessed at appropriate times.