### PR TITLE
Fix SBOM manifest directory

### DIFF
--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -28,7 +28,7 @@
     Doing it as AfterTargets="AddVsixForSigning" unnecessarily binds the SBOM process to signing. But there is not currently a scenario where we wouldn't sign and generate an SBOM.
   -->
   <Target Name="UpdateManifestJsonForSbom" AfterTargets="AddVsixForSigning">
-    <Exec ContinueOnError="false" Command="powershell -NonInteractive -NoLogo -NoProfile -ExecutionPolicy Unrestricted -Command &quot;. $(RepoRoot)build\script\UpdateManifestJsonForSbom.ps1 -manifestJsonPath '$(VisualStudioSetupInsertionPath)$(ManifestJsonName).json' -sbomMetadataPath '$(ArtifactsBinDir)spdx_2.2\manifest.spdx.json'&quot;" />
+    <Exec ContinueOnError="false" Command="powershell -NonInteractive -NoLogo -NoProfile -ExecutionPolicy Unrestricted -Command &quot;. $(RepoRoot)build\script\UpdateManifestJsonForSbom.ps1 -manifestJsonPath '$(VisualStudioSetupInsertionPath)$(ManifestJsonName).json' -sbomMetadataPath '$(ArtifactsBinDir)_manifest\spdx_2.2\manifest.spdx.json'&quot;" />
   </Target>
 
   <!-- Copies the vsix files after they've been signed to the different output folders. -->


### PR DESCRIPTION
There seems to have been a change that happened between Wednesday (8th) and Friday (10th) last week that is a breaking change for the ManifestGeneratorTask DevOps task. This is causing our build to fail.

When setting up the task, you can specify a value for `ManifestDirPath` which sets where the manifest will be output. The default value for this parameter is `${BuildDropPath}/_manifest`. What has happened is specifying our own `ManifestDirPath` instead of outputting to the directory we specified, now outputs to `${ManifestDirPath}/_manifest`. Meaning, it will always output to a subdirectory of `_manifest` no matter what value you set for the parameter.

I've let VS Eng know that this was changed as it seems like a bug. For now, we can simply change the SBOM script I have to look in the `_manifest` directory and everything will work appropriately. This will allow the build to succeed again.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8240)