### PR TITLE
Better hygiene for solution build event subscriptions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
         {
             if (initialized)
             {
-                Assumes.NotNull(_solutionBuildEvents);
+                Assumes.NotNull(_solutionBuildEventsSubscription);
                 Assumes.NotNull(_rdtEventsSubscription);
 
                 if (_solutionBuildEventsSubscription is not null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -90,15 +90,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                 Assumes.NotNull(_solutionBuildEventsSubscription);
                 Assumes.NotNull(_rdtEventsSubscription);
 
-                if (_solutionBuildEventsSubscription is not null)
-                {
-                    await _solutionBuildEventsSubscription.DisposeAsync();
-                }
-
-                if (_rdtEventsSubscription is not null)
-                {
-                    await _rdtEventsSubscription.DisposeAsync();
-                }
+                await _solutionBuildEventsSubscription.DisposeAsync();
+                await _rdtEventsSubscription.DisposeAsync();
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureDetector.cs
@@ -90,6 +90,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                 Assumes.NotNull(_solutionBuildEventsSubscription);
                 Assumes.NotNull(_rdtEventsSubscription);
 
+                // Switch the UI thread once here, rather than once per dispose below
+                await JoinableFactory.SwitchToMainThreadAsync();
+
                 await _solutionBuildEventsSubscription.DisposeAsync();
                 await _rdtEventsSubscription.DisposeAsync();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/SolutionBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/SolutionBuildManager.cs
@@ -63,9 +63,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 await JoinableFactory.SwitchToMainThreadAsync();
 
-                HResult.Verify(
-                    _vsSolutionBuildManager2.UnadviseUpdateSolutionEvents(cookie),
-                    $"Error unadvising solution events in {typeof(SolutionBuildManager)}.");
+                if (cookie != VSConstants.VSCOOKIE_NIL)
+                {
+                    HResult.Verify(
+                        _vsSolutionBuildManager2.UnadviseUpdateSolutionEvents(cookie),
+                        $"Error unadvising solution events in {typeof(SolutionBuildManager)}.");
+                }
 
                 if (cookie3 != VSConstants.VSCOOKIE_NIL)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/AsyncDisposable.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/AsyncDisposable.cs
@@ -8,8 +8,16 @@ namespace Microsoft.VisualStudio.ProjectSystem
     {
         private readonly Func<ValueTask> _callback;
 
+        private int _isDisposed;
+
         public AsyncDisposable(Func<ValueTask> callback) => _callback = callback;
 
-        public async ValueTask DisposeAsync() => await _callback();
+        public async ValueTask DisposeAsync()
+        {
+            if (Interlocked.CompareExchange(ref _isDisposed, 1, 0) == 0)
+            {
+                await _callback();
+            }
+        }
     }
 }


### PR DESCRIPTION
Some improvements to how we register and unregister from solution build events.

These follow investigation into the crash described in [AB#1535665](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1535665).

That crash comes from some native code and it's unclear to me whether the changes here would influence that crash at all, but these changes do improve our correctness by:

1. Avoiding a double-dispose that might potentially request unadvise more than once
2. Ensuring that exceptions don't stop us treating our pair of subscriptions in such a way that one of the two is left dangling
3. Not unadvising events if we somehow have a nil cookie

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8269)