### PR TITLE
Hide new properties from Application Framework category.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -95,7 +95,8 @@
                 DisplayName="High DPI mode"
                 Description="Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195173"
-                Category="ApplicationFramework">
+                Category="ApplicationFramework"
+                Visible="False">
     <EnumProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
@@ -171,7 +172,8 @@
                        Description="Sets the form to be used as a splash screen for the application."
                        HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195177"
                        Category="ApplicationFramework"
-                       EnumProvider="StartupObjectsEnumProvider">
+                       EnumProvider="StartupObjectsEnumProvider"
+                       Visible="False">
     <DynamicEnumProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
@@ -194,7 +196,8 @@
                 DisplayName="Minimum splash screen display time"
                 Description="Sets the minimum length of time, in milliseconds, for which the splash screen is displayed."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195289"
-                Category="ApplicationFramework">
+                Category="ApplicationFramework"
+                Visible="False">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />


### PR DESCRIPTION
We can hold from showing these 3 new properties from the UI until we have the correct logic in place in the code generator for the Application.Designer.vb that will come in 17.4.

This is how it would look like:
![image](https://user-images.githubusercontent.com/8518253/176320967-bee32368-0281-444f-81e0-288d58031afc.png)

Note: we agreed that it was okay to hide these 3 properties as they weren't surfaced in the old experience, and we want to ensure the end-to-end scenario works before introducing them.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8283)