### PR TITLE
Avoid NuGet restore cycles

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FeatureFlags.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FeatureFlags.cs
@@ -1,0 +1,9 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal class FeatureFlags
+    {
+        internal const string EnableNuGetRestoreCycleDetection = "ManagedProjectSystem.EnableNuGetRestoreCycleDetection";
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/NuGetRestoreCycleDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/NuGetRestoreCycleDetector.cs
@@ -1,0 +1,106 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
+{
+    // This algorithm is to detect the pattern A -> B -> A -> B -> A in the most recent N values.
+    // To keep track of the most N recent values we are using a queue of fixed size, where:
+    //   The most recent value is inserted at the front in O(1) time, and the oldest value is removed at the 
+    // back in O(1) time.
+    //   The counter will keep track of how many times values have appeared in the queue consecutively.
+    // i.e.
+    // A -> B -> C -> A -> B -> D -> X -> Y -> X -> Y -> X -> Y -> X
+    //                                        |---cycle detected----|
+    internal sealed class NuGetRestoreCycleDetector
+    {
+        // The fixed size of the queue
+        private readonly int _size = 5;
+
+        private readonly object _lock;
+        private readonly Queue<byte[]> _values;
+        private readonly Dictionary<byte[], int> _lookupTable;
+        private int _counter;
+
+        /// <summary>
+        ///     Fixed size of the numbers of values to store.
+        /// </summary>
+        /// <remarks>
+        ///     This represents how deep to search for hash cycle.
+        /// </remarks>
+        public int Size { get; private set; }
+
+        public NuGetRestoreCycleDetector()
+        {
+            _lock = new object();
+            _values = new Queue<byte[]>();
+            _lookupTable = new Dictionary<byte[], int>();
+            Size = _size;
+        }
+
+        /// <summary>
+        ///     Validate if hash1 cycle exist. 
+        ///     If no cycle exist, then the hashValue is stored.
+        /// </summary>
+        /// <param name="hashValue">This is hashValue that is used to verify if it exists in previous restores</param>
+        /// <returns>True if it contains hash1 cycle, otherwise false</returns>
+        public bool ComputeCycleDetection(byte[] hashValue)
+        {
+            lock (_lock)
+            {
+                if (QueueContainsValue(hashValue))
+                {
+                    _counter++;
+                    
+                    // Verify that a hashValue has repeated in almost all cases
+                    if (_counter > Size)
+                    {
+                        Clear();
+                        return true;
+                    }
+                }
+                else
+                {
+                    _counter = 0;
+                }
+
+                Add(hashValue);
+            }
+
+            return false;
+
+            bool QueueContainsValue(byte[] hashValue)
+            {
+                if (_lookupTable.TryGetValue(hashValue, out int hashCounter) && hashCounter > 0)
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        private void Add(byte[] newHashValue)
+        {
+            if (_values.Count >= Size)
+            {
+                var oldestHashValue = _values.Dequeue();
+                _lookupTable[oldestHashValue]--;
+            }
+
+            _values.Enqueue(newHashValue);
+            if (_lookupTable.ContainsKey(newHashValue))
+            {
+                _lookupTable[newHashValue]++;
+            }
+            else
+            {
+                _lookupTable.Add(newHashValue, 1);
+            }
+        }
+
+        public void Clear()
+        {
+            _counter = 0;
+            _values.Clear();
+            _lookupTable.Clear();
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/IInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/IInfoBarService.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+
+/// <summary>
+/// Displays messages in the information bar attached to Visual Studio's main window.
+/// </summary>
+[ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.System)]
+internal interface IInfoBarService
+{
+    /// <summary>
+    /// Shows an information bar with the specified message, image and UI, replacing an existing one
+    /// with the same message if there is one.
+    /// </summary>
+    Task ShowInfoBarAsync(string message, ImageMoniker image, CancellationToken cancellationToken, params InfoBarUI[] items);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/InfoBarUI.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/InfoBarUI.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+
+/// <summary>
+/// Represents information bar user interface elements.
+/// </summary>
+internal class InfoBarUI
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InfoBarUI"/> class.
+    /// </summary>
+    /// <param name="title">The title of the UI _element.</param>
+    /// <param name="kind">The kind of the UI _element, either <see cref="InfoBarUIKind.Button"/> or <see cref="InfoBarUIKind.Hyperlink"/></param>
+    /// <param name="action">The <see cref="Action"/> to run when the UI _element is clicked</param>
+    /// <param name="closeAfterAction"><see langword="true"/> if the information bar should close after <paramref name="action"/> is run.</param>
+    public InfoBarUI(string title, InfoBarUIKind kind, Action action, bool closeAfterAction = true)
+    {
+        Requires.NotNullOrEmpty(title, nameof(title));
+        Requires.NotNull(action, nameof(action));
+
+        Title = title;
+        Kind = kind;
+        Action = action;
+        CloseAfterAction = closeAfterAction;
+    }
+
+    /// <summary>
+    /// Gets the title of the UI _element.
+    /// </summary>
+    public string Title { get; }
+
+    /// <summary>
+    /// Gets the kind of the UI _element, either <see cref="InfoBarUIKind.Button"/> or <see cref="InfoBarUIKind.Hyperlink"/>.
+    /// </summary>
+    public InfoBarUIKind Kind { get; }
+
+    /// <summary>
+    /// Gets the <see cref="Action"/> to run when the UI _element is clicked.
+    /// </summary>
+    public Action Action { get; }
+
+    /// <summary>
+    /// Gets whether information bar should close after <see cref="Action"/> is run.
+    /// </summary>
+    public bool CloseAfterAction { get; }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/InfoBarUIKind.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/InfoBarUIKind.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+
+/// <summary>
+/// Represents the kind of a <see cref="InfoBarUI"/>.
+/// </summary>
+internal enum InfoBarUIKind
+{
+    /// <summary>
+    /// The <see cref="InfoBarUI"/> is a button.
+    /// </summary>
+    Button,
+
+    /// <summary>
+    /// The <see cref="InfoBarUI"/> is a hyperlink.
+    /// </summary>
+    Hyperlink,
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.InfoBarEntry.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.InfoBarEntry.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+
+internal partial class VsInfoBarService
+{
+    private class InfoBarEntry : IVsInfoBarUIEvents
+    {
+        private readonly IVsInfoBarUIElement _element;
+        private readonly InfoBarUI[] _items;
+        private readonly Action<InfoBarEntry> _onClose;
+        private readonly uint _cookie;
+
+        public InfoBarEntry(string message, IVsInfoBarUIElement element, InfoBarUI[] items, Action<InfoBarEntry> onClose)
+        {
+            Assumes.NotNull(message);
+            Assumes.NotNull(element);
+            Assumes.NotNull(items);
+            Assumes.NotNull(onClose);
+
+            Message = message;
+            _element = element;
+            _items = items;
+            _onClose = onClose;
+            element.Advise(this, out _cookie);
+        }
+
+        public string Message { get; }
+
+        public void Close()
+        {
+            _element.Close();
+        }
+
+        public void OnActionItemClicked(IVsInfoBarUIElement element, IVsInfoBarActionItem actionItem)
+        {
+            Requires.NotNull(element, nameof(element));
+            Requires.NotNull(actionItem, nameof(actionItem));
+
+            InfoBarUI item = _items.First(i => i.Title == actionItem.Text);
+            item.Action();
+
+            if (item.CloseAfterAction)
+            {
+                Close();
+            }
+        }
+
+        public void OnClosed(IVsInfoBarUIElement element)
+        {
+            Requires.NotNull(element, nameof(element));
+
+            _element.Unadvise(_cookie);
+            _onClose(this);
+        }
+    }
+}
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
@@ -1,0 +1,131 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+
+/// <summary>
+/// Implementation of <see cref="IInfoBarService"/> that pushes messages to the info bar attached to Visual Studio's main window.
+/// </summary>
+[Export(typeof(IInfoBarService))]
+internal partial class VsInfoBarService : IInfoBarService
+{
+    private readonly IProjectThreadingService _threadingService;
+    private readonly IVsShellServices _vsShellServices;
+    private readonly IVsUIService<SVsShell, IVsShell> _vsShell;
+    private readonly IVsUIService<SVsInfoBarUIFactory, IVsInfoBarUIFactory> _vsInfoBarFactory;
+    private readonly List<InfoBarEntry> _entries = new();
+
+    [ImportingConstructor]
+    public VsInfoBarService(
+        IProjectThreadingService threadingService,
+        IVsShellServices vsShellServices,
+        IVsUIService<SVsShell, IVsShell> vsShell,
+        IVsUIService<SVsInfoBarUIFactory, IVsInfoBarUIFactory> vsInfoBarFactory)
+    {
+        _threadingService = threadingService;
+        _vsShellServices = vsShellServices;
+        _vsShell = vsShell;
+        _vsInfoBarFactory = vsInfoBarFactory;
+    }
+
+    public async Task ShowInfoBarAsync(string message, ImageMoniker image, CancellationToken cancellationToken, params InfoBarUI[] items)
+    {
+        Requires.NotNullOrEmpty(message, nameof(message));
+        Requires.NotNull(items, nameof(items));
+
+        if (!_vsShellServices.IsInServerMode)
+        {
+            await _threadingService.SwitchToUIThread(cancellationToken);
+
+            IVsInfoBarHost? host = FindMainWindowInfoBarHost();
+            if (host == null)
+            {
+                return;
+            }
+
+            // We want to avoid posting the same message over and over again, so we remove any existing info bar
+            // with the same message, and add the new one which will cause it to float to the bottom of the host.
+            RemoveInfoBar(message);
+            AddInfoBar(host, message, image, items);
+        }
+    }
+
+    private IVsInfoBarHost? FindMainWindowInfoBarHost()
+    {
+        if (_vsShell.Value is null)
+        {
+            return null;
+        }
+
+        if (ErrorHandler.Failed(_vsShell.Value.GetProperty((int)__VSSPROPID7.VSSPROPID_MainWindowInfoBarHost, out object mainWindowInfoBarHost)))
+        {
+            return null;
+        }
+
+        return mainWindowInfoBarHost as IVsInfoBarHost;
+    }
+
+    private IVsInfoBarUIElement? CreateInfoBarUIElement(string message, ImageMoniker image, InfoBarUI[] items)
+    {
+        if (_vsInfoBarFactory.Value is null)
+        {
+            return null;
+        }
+
+        var actionItems = new List<IVsInfoBarActionItem>(items.Length);
+
+        foreach (InfoBarUI item in items)
+        {
+            switch (item.Kind)
+            {
+                default:
+                case InfoBarUIKind.Button:
+                    Assumes.True(item.Kind == InfoBarUIKind.Button);
+                    actionItems.Add(new InfoBarButton(item.Title));
+                    break;
+                case InfoBarUIKind.Hyperlink:
+                    actionItems.Add(new InfoBarHyperlink(item.Title));
+                    break;
+            }
+        }
+
+        var infoBarModel = new InfoBarModel(
+            message,
+            actionItems.ToArray(),
+            image,
+            isCloseButtonVisible: true);
+
+        return _vsInfoBarFactory.Value.CreateInfoBar(infoBarModel);
+    }
+
+    private void AddInfoBar(IVsInfoBarHost host, string message, ImageMoniker image, InfoBarUI[] items)
+    {
+        IVsInfoBarUIElement? element = CreateInfoBarUIElement(message, image, items);
+        if (element != null)
+        {
+            var entry = new InfoBarEntry(message, element, items, OnClosed);
+            _entries.Add(entry);
+            host.AddInfoBar(element);
+        }
+    }
+
+    private void RemoveInfoBar(string message)
+    {
+        // Assumption is that message is "good" enough to uniquely identify problems
+        InfoBarEntry entry = _entries.Find(e => e.Message == message);
+        entry?.Close();
+    }
+
+    private void OnClosed(InfoBarEntry entry)
+    {
+        Requires.NotNull(entry, nameof(entry));
+
+        _threadingService.VerifyOnUIThread();
+
+        _entries.Remove(entry);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/IVsShellServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/IVsShellServices.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Microsoft.VisualStudio.Shell
+{
+    /// <summary>
+    /// Provides common shell services in an agnostic manner
+    /// </summary>
+    /// <remarks>
+    /// This contract defines the boundary between the VS shell system
+    /// and the consumer to help avoid taking unnecessary assembly dependencies
+    /// in the client.
+    /// </remarks>
+    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Host)]
+    internal interface IVsShellServices
+    {
+        /// <summary>
+        /// Gets a value indicating whether VS is running in the server mode.
+        /// </summary>
+        /// <remarks>
+        /// This has a free-threaded implementation.
+        /// </remarks>
+        bool IsInServerMode { get; }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/VSShellServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/VSShellServices.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using Microsoft.VisualStudio.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.Shell.Interop;
+
+#nullable disable
+
+namespace Microsoft.VisualStudio.Shell;
+
+/// <summary>
+/// See IVSShellServices.
+/// </summary>
+[Export(typeof(IVsShellServices))]
+[AppliesTo(ProjectCapabilities.AlwaysApplicable)]
+internal class VSShellServices : OnceInitializedOnceDisposed, IVsShellServices
+{
+    /// <summary>
+    /// The service provider providing access to the VS services.
+    /// </summary>
+    [Import]
+    private IVsUIService<SVsShell, IVsShell> ServiceProvider { get; set; }
+
+    public bool IsInServerMode { get; private set; }
+
+    /// <summary>
+    /// The SVsShell service.
+    /// </summary>
+    private IVsShell vsShell;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VSShellServices"/> class.
+    /// </summary>
+    public VSShellServices()
+        : base(synchronousDisposal: true) // disposal requires UI thread unadvise, so async defeats that.
+    {
+    }
+
+    protected override void Initialize()
+    {
+        vsShell = ServiceProvider.Value;
+
+        if (ErrorHandler.Succeeded(vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object result)) && (bool)result)
+        {
+            IsInServerMode = CheckIsInServerMode();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool CheckIsInServerMode()
+    {
+        if (ErrorHandler.Succeeded(vsShell.GetProperty((int)__VSSPROPID11.VSSPROPID_ShellMode, out object value))
+            && value is int shellMode
+            && shellMode == (int)__VSShellMode.VSSM_Server)
+            return true;
+
+        return false;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -322,6 +322,20 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+        ///Because the NuGet restore didn&apos;t finish correctly, the project might be in a bad state.
+        ///
+        ///This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+        ///
+        ///NuGet Error NU1108.
+        /// </summary>
+        internal static string InfoBarMessageNuGetCycleDetected {
+            get {
+                return ResourceManager.GetString("InfoBarMessageNuGetCycleDetected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Editing of multiple target framework is not supported..
         /// </summary>
         internal static string MultiTFEditNotSupported {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -295,4 +295,12 @@ In order to debug this project, add an executable project to this solution which
     <value>The .xaml file was in an unexpected format, near line {0} column {1}.</value>
     <comment>{0} is the line number of the problematic XAML, and {1} is the column.</comment>
   </data>
+  <data name="InfoBarMessageNuGetCycleDetected" xml:space="preserve">
+    <value>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</value>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -115,6 +115,21 @@
         <target state="translated">UPOZORNĚNÍ: Potenciální problém s výkonem sestavení v projektu {0}. Projekt se po úspěšném sestavení nezobrazuje jako aktuální: {1}. Viz https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Připojování k procesu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -115,6 +115,21 @@
         <target state="translated">WARNUNG: Potenzielles Problem mit der Buildleistung in '{0}'. Das Projekt erscheint nach einem erfolgreichen Build nicht aktuell: {1}. Siehe https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Anhängen an den Prozess.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -115,6 +115,21 @@
         <target state="translated">ADVERTENCIA: posible problema de rendimiento de compilación en '{0}'. El proyecto no aparece actualizado después de una compilación correcta: {1}. Ver https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Adjuntando al proceso.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -115,6 +115,21 @@
         <target state="translated">AVERTISSEMENT : problème potentiel de performances de build dans '{0}'. Le projet n’apparaît pas à jour après une build réussie : {1}. Voir https://aka.ms/incremental-build-failure</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Attachement au processus</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -115,6 +115,21 @@
         <target state="translated">AVVISO: possibile problema di prestazioni di compilazione in '{0}'. Il progetto non viene visualizzato aggiornato dopo una compilazione riuscita: {1}. Vedi https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Connessione al processo.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -115,6 +115,21 @@
         <target state="translated">警告: '{0}' でビルド パフォーマンスの問題が発生する可能性があります。プロジェクトは、ビルドが成功した後に最新の状態になりません: {1}。https://aka.ms/incremental-build-failure を参照してください。</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">プロセスにアタッチしています。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -115,6 +115,21 @@
         <target state="translated">경고: '{0}'에서의 잠재적 빌드 성능 문제입니다. 빌드가 성공한 후에는 프로젝트가 최신 상태로 표시되지 않습니다. {1}. https://aka.ms/incremental-build-failure를 참조하세요.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">프로세스에 연결하는 중입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -115,6 +115,21 @@
         <target state="translated">OSTRZEŻENIE: potencjalny problem z wydajnością kompilacji w „{0}”. Projekt wydaje się być nieaktualny po pomyślnej kompilacji: {1}. Zobacz stronę https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Dołączanie do procesu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -115,6 +115,21 @@
         <target state="translated">AVISO: potencial problema de desempenho de compilação em '{0}'. O projeto não aparece atualizado após uma compilação bem sucedida: {1}. Ver https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Anexando ao processo.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -115,6 +115,21 @@
         <target state="translated">ПРЕДУПРЕЖДЕНИЕ. Возможная проблема с производительностью сборки в "{0}". Проект не отображается обновленным после успешной сборки: {1}. Сведения см. на странице https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Выполняется подключение к процессу.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -115,6 +115,21 @@
         <target state="translated">UYARI: '{0}' içinde olası derleme performansı sorunu var. Proje, başarılı bir derlemeden sonra güncel görünmüyor: {1}. Bkz. https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">İşleme ekleniyor.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -115,6 +115,21 @@
         <target state="translated">警告: "{0}" 中可能存在生成性能问题。成功生成后，项目不会显示为最新版本: {1}。请参阅 https://aka.ms/incremental-build-failure。</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">正在附加到流程。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -115,6 +115,21 @@
         <target state="translated">警告: '{0}'中可能發生組建效能問題。成功建置之後，此專案未顯示為最新狀態: {1}。請參閱https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="InfoBarMessageNuGetCycleDetected">
+        <source>A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</source>
+        <target state="new">A circular dependency A -&gt; B -&gt; A was detected during NuGet Restore which caused NuGet to stop restoring.
+Because the NuGet restore didn't finish correctly, the project might be in a bad state.
+
+This might be caused because one or more projects have a package that sets AssetTargetFallback, not supported for this scenario, which caused certain PackageReference to be included.
+
+NuGet Error NU1108</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">正在附加至處理序。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -71,5 +71,10 @@ namespace Microsoft.VisualStudio.Telemetry
         ///     Indicates that the user was notified of the suspected incremental build failure.
         /// </summary>
         public const string IncrementalBuildValidationFailureDisplayed = Prefix + "/incrementalbuild/validationfailure/displayed";
+
+        /// <summary>
+        ///     Indicates that the NuGet restore detected a cycle.
+        /// </summary>
+        public const string NuGetRestoreCycleDetected = Prefix + "/nugetrestore/cycledetected";
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreDataSourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreDataSourceTests.cs
@@ -1,7 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.Snapshots;
+using Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+using Microsoft.VisualStudio.Telemetry;
 using NuGet.SolutionRestoreManager;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
@@ -84,8 +87,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             return instance;
         }
 
-        private static PackageRestoreDataSource CreateInstance(UnconfiguredProject? project = null, IPackageRestoreUnconfiguredInputDataSource? dataSource = null, IVsSolutionRestoreService3? solutionRestoreService = null)
+        private static PackageRestoreDataSource CreateInstance(
+            UnconfiguredProject? project = null, 
+            IPackageRestoreUnconfiguredInputDataSource? dataSource = null, 
+            IVsSolutionRestoreService3? solutionRestoreService = null,
+            bool featureFlagEnabled = false)
         {
+            var featureFlagServiceMock = new Mock<IVsFeatureFlags>();
+            featureFlagServiceMock.Setup(m => m.IsFeatureEnabled(FeatureFlags.EnableNuGetRestoreCycleDetection, false)).Returns(featureFlagEnabled);
+            var vsFeatureFlagsServiceService = new Mock<IVsUIService<SVsFeatureFlags, IVsFeatureFlags>>();
+            vsFeatureFlagsServiceService.SetupGet(m => m.Value).Returns(featureFlagServiceMock.Object);
+
+            var telemetryService = (new Mock<ITelemetryService>()).Object;
+            var infoBarService = (new Mock<IInfoBarService>()).Object;
             project ??= UnconfiguredProjectFactory.CreateWithActiveConfiguredProjectProvider(IProjectThreadingServiceFactory.Create());
             dataSource ??= IPackageRestoreUnconfiguredInputDataSourceFactory.Create();
             IProjectAsynchronousTasksService projectAsynchronousTasksService = IProjectAsynchronousTasksServiceFactory.Create();
@@ -96,6 +110,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             var sharedJoinableTaskCollection = new PackageRestoreSharedJoinableTaskCollection(IProjectThreadingServiceFactory.Create());
 
             return new PackageRestoreDataSourceMocked(
+                vsFeatureFlagsServiceService.Object,
+                telemetryService,
+                infoBarService,
                 project,
                 dataSource,
                 projectAsynchronousTasksService,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreDataSourceMocked.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreDataSourceMocked.cs
@@ -1,13 +1,20 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.IO;
+using Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBarService;
+using Microsoft.VisualStudio.Telemetry;
 using NuGet.SolutionRestoreManager;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.Snapshots
 {
     internal class PackageRestoreDataSourceMocked : PackageRestoreDataSource
     {
-        public PackageRestoreDataSourceMocked(UnconfiguredProject project, 
+        public PackageRestoreDataSourceMocked(
+            IVsUIService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService,
+            ITelemetryService telemetryService,
+            IInfoBarService infoBarService,
+            UnconfiguredProject project, 
             IPackageRestoreUnconfiguredInputDataSource dataSource, 
             IProjectAsynchronousTasksService projectAsynchronousTasksService, 
             IVsSolutionRestoreService3 solutionRestoreService, 
@@ -15,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.Snapshots
             IProjectDiagnosticOutputService logger, 
             IVsSolutionRestoreService4 solutionRestoreService4, 
             PackageRestoreSharedJoinableTaskCollection sharedJoinableTaskCollection) 
-            : base(project, dataSource, projectAsynchronousTasksService, solutionRestoreService, fileSystem, logger, solutionRestoreService4, sharedJoinableTaskCollection)
+            : base(featureFlagsService, telemetryService, infoBarService, project, dataSource, projectAsynchronousTasksService, solutionRestoreService, fileSystem, logger, solutionRestoreService4, sharedJoinableTaskCollection)
         {
         }
 


### PR DESCRIPTION
Fixes #8326

Avoid infinite NuGet restores.
Scenario:
Projects might have a package that sets `AssetTargetsFallback` value that can cause a certain `PackageReference` to be included. This package contains a props file that changed the `AssetTargetFallback` property value, and the `PackageReference` Condition was no longer true, causing it to be removed. Once removed, the `AssetTargetFallback` value from the `csproj` was used again, causing an infinite restore -> design time build -> restore loop.

This change:
Since DotNet ProjectSystem can detect changes in NuGet restores by calculating a hash, we can use this hash to detect changes in `AssetTargetFallBack` and check when this value gets repeated.

This pr makes use of the `NuGetRestoreCycleDetector` to keep the last N hashes, and once it detects a repeated value (cycle) Dotnet ProjectSystem can stop NuGet restores.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8239)