### PR TITLE
Small edits on DisplayNames

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -38,7 +38,7 @@
   </BoolProperty>
 
   <BoolProperty Name="EnableVisualStyles"
-                DisplayName="Windows XP Visual Styles"
+                DisplayName="Windows Visual Styles"
                 Description="Uses the most current version for the Control Library COMCTL to provide control rendering with modern visual styling."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195445"
                 Category="ApplicationFramework">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -616,7 +616,7 @@
                 Category="Advanced"/>
 
   <BoolProperty Name="DefineTrace"
-                DisplayName="Degine TRACE constant"
+                DisplayName="Define TRACE constant"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196264"
                 Category="Advanced"/>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|EnableVisualStyles|DisplayName">
-        <source>Windows XP Visual Styles</source>
-        <target state="new">Windows XP Visual Styles</target>
+        <source>Windows Visual Styles</source>
+        <target state="new">Windows Visual Styles</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|SaveMySettingsOnExit|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -8,8 +8,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
-        <source>Degine TRACE constant</source>
-        <target state="new">Degine TRACE constant</target>
+        <source>Define TRACE constant</source>
+        <target state="new">Define TRACE constant</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|GenerateDocumentationFile|Description">


### PR DESCRIPTION
We had a typo in the property `DefineTrace` and a request to remove XP from the `EnableVisualStyles` property's DisplayName.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8266)