### PR TITLE
Intercept WinForms properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
@@ -19,12 +19,26 @@ internal class MyAppDocument
 
     public string GetProperty(string propertyName)
     {
-        return _doc.Root.Element(propertyName).Value;
+        XElement element = _doc.Root.Element(propertyName);
+
+        if (element is null)
+            return string.Empty;
+
+        return element.Value;
     }
 
     public void SetProperty(string propertyName, string propertyValue)
     {
-        _doc.Root.Element(propertyName).Value = propertyValue;
+        XElement element = _doc.Root.Element(propertyName);
+
+        if (element is not null)
+            element.Value = propertyValue;
+        else
+        {
+            element = new XElement(propertyName, propertyValue);
+            _doc.Root.Add(element);
+        }
+
         using var textWriter = new DocDataTextWriter(_docData);
         _doc.Save(textWriter);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
@@ -7,30 +7,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 
 internal class MyAppDocument
 {
-    private XDocument _doc;
-    private XElement _root;
-    private readonly DocDataTextReader _reader;
+    private readonly XDocument _doc;
+    private readonly DocData _docData;
 
-    private readonly string _fileName;
-
-    public MyAppDocument(string fileName, DocDataTextReader textReader)
+    public MyAppDocument(DocData docData)
     {
-        _reader = textReader;
-        _doc = XDocument.Load(_reader);
-        _root = _doc.Root;
-        _fileName = fileName;
+        using var textReader = new DocDataTextReader(docData);
+        _doc = XDocument.Load(textReader);
+        _docData = docData;
     }
 
-    public string GetProperty(string filePath, string propertyName)
+    public string GetProperty(string propertyName)
     {
-        _doc = XDocument.Load(_reader);
-        _root = _doc.Root;
-        return (string)_root.Element(propertyName);
+        return _doc.Root.Element(propertyName).Value;
     }
 
     public void SetProperty(string propertyName, string propertyValue)
     {
-        _root.Element(propertyName).Value = propertyValue;
-        _doc.Save(_fileName);
+        _doc.Root.Element(propertyName).Value = propertyValue;
+        using var textWriter = new DocDataTextWriter(_docData);
+        _doc.Save(textWriter);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Xml.Linq;
+using Microsoft.VisualStudio.Shell.Design.Serialization;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
+
+internal class MyAppDocument
+{
+    private XDocument _doc;
+    private XElement _root;
+    private readonly DocDataTextReader _reader;
+
+    private readonly string _fileName;
+
+    public MyAppDocument(string fileName, DocDataTextReader textReader)
+    {
+        _reader = textReader;
+        _doc = XDocument.Load(_reader);
+        _root = _doc.Root;
+        _fileName = fileName;
+    }
+
+    public string GetProperty(string filePath, string propertyName)
+    {
+        _doc = XDocument.Load(_reader);
+        _root = _doc.Root;
+        return (string)_root.Element(propertyName);
+    }
+
+    public void SetProperty(string propertyName, string propertyValue)
+    {
+        _root.Element(propertyName).Value = propertyValue;
+        _doc.Save(_fileName);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -30,226 +30,16 @@ internal class MyAppFileAccessor : IMyAppFileAccessor
         _fileName = fileName;
     }
 
-    public async Task<bool?> GetMySubMainAsync()
+    private async Task<MyAppDocument?> TryGetMyAppFileAsync()
     {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, MySubMainProperty);
+        string filePath = Path.GetFullPath(_fileName);
 
-        if (value is null)
-            return null;
-        else
-            return bool.Parse(value);
-    }
-    
-    public async Task SetMySubMainAsync(string mySubMain)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(MySubMainProperty, mySubMain);
-        }
-    }
-
-    public async Task<string?> GetMainFormAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, MainFormProperty);
-
-        if (value is null)
-            return null;
-        else
-            return value;
-    }
-    
-    public async Task SetMainFormAsync(string mainForm)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(MySubMainProperty, mainForm);
-        }
-    }
-
-    public async Task<bool?> GetSingleInstanceAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, SingleInstanceProperty);
-
-        if (value is null)
-            return null;
-        else
-            return bool.Parse(value);
-    }
-
-    public async Task SetSingleInstanceAsync(bool singleInstance)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(SingleInstanceProperty, singleInstance.ToString());
-        }
-    }
-    
-    public async Task<int?> GetShutdownModeAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, ShutdownModeProperty);
-
-        if (value is null)
-            return null;
-        else
-            return int.Parse(value);
-    }
-
-    public async Task SetShutdownModeAsync(int shutdownMode)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(ShutdownModeProperty, shutdownMode.ToString());
-        }
-    }
-
-    public async Task<bool?> GetEnableVisualStylesAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, EnableVisualStylesProperty);
-
-        if (value is null)
-            return null;
-        else
-            return bool.Parse(value);
-    }
-
-    public async Task SetEnableVisualStylesAsync(bool enableVisualStyles)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(EnableVisualStylesProperty, enableVisualStyles.ToString());
-        }
-    }
-
-    public async Task<int?> GetAuthenticationModeAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, AuthenticationModeProperty);
-
-        if (value is null)
-            return null;
-        else
-            return int.Parse(value);
-    }
-
-    public async Task SetAuthenticationModeAsync(int authenticationMode)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(AuthenticationModeProperty, authenticationMode.ToString());
-        }
-    }
-
-    public async Task<bool?> GetSaveMySettingsOnExitAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, SaveMySettingsOnExitProperty);
-
-        if (value is null)
-            return null;
-        else
-            return bool.Parse(value);
-    }
-
-    public async Task SetSaveMySettingsOnExitAsync(bool saveMySettingsOnExit)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(SaveMySettingsOnExitProperty, saveMySettingsOnExit.ToString());
-        }
-    }
-
-    public async Task<int?> GetHighDpiModeAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, HighDpiModeProperty);
-
-        if (value is null)
-            return null;
-        else
-            return int.Parse(value);
-    }
-
-    public async Task SetHighDpiModeAsync(int highDpiMode)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(HighDpiModeProperty, highDpiMode.ToString());
-        }
-    }
-
-    public async Task<string?> GetSplashScreenAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, SplashScreenProperty);
-
-        if (value is null)
-            return null;
-        else
-            return value;
-    }
-
-    public async Task SetSplashScreenAsync(string splashScreen)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(SplashScreenProperty, splashScreen);
-        }
-    }
-
-    public async Task<int?> GetMinimumSplashScreenDisplayTimeAsync()
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
-        string? value = myAppDocument?.GetProperty(_filePath, MinimumSplashScreenDisplayTimeProperty);
-
-        if (value is null)
-            return null;
-        else
-            return int.Parse(value);
-    }
-
-    public async Task SetMinimumSplashScreenDisplayTimeAsync(int minimumSplashScreenDisplayTime)
-    {
-        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
-
-        if (myAppDocument is not null)
-        {
-            myAppDocument.SetProperty(MinimumSplashScreenDisplayTimeProperty, minimumSplashScreenDisplayTime.ToString());
-        }
-    }
-
-    private async Task<MyAppDocument?> TryGetMyAppFileAsync(bool create)
-    {
-        string _filePath = Path.GetFullPath(_fileName);
-
-        if (_filePath is null)
+        if (filePath is null)
         {
             throw new InvalidOperationException($"The file {_fileName} path cannot be found.");
         }
 
-        var docData = new DocData(_serviceProvider, _filePath);
+        var docData = new DocData(_serviceProvider, filePath);
 
         if (docData is not null)
         {
@@ -259,4 +49,78 @@ internal class MyAppFileAccessor : IMyAppFileAccessor
 
         return null;
     }
+
+    private async Task SetPropertyAsync(string propertyName, string value)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync();
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(propertyName, value);
+        }
+    }
+
+    private async Task<string?> GetStringPropertyValueAsync(string propertyName)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync();
+        return myAppDocument?.GetProperty(_filePath, propertyName);
+    }
+
+    private async Task<bool?> GetBooleanPropertyValueAsync(string propertyName)
+    {
+        string? value = await GetStringPropertyValueAsync(propertyName);
+
+        if (bool.TryParse(value, out bool booleanValue))
+            return booleanValue;
+        return null;
+    }
+
+    private async Task<int?> GetIntPropertyValueAsync(string propertyName)
+    {
+        string? value = await GetStringPropertyValueAsync(propertyName);
+
+        if (int.TryParse(value, out int intValue))
+            return intValue;
+        return null;
+    }
+
+    public async Task<bool?> GetMySubMainAsync() => await GetBooleanPropertyValueAsync(MySubMainProperty);
+
+    public async Task SetMySubMainAsync(string value) => await SetPropertyAsync(MySubMainProperty, value);
+
+    public async Task<string?> GetMainFormAsync() => await GetStringPropertyValueAsync(MainFormProperty);
+
+    public async Task SetMainFormAsync(string value) => await SetPropertyAsync(MainFormProperty, value);
+
+    public async Task<bool?> GetSingleInstanceAsync() => await GetBooleanPropertyValueAsync(SingleInstanceProperty);
+
+    public async Task SetSingleInstanceAsync(bool value) => await SetPropertyAsync(SingleInstanceProperty, value.ToString().ToLower());
+
+    public async Task<int?> GetShutdownModeAsync() => await GetIntPropertyValueAsync(ShutdownModeProperty);
+
+    public async Task SetShutdownModeAsync(int value) => await SetPropertyAsync(ShutdownModeProperty, value.ToString());
+
+    public async Task<bool?> GetEnableVisualStylesAsync() => await GetBooleanPropertyValueAsync(EnableVisualStylesProperty);
+
+    public async Task SetEnableVisualStylesAsync(bool value) => await SetPropertyAsync(EnableVisualStylesProperty, value.ToString().ToLower());
+
+    public async Task<int?> GetAuthenticationModeAsync() => await GetIntPropertyValueAsync(AuthenticationModeProperty);
+
+    public async Task SetAuthenticationModeAsync(int value) => await SetPropertyAsync(AuthenticationModeProperty, value.ToString());
+
+    public async Task<bool?> GetSaveMySettingsOnExitAsync() => await GetBooleanPropertyValueAsync(SaveMySettingsOnExitProperty);
+
+    public async Task SetSaveMySettingsOnExitAsync(bool value) => await SetPropertyAsync(SaveMySettingsOnExitProperty, value.ToString().ToLower());
+
+    public async Task<int?> GetHighDpiModeAsync() => await GetIntPropertyValueAsync(HighDpiModeProperty);
+
+    public async Task SetHighDpiModeAsync(int value) => await SetPropertyAsync(HighDpiModeProperty, value.ToString());
+
+    public async Task<string?> GetSplashScreenAsync() => await GetStringPropertyValueAsync(SplashScreenProperty);
+
+    public async Task SetSplashScreenAsync(string value) => await SetPropertyAsync(SplashScreenProperty, value);
+
+    public async Task<int?> GetMinimumSplashScreenDisplayTimeAsync() => await GetIntPropertyValueAsync(MinimumSplashScreenDisplayTimeProperty);
+
+    public async Task SetMinimumSplashScreenDisplayTimeAsync(int value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value.ToString());
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -1,0 +1,262 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Shell.Design.Serialization;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
+
+[Export(typeof(IMyAppFileAccessor))]
+[AppliesTo(ProjectCapability.DotNet)]
+internal class MyAppFileAccessor : IMyAppFileAccessor
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly string _filePath;
+    private readonly string _fileName = "Application.myapp";
+
+    private const string MySubMainProperty = "MySubMain";
+    private const string MainFormProperty = "MainForm";
+    private const string SingleInstanceProperty = "SingleInstance";
+    private const string ShutdownModeProperty = "ShutdownMode";
+    private const string EnableVisualStylesProperty = "EnableVisualStyles";
+    private const string AuthenticationModeProperty = "AuthenticationMode";
+    private const string SaveMySettingsOnExitProperty = "SaveMySettingsOnExit";
+    private const string HighDpiModeProperty = "HighDpiMode";
+    private const string SplashScreenProperty = "SplashScreen";
+    private const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
+
+    public MyAppFileAccessor(IServiceProvider serviceProvider, string filePath, string fileName)
+    {
+        _serviceProvider = serviceProvider;
+        _filePath = filePath;
+        _fileName = fileName;
+    }
+
+    public async Task<bool?> GetMySubMainAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, MySubMainProperty);
+
+        if (value is null)
+            return null;
+        else
+            return bool.Parse(value);
+    }
+    
+    public async Task SetMySubMainAsync(string mySubMain)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(MySubMainProperty, mySubMain);
+        }
+    }
+
+    public async Task<string?> GetMainFormAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, MainFormProperty);
+
+        if (value is null)
+            return null;
+        else
+            return value;
+    }
+    
+    public async Task SetMainFormAsync(string mainForm)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(MySubMainProperty, mainForm);
+        }
+    }
+
+    public async Task<bool?> GetSingleInstanceAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, SingleInstanceProperty);
+
+        if (value is null)
+            return null;
+        else
+            return bool.Parse(value);
+    }
+
+    public async Task SetSingleInstanceAsync(bool singleInstance)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(SingleInstanceProperty, singleInstance.ToString());
+        }
+    }
+    
+    public async Task<int?> GetShutdownModeAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, ShutdownModeProperty);
+
+        if (value is null)
+            return null;
+        else
+            return int.Parse(value);
+    }
+
+    public async Task SetShutdownModeAsync(int shutdownMode)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(ShutdownModeProperty, shutdownMode.ToString());
+        }
+    }
+
+    public async Task<bool?> GetEnableVisualStylesAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, EnableVisualStylesProperty);
+
+        if (value is null)
+            return null;
+        else
+            return bool.Parse(value);
+    }
+
+    public async Task SetEnableVisualStylesAsync(bool enableVisualStyles)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(EnableVisualStylesProperty, enableVisualStyles.ToString());
+        }
+    }
+
+    public async Task<int?> GetAuthenticationModeAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, AuthenticationModeProperty);
+
+        if (value is null)
+            return null;
+        else
+            return int.Parse(value);
+    }
+
+    public async Task SetAuthenticationModeAsync(int authenticationMode)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(AuthenticationModeProperty, authenticationMode.ToString());
+        }
+    }
+
+    public async Task<bool?> GetSaveMySettingsOnExitAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, SaveMySettingsOnExitProperty);
+
+        if (value is null)
+            return null;
+        else
+            return bool.Parse(value);
+    }
+
+    public async Task SetSaveMySettingsOnExitAsync(bool saveMySettingsOnExit)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(SaveMySettingsOnExitProperty, saveMySettingsOnExit.ToString());
+        }
+    }
+
+    public async Task<int?> GetHighDpiModeAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, HighDpiModeProperty);
+
+        if (value is null)
+            return null;
+        else
+            return int.Parse(value);
+    }
+
+    public async Task SetHighDpiModeAsync(int highDpiMode)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(HighDpiModeProperty, highDpiMode.ToString());
+        }
+    }
+
+    public async Task<string?> GetSplashScreenAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, SplashScreenProperty);
+
+        if (value is null)
+            return null;
+        else
+            return value;
+    }
+
+    public async Task SetSplashScreenAsync(string splashScreen)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(SplashScreenProperty, splashScreen);
+        }
+    }
+
+    public async Task<int?> GetMinimumSplashScreenDisplayTimeAsync()
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(false);
+        string? value = myAppDocument?.GetProperty(_filePath, MinimumSplashScreenDisplayTimeProperty);
+
+        if (value is null)
+            return null;
+        else
+            return int.Parse(value);
+    }
+
+    public async Task SetMinimumSplashScreenDisplayTimeAsync(int minimumSplashScreenDisplayTime)
+    {
+        MyAppDocument? myAppDocument = await TryGetMyAppFileAsync(true);
+
+        if (myAppDocument is not null)
+        {
+            myAppDocument.SetProperty(MinimumSplashScreenDisplayTimeProperty, minimumSplashScreenDisplayTime.ToString());
+        }
+    }
+
+    private async Task<MyAppDocument?> TryGetMyAppFileAsync(bool create)
+    {
+        string _filePath = Path.GetFullPath(_fileName);
+
+        if (_filePath is null)
+        {
+            throw new InvalidOperationException($"The file {_fileName} path cannot be found.");
+        }
+
+        var docData = new DocData(_serviceProvider, _filePath);
+
+        if (docData is not null)
+        {
+            var textReader = new DocDataTextReader(docData);
+            return new MyAppDocument(_fileName, textReader);
+        }
+
+        return null;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -52,8 +52,17 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
             string absolutePath = _project.MakeRooted("My Project\\Application.myapp");
 
             await _threadingService.SwitchToUIThread();
-            _docData = new DocData(_serviceProvider, absolutePath);
-            _docData.Modifying += DocData_Modifying;
+            try
+            {
+                _docData = new DocData(_serviceProvider, absolutePath);
+                _docData.Modifying += DocData_Modifying;
+            } 
+            catch (Exception)
+            {
+                // If we have reached here, it means that the file doesn't exist in that location.
+                return null;
+            }
+            
             await TaskScheduler.Default;
         }
 
@@ -63,8 +72,6 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
         }
 
         return myAppDocument;
-
-        //return null; // Consider when we will reach here: when file doesn't exist.
     }
 
     private async Task SetPropertyAsync(string propertyName, string value)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkPropertiesValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkPropertiesValueProvider.cs
@@ -1,0 +1,85 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+[ExportInterceptingPropertyValueProvider(
+    new[] 
+    {
+        EnableVisualStylesProperty,
+        SingleInstanceProperty,
+        SaveMySettingsOnExitProperty,
+        HighDpiModeProperty,
+        AuthenticationModeProperty,
+        ShutdownModeProperty,
+        SplashScreenProperty,
+        MinimumSplashScreenDisplayTimeProperty
+    }, 
+    ExportInterceptingPropertyValueProviderFile.ProjectFile)] //Note: we don't need to save it in the project file, but we'll intercept the properties.
+internal sealed class ApplicationFrameworkPropertiesValueProvider : InterceptingPropertyValueProviderBase
+{
+    internal const string EnableVisualStylesProperty = "EnableVisualStyles";
+    internal const string SingleInstanceProperty = "SingleInstance";
+    internal const string SaveMySettingsOnExitProperty = "SaveMySettingsOnExit";
+    internal const string HighDpiModeProperty = "HighDpiMode";
+    internal const string AuthenticationModeProperty = "VBAuthenticationMode";
+    internal const string ShutdownModeProperty = "ShutdownMode";
+    internal const string SplashScreenProperty = "SplashScreen";
+    internal const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
+
+    private readonly IMyAppFileAccessor _myAppXamlFileAccessor;
+
+    [ImportingConstructor]
+    public ApplicationFrameworkPropertiesValueProvider(IMyAppFileAccessor MyAppXamlFileAccessor)
+    {
+        _myAppXamlFileAccessor = MyAppXamlFileAccessor;
+    }
+
+    public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return GetPropertyValueAsync(propertyName);
+    }
+
+    public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        return GetPropertyValueAsync(propertyName);
+    }
+
+    public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+    {
+        await (propertyName switch
+        {
+            //ApplicationFrameworkProperty => _myAppXamlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
+            SingleInstanceProperty => _myAppXamlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+            SaveMySettingsOnExitProperty => _myAppXamlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+            HighDpiModeProperty => _myAppXamlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+            AuthenticationModeProperty => _myAppXamlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+            ShutdownModeProperty => _myAppXamlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+            SplashScreenProperty => _myAppXamlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
+            MinimumSplashScreenDisplayTimeProperty => _myAppXamlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+
+            _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
+        });
+
+        return null;
+    }
+
+    private async Task<string> GetPropertyValueAsync(string propertyName)
+    {
+        return propertyName switch
+        {
+            //ApplicationFrameworkProperty => (await _myAppXamlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
+            EnableVisualStylesProperty => (await _myAppXamlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
+            SingleInstanceProperty => (await _myAppXamlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
+            SaveMySettingsOnExitProperty => (await _myAppXamlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
+            HighDpiModeProperty => (await _myAppXamlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
+            AuthenticationModeProperty => (await _myAppXamlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
+            ShutdownModeProperty => (await _myAppXamlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
+            SplashScreenProperty => await _myAppXamlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
+            MinimumSplashScreenDisplayTimeProperty => (await _myAppXamlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
+
+            _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
+        };
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkPropertiesValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkPropertiesValueProvider.cs
@@ -48,9 +48,28 @@ internal sealed class ApplicationFrameworkPropertiesValueProvider : Intercepting
 
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
+        // ValueProvider needs to convert string enums to valid values to be saved.
+        if (propertyName == AuthenticationModeProperty)
+        {
+            if (unevaluatedPropertyValue == "Windows")
+                unevaluatedPropertyValue = "0";
+
+            if (unevaluatedPropertyValue == "ApplicationDefined")
+                unevaluatedPropertyValue= "1";
+        }
+        else if (propertyName == ShutdownModeProperty)
+        {
+            if (unevaluatedPropertyValue == "AfterMainFormCloses")
+                unevaluatedPropertyValue = "0";
+
+            if (unevaluatedPropertyValue == "AfterAllFormsClose")
+                unevaluatedPropertyValue = "1";
+        }
+
         await (propertyName switch
         {
             //ApplicationFrameworkProperty => _myAppXamlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
+            EnableVisualStylesProperty => _myAppXamlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
             SingleInstanceProperty => _myAppXamlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
             SaveMySettingsOnExitProperty => _myAppXamlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
             HighDpiModeProperty => _myAppXamlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkPropertiesValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkPropertiesValueProvider.cs
@@ -125,7 +125,7 @@ internal sealed class ApplicationFrameworkPropertiesValueProvider : Intercepting
                 "1" => "ApplicationDefined",
                 "" => "",
 
-                _ => throw new InvalidDataException($"Invalid value '{value}' for '{propertyName}' property.")
+                _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
             };
         }
         else if (propertyName == HighDpiModeProperty)
@@ -139,7 +139,7 @@ internal sealed class ApplicationFrameworkPropertiesValueProvider : Intercepting
                 "4" => "DpiUnawareGdiScaled",
                 "" => "",
 
-                _ => throw new InvalidDataException($"Invalid value '{value}' for '{propertyName}' property.")
+                _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
             };
         }
         else if (propertyName == ShutdownModeProperty)
@@ -150,7 +150,7 @@ internal sealed class ApplicationFrameworkPropertiesValueProvider : Intercepting
                 "1" => "AfterAllFormsClose",
                 "" => "",
 
-                _ => throw new InvalidDataException($"Invalid value '{value}' for '{propertyName}' property.")
+                _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
             };
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -114,11 +114,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 {
                     // Enabled: <MyType>WindowsForms</MyType>
                     await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, EnabledValue);
+
+                    // TODO: We also need to save this property in the myapp file.
                 }
                 else
                 {
                     // Disabled: <MyType>WindowsFormsWithCustomSubMain</MyType>
                     await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, DisabledValue);
+
+                    // TODO: We also need to save this property in the myapp file.
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -138,7 +138,6 @@
       </NameValuePair>
     </EnumProperty.Metadata>
     <!-- TODO: Validate DisplayName values. -->
-    <!-- TODO: Value provider logic needed to convert string enums to integer values -->
     <EnumValue Name="Windows"
                DisplayName="Windows - Retrieve user info through My.User at runtime." />
     <EnumValue Name="ApplicationDefined"
@@ -161,7 +160,6 @@
         </NameValuePair.Value>
       </NameValuePair>
     </EnumProperty.Metadata>
-    <!-- TODO: Value provider logic needed to convert string enums to integer values -->
     <EnumValue Name="AfterMainFormCloses"
                DisplayName="Shut down when the main form closes." />
     <EnumValue Name="AfterAllFormsClose"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -42,6 +42,10 @@
                 Description="Uses the most current version for the Control Library COMCTL to provide control rendering with modern visual styling."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195445"
                 Category="ApplicationFramework">
+    <BoolProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -56,6 +60,10 @@
                 Description="Prevents users from running multiple instances of the application. Default is cleared, which allows multiple instances of the application to be run."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195340"
                 Category="ApplicationFramework">
+    <BoolProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -70,6 +78,10 @@
                 Description="Controls if settings are saved when users shut down their computers."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195171"
                 Category="ApplicationFramework">
+    <BoolProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -84,6 +96,10 @@
                 Description="Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195173"
                 Category="ApplicationFramework">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </EnumProperty.DataSource>
     <EnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -105,11 +121,15 @@
                DisplayName="Per monitor V2 - DPI detected on-launch and on-change including child windows" />
   </EnumProperty>
 
-  <EnumProperty Name="AuthenticationMode"
+  <EnumProperty Name="VBAuthenticationMode"
                 DisplayName="Authentication mode"
                 Description="Specifies the method of identifying the logged-on user, when needed."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195341"
                 Category="ApplicationFramework">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </EnumProperty.DataSource>
     <EnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -130,6 +150,10 @@
                 Description="Indicates which condition causes the application to shut down."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195343"
                 Category="ApplicationFramework">
+    <EnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </EnumProperty.DataSource>
     <EnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -150,6 +174,10 @@
                        HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195177"
                        Category="ApplicationFramework"
                        EnumProvider="StartupObjectsEnumProvider">
+    <DynamicEnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
@@ -169,6 +197,10 @@
                 Description="Sets the minimum length of time, in milliseconds, for which the splash screen is displayed."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195289"
                 Category="ApplicationFramework">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
     <StringProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -82,16 +82,6 @@
         <target state="new">Startup URI</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|Description">
-        <source>Specifies the method of identifying the logged-on user, when needed.</source>
-        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumProperty|AuthenticationMode|DisplayName">
-        <source>Authentication mode</source>
-        <target state="new">Authentication mode</target>
-        <note />
-      </trans-unit>
       <trans-unit id="EnumProperty|HighDpiMode|Description">
         <source>Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</source>
         <target state="new">Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event.</target>
@@ -122,14 +112,14 @@
         <target state="new">Shutdown mode</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.ApplicationDefined|DisplayName">
-        <source>Application-defined - Custom authentication implemented within the application.</source>
-        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|Description">
+        <source>Specifies the method of identifying the logged-on user, when needed.</source>
+        <target state="new">Specifies the method of identifying the logged-on user, when needed.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|AuthenticationMode.Windows|DisplayName">
-        <source>Windows - Retrieve user info through My.User at runtime.</source>
-        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
+      <trans-unit id="EnumProperty|VBAuthenticationMode|DisplayName">
+        <source>Authentication mode</source>
+        <target state="new">Authentication mode</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
@@ -180,6 +170,16 @@
       <trans-unit id="EnumValue|ShutdownMode_WPF.OnMainWindowClose|DisplayName">
         <source>On main window close</source>
         <target state="new">On main window close</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.ApplicationDefined|DisplayName">
+        <source>Application-defined - Custom authentication implemented within the application.</source>
+        <target state="new">Application-defined - Custom authentication implemented within the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|VBAuthenticationMode.Windows|DisplayName">
+        <source>Windows - Retrieve user info through My.User at runtime.</source>
+        <target state="new">Windows - Retrieve user info through My.User at runtime.</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|CreateOrOpenApplicationXaml|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
@@ -1,0 +1,109 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
+
+/// <summary>
+/// Provides access to properties in the myapp file.
+/// </summary>
+internal interface IMyAppFileAccessor
+{
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<bool?> GetMySubMainAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetMySubMainAsync(string mySubMain);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<string?> GetMainFormAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetMainFormAsync(string mainForm);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<bool?> GetSingleInstanceAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetSingleInstanceAsync(bool singleInstance);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<int?> GetShutdownModeAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetShutdownModeAsync(int shutdownMode);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<bool?> GetEnableVisualStylesAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetEnableVisualStylesAsync(bool enableVisualStyles);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<int?> GetAuthenticationModeAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetAuthenticationModeAsync(int authenticationMode);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<bool?> GetSaveMySettingsOnExitAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetSaveMySettingsOnExitAsync(bool saveMySettingsOnExit);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<int?> GetHighDpiModeAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetHighDpiModeAsync(int highDpiMode);
+
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<string?> GetSplashScreenAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetSplashScreenAsync(string splashScreen);
+    
+    /// <summary>
+    /// Returns the current value of property as stored in the myapp file.
+    /// </summary>
+    Task<int?> GetMinimumSplashScreenDisplayTimeAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetMinimumSplashScreenDisplayTimeAsync(int minimumSplashScreenDisplayTime);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
@@ -5,6 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 /// <summary>
 /// Provides access to properties in the myapp file.
 /// </summary>
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.System, Cardinality = Composition.ImportCardinality.ExactlyOne)]
 internal interface IMyAppFileAccessor
 {
     /// <summary>


### PR DESCRIPTION
WinForms project have specific Applcation Framework properties that need to be read and saved in the corresponding Application.myapp file. For now, we will intercept those properties via the `ApplicationFrameworkPropertiesValueProvider`, but ideally we would like to implement a `IProjectPropertiesProvider` to access the myapp file.

Addresses #7236.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8252)