### PR TITLE
Code cleanup in AccessModifierConverter

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -10,17 +10,19 @@ Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Shell.Interop
 
 Namespace Microsoft.VisualStudio.Editors.DesignerFramework
+    ''' <summary>
+    '''     Access modifier types for resources
+    ''' </summary>
+    Friend Enum AccessModifierType
+        [Public]
+        [Internal]
+    End Enum
 
     ''' <summary>
-    ''' Gets the language-dependent terminology for Public/Friend
+    ''' Gets the language-dependent terminology for Public/Internal
     ''' </summary>
     Friend Class AccessModifierConverter
         Private ReadOnly _converter As TypeConverter
-
-        Public Enum Access
-            [Public]
-            [Friend]
-        End Enum
 
         Public Sub New(provider As CodeDomProvider)
             If provider IsNot Nothing Then
@@ -35,18 +37,18 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         End Sub
 
         ''' <summary>
-        ''' Gets the language-dependent terminology for Public/Friend
+        ''' Gets the language-dependent terminology for Public/Internal
         ''' </summary>
         ''' <param name="accessibility"></param>
-        Public Function ConvertToString(accessibility As Access) As String
+        Public Function ConvertToString(accessibility As AccessModifierType) As String
             Select Case accessibility
-                Case Access.Friend
+                Case AccessModifierType.Internal
                     If _converter IsNot Nothing Then
                         Return _converter.ConvertToString(MemberAttributes.Assembly)
                     Else
                         Return "Internal"
                     End If
-                Case Access.Public
+                Case AccessModifierType.Public
                     If _converter IsNot Nothing Then
                         Return _converter.ConvertToString(MemberAttributes.Public)
                     Else
@@ -78,11 +80,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ' checked the project system yet)
         ' This field should only be accessed through the CustomToolsRegistered property.
         Private _customToolsRegistered As Boolean?
-
-        Public Enum Access
-            [Public]
-            [Friend]
-        End Enum
 
 #Region "Nested class CodeGenerator"
 
@@ -124,10 +121,10 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Private Class CodeGeneratorWithDelayedName
             Inherits CodeGenerator
 
-            Private ReadOnly _accessibility As AccessModifierConverter.Access
+            Private ReadOnly _accessibility As AccessModifierType
             Private ReadOnly _serviceProvider As IServiceProvider
 
-            Public Sub New(accessibility As AccessModifierConverter.Access, serviceProvider As IServiceProvider, customToolValue As String)
+            Public Sub New(accessibility As AccessModifierType, serviceProvider As IServiceProvider, customToolValue As String)
                 MyBase.New(customToolValue)
 
                 Requires.NotNull(serviceProvider, NameOf(serviceProvider))
@@ -311,8 +308,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="accessibility"></param>
         ''' <param name="customToolValue"></param>
-        Public Sub AddCodeGeneratorEntry(accessibility As AccessModifierConverter.Access, customToolValue As String)
-            Debug.Assert([Enum].IsDefined(GetType(AccessModifierConverter.Access), accessibility))
+        Public Sub AddCodeGeneratorEntry(accessibility As AccessModifierType, customToolValue As String)
+            Debug.Assert([Enum].IsDefined(GetType(AccessModifierType), accessibility))
 
             Dim entry As New CodeGeneratorWithDelayedName(accessibility, _serviceProvider, customToolValue)
             _codeGeneratorEntries.Add(entry)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorView.vb
@@ -268,10 +268,10 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
 
                 _isInDevice20Project = IsInDevice20Project(rootDesigner)
 
-                AddCodeGeneratorEntry(AccessModifierConverter.Access.Friend, IIf(useVbMyResXCodeGenerator, VBMYCUSTOMTOOL, STANDARDCUSTOMTOOL))
+                AddCodeGeneratorEntry(AccessModifierType.Internal, IIf(useVbMyResXCodeGenerator, VBMYCUSTOMTOOL, STANDARDCUSTOMTOOL))
                 If Not _isInDevice20Project Then
                     ' public generator is not supported in Device 2.0 projects
-                    AddCodeGeneratorEntry(AccessModifierConverter.Access.Public, IIf(useVbMyResXCodeGenerator, VBMYCUSTOMTOOLPUBLIC, STANDARDCUSTOMTOOLPUBLIC))
+                    AddCodeGeneratorEntry(AccessModifierType.Public, IIf(useVbMyResXCodeGenerator, VBMYCUSTOMTOOLPUBLIC, STANDARDCUSTOMTOOLPUBLIC))
                 End If
 
                 If allowNoCodeGeneration Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -47,8 +47,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Public Sub New(rootDesigner As BaseRootDesigner, serviceProvider As IServiceProvider, projectItem As EnvDTE.ProjectItem, namespaceToOverrideIfCustomToolIsEmpty As String)
                 MyBase.New(rootDesigner, serviceProvider, projectItem, namespaceToOverrideIfCustomToolIsEmpty)
 
-                AddCodeGeneratorEntry(AccessModifierConverter.Access.Friend, SettingsSingleFileGenerator.SingleFileGeneratorName)
-                AddCodeGeneratorEntry(AccessModifierConverter.Access.Public, PublicSettingsSingleFileGenerator.SingleFileGeneratorName)
+                AddCodeGeneratorEntry(AccessModifierType.Internal, SettingsSingleFileGenerator.SingleFileGeneratorName)
+                AddCodeGeneratorEntry(AccessModifierType.Public, PublicSettingsSingleFileGenerator.SingleFileGeneratorName)
 
                 'Make sure both the internal and public custom tool values are "recognized"
                 AddRecognizedCustomToolValue(SettingsSingleFileGenerator.SingleFileGeneratorName)
@@ -88,7 +88,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     Return _committingChanges
                 End Get
                 Set
-                    _committingChanges = value
+                    _committingChanges = Value
                 End Set
             End Property
         End Class


### PR DESCRIPTION
- Rename AccessModifierConverter.Access to AccessModifierType
- Change AccessModifierType.Friend to AccessModifierType.Internal

![image](https://user-images.githubusercontent.com/510598/173859965-da1ad9b0-dd67-4402-b545-4ea83c060400.png)
