### PR TITLE
Handle exception when a resx file is moved from a folder to root

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
         Private _isDisposed As Boolean
         Private ReadOnly _rootDesigner As BaseRootDesigner
-        Private ReadOnly _projectItem As EnvDTE.ProjectItem
+        Private ReadOnly _resxFileProjectItem As EnvDTE.ProjectItem
         Private ReadOnly _serviceProvider As IServiceProvider
         Private ReadOnly _namespaceToOverrideIfCustomToolIsEmpty As String
         Private ReadOnly _codeGeneratorEntries As New List(Of CodeGenerator)
@@ -299,7 +299,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Requires.NotNull(serviceProvider, NameOf(serviceProvider))
 
             _rootDesigner = rootDesigner
-            _projectItem = projectItem
+            _resxFileProjectItem = projectItem
             _serviceProvider = serviceProvider
             _namespaceToOverrideIfCustomToolIsEmpty = namespaceToOverrideIfCustomToolIsEmpty
         End Sub
@@ -407,7 +407,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             value = Nothing
 
             Try
-                Dim customToolProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_projectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
+                Dim customToolProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_resxFileProjectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
                 If customToolProperty IsNot Nothing Then
                     Dim customToolValue As String = TryCast(customToolProperty.Value, String)
                     value = customToolValue
@@ -451,8 +451,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="value"></param>
         Private Sub TrySetCustomToolValue(value As String)
             Try
-                Dim customToolProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_projectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
-                Dim customToolNamespaceProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_projectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOLNAMESPACE)
+                Dim customToolProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_resxFileProjectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
+                Dim customToolNamespaceProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_resxFileProjectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOLNAMESPACE)
 
                 If customToolProperty IsNot Nothing Then
                     Dim previousCustomToolValue As String = TryCast(customToolProperty.Value, String)
@@ -565,7 +565,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         Protected Overridable ReadOnly Property Hierarchy As IVsHierarchy
             Get
-                Return ShellUtil.VsHierarchyFromDTEProject(_serviceProvider, _projectItem.ContainingProject)
+                Return ShellUtil.VsHierarchyFromDTEProject(_serviceProvider, _resxFileProjectItem.ContainingProject)
             End Get
         End Property
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -405,15 +405,10 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="value"></param>
         Private Function TryGetCustomToolPropertyValue(ByRef value As String) As Boolean
             value = Nothing
+            Dim customToolProperty As EnvDTE.Property = Nothing
 
             Try
-                Dim customToolProperty As EnvDTE.Property = DTEUtils.GetProjectItemProperty(_resxFileProjectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
-                If customToolProperty IsNot Nothing Then
-                    Dim customToolValue As String = TryCast(customToolProperty.Value, String)
-                    value = customToolValue
-                    _previousCustomToolValue = customToolValue
-                    Return True
-                End If
+                customToolProperty = DTEUtils.GetProjectItemProperty(_resxFileProjectItem, DTEUtils.PROJECTPROPERTY_CUSTOMTOOL)
             Catch ex As KeyNotFoundException
                 ' Possible limitation of Cps. In some cases Cps is not able to maintain the same item id for items,
                 ' causing them to Not be found. In some scenarios (i.e., when the item Is moved), it ends up having
@@ -423,6 +418,13 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     Return True
                 End If
             End Try
+
+            If customToolProperty IsNot Nothing Then
+                Dim customToolValue As String = TryCast(customToolProperty.Value, String)
+                value = customToolValue
+                _previousCustomToolValue = customToolValue
+                Return True
+            End If
 
             Return False
         End Function


### PR DESCRIPTION
Fixes [AB#1243638](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1243638) 

Scenario: 
When a user has any C# project type, containing more than two nested folders and a resX file located inside the nested folder. If the user opens the resX file, and keep it open while the user moves (drag & drop) the resX file from the folder to the root of the project, cps will throw the exception `KeyNotFoundException` because item id is invalid. 
This is a limitation of Cps. In some cases Cps is not able to maintain the same item id for items, causing them to not be found.
In some scenarios (i.e., when the item is moved), it ends up having a different id, so the older one can't be found anymore.

Since this is not easy to fix in Cps, and it is better to handle this at the dotnet project system level.
One possible solution is try to reacquire the `DTE.ProjectItem` when the exception occurs, but doing this causes to throw other exceptions.
The solution provided in here is to reuse the last valid custom tool value used in the `AccessModifierCombobox` if the exception is thrown. Reusing makes sense because the custom tool value is coming from the same resX file, and during the file move this value will not change.

Also as part of this change  `_projectItem` is renamed to `_resxFileProjectItem` to make clear that the custom tool value is from the resx file being edited.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8253)