### PR TITLE
Improve the incremental build warning message

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to WARNING: Potential incremental build failure in &apos;{0}&apos;. {1}. See https://aka.ms/incremental-build-failure..
+        ///   Looks up a localized string similar to WARNING: Potential build performance issue in &apos;{0}&apos;. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure..
         /// </summary>
         internal static string IncrementalBuildFailureWarningMessage_2 {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -282,7 +282,7 @@ In order to debug this project, add an executable project to this solution which
     <value>Hot Reload is not available because startup hooks have been disabled, possibly due to trimming.</value>
   </data>
   <data name="IncrementalBuildFailureWarningMessage_2" xml:space="preserve">
-    <value>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</value>
+    <value>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</value>
     <comment>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</comment>
   </data>
   <data name="UpdateNamespacePromptMessage" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">UPOZORNĚNÍ: Potenciální přírůstkové selhání sestavení v {0}. {1}. Další informace: https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">UPOZORNĚNÍ: Potenciální přírůstkové selhání sestavení v {0}. {1}. Další informace: https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">WARNUNG: Potenzieller inkrementeller Buildfehler in "{0}". {1}. Siehe https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">WARNUNG: Potenzieller inkrementeller Buildfehler in "{0}". {1}. Siehe https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">ADVERTENCIA: posible error de compilación incremental en "{0}". {1}. Consultar: https://aka.ms/incremental-build-failure</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">ADVERTENCIA: posible error de compilación incremental en "{0}". {1}. Consultar: https://aka.ms/incremental-build-failure</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">AVERTISSEMENT : échec potentiel de build incrémentielle dans '{0}' {1}. Voir : https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">AVERTISSEMENT : échec potentiel de build incrémentielle dans '{0}' {1}. Voir : https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">AVVISO: possibile errore di compilazione incrementale in '{0}{1}'. Vedi: https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">AVVISO: possibile errore di compilazione incrementale in '{0}{1}'. Vedi: https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="new">WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="new">WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">경고: '{0}'에서 증분 빌드 실패가 발생할 수 있습니다. {1}. 참조: https://aka.ms/incremental-build-failure</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">경고: '{0}'에서 증분 빌드 실패가 발생할 수 있습니다. {1}. 참조: https://aka.ms/incremental-build-failure</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">OSTRZEŻENIE: Potencjalny przyrostowy błąd kompilacji w „{0}”. {1}. Zobacz: https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">OSTRZEŻENIE: Potencjalny przyrostowy błąd kompilacji w „{0}”. {1}. Zobacz: https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">AVISO: Potencial falha de compilação incremental em '{0}'. {1}. Veja https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">AVISO: Potencial falha de compilação incremental em '{0}'. {1}. Veja https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">ПРЕДУПРЕЖДЕНИЕ. Возможный сбой добавочной сборки в "{0}". {1}. Сведения: https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">ПРЕДУПРЕЖДЕНИЕ. Возможный сбой добавочной сборки в "{0}". {1}. Сведения: https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">UYARI: '{0}' içinde olası artımlı derleme hatası oluştu. {1}. Bkz. https://aka.ms/incremental-build-failure.</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">UYARI: '{0}' içinde olası artımlı derleme hatası oluştu. {1}. Bkz. https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">警告:“{0}”中可能的增量生成失败。{1}。请参阅: https://aka.ms/incremental-build-failure。</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">警告:“{0}”中可能的增量生成失败。{1}。请参阅: https://aka.ms/incremental-build-failure。</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -111,8 +111,8 @@
         <note />
       </trans-unit>
       <trans-unit id="IncrementalBuildFailureWarningMessage_2">
-        <source>WARNING: Potential incremental build failure in '{0}'. {1}. See https://aka.ms/incremental-build-failure.</source>
-        <target state="translated">警告: '{0}' 可能發生累加建置失敗。{1}。請參閱: https://aka.ms/incremental-build-failure。</target>
+        <source>WARNING: Potential build performance issue in '{0}'. The project does not appear up-to-date after a successful build: {1}. See https://aka.ms/incremental-build-failure.</source>
+        <target state="needs-review-translation">警告: '{0}' 可能發生累加建置失敗。{1}。請參閱: https://aka.ms/incremental-build-failure。</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">


### PR DESCRIPTION
The previous message could be interpreted as meaning the build failed in some way. This message should make the nature of the warning more obvious.

Thanks @y87feng for the feedback on this.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8315)