### PR TITLE
Update CPS version, pass EditabilityCondition metadata back to cps

### DIFF
--- a/build/import/Packages.targets
+++ b/build/import/Packages.targets
@@ -51,7 +51,7 @@
     <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.1.0-preview-2-32002-062" />
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.1.0-preview-2-32002-062"/>
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.2.30-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.3.13-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.0.4492" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
@@ -60,23 +60,23 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.1.0-preview-2-32002-062" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.4.13" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.2.32" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.2.32" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.3.22-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.3.22-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.53" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.58" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.1.0-preview-2-32002-062" />
     <PackageReference Update="System.Threading.Tasks.Dataflow"                                        Version="6.0.0" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219"/>
 
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
-    <PackageReference Include="StreamJsonRpc"                                                         Version="2.11.32-alpha" />
+    <PackageReference Include="StreamJsonRpc"                                                         Version="2.11.35" />
 
     <!-- CPS -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.3.195-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.3.195-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.3.195-pre" />
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.3.195-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem"                                   Version="17.4.5-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.4.5-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.4.5-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.4.5-pre" />
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionBase.cs
@@ -62,6 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
             s_requestedPropertyProperties.RequireProperty(UIPropertyType.VisibilityConditionPropertyName);
             s_requestedPropertyProperties.RequireProperty(UIPropertyType.DimensionVisibilityConditionPropertyName);
             s_requestedPropertyProperties.RequireProperty(UIPropertyType.ConfiguredValueVisibilityConditionPropertyName);
+            s_requestedPropertyProperties.RequireProperty(UIPropertyType.EditabilityConditionPropertyName);
             s_requestedPropertyProperties.Freeze();
 
             s_requestedEditorProperties = new UIPropertyEditorPropertiesAvailableStatus();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -126,6 +126,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 newUIProperty.ConfiguredValueVisibilityCondition = configuredValueVisibilityCondition ?? string.Empty;
             }
             
+            if (requestedProperties.EditabilityCondition)
+            {
+                string? editabilityCondition = property.GetMetadataValueOrNull("EditabilityCondition");
+                newUIProperty.EditabilityCondition = editabilityCondition ?? string.Empty;
+            }
+            
             ((IEntityValueFromProvider)newUIProperty).ProviderState = new PropertyProviderState(cache, property.ContainingRule, propertiesContext, property.Name);
 
             return newUIProperty;


### PR DESCRIPTION
This is a compliment to [this](https://devdiv.visualstudio.com/DevDiv/_git/CPS/commit/411f55af22664adfdb61c1591c61c7cde9f9837d) CPS commit that adds EditabilityCondition as UIProperty metadata. It passes the EditabilityCondition back to CPS, including on launch pages.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8312)