### PR TITLE
Make sure Prefer 32 Bit property is appearing when it should

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -122,7 +122,7 @@
         <NameValuePair.Value>
           (and
             (has-net-framework)
-            (has-evaluated-value "Build" "PlatformTarget" "AnyCPU")
+            (has-evaluated-value "Build" "PlatformTarget" "Any CPU")
             (or
               (has-evaluated-value "Application" "OutputType" "Exe")
               (has-evaluated-value "Application" "OutputType" "WinExe")

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -110,7 +110,7 @@
         <NameValuePair.Value>
           (and
             (has-net-framework)
-            (has-evaluated-value "Build" "PlatformTarget" "AnyCPU")
+            (has-evaluated-value "Build" "PlatformTarget" "Any CPU")
             (or
               (has-evaluated-value "Application" "OutputType" "Exe")
               (has-evaluated-value "Application" "OutputType" "WinExe")


### PR DESCRIPTION
Currently, the property only shows up if the following condition is satisfied: `(has-evaluated-value "Build" "PlatformTarget" "AnyCPU")`

However, even though the value is saved to the csproj as AnyCPU, the actual unevaluated/evaluated value of AnyCPU is _Any CPU_. This change simply renames AnyCPU to Any CPU in the visibility condition.

Fixes #8016 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8290)