### PR TITLE
Check correct registry key on ARM64

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/NetCoreRuntimeVersionsRegistryReader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/NetCoreRuntimeVersionsRegistryReader.cs
@@ -1,12 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Microsoft.Win32;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Runtimes
 {
     internal sealed class NetCoreRuntimeVersionsRegistryReader
     {
-        private static readonly string s_netCoreRegistryKeyPath = "SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\x64\\sharedfx\\";
+        private static readonly string s_arm64NetCoreRegistryKeyPath = "SOFTWARE\\dotnet\\Setup\\InstalledVersions\\ARM64\\sharedfx\\";
+        private static readonly string s_x64NetCoreRegistryKeyPath = "SOFTWARE\\WOW6432Node\\dotnet\\Setup\\InstalledVersions\\x64\\sharedfx\\";
         private static readonly string s_netCoreRegistryKeyName = "Microsoft.NETCore.App";
 
         /// <summary>
@@ -18,16 +20,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.Runtimes
         /// <returns>A list of strings representing runtime versions in the format v{Majorversion}.{MinorVersion}. i.e. "v3.1"</returns>
         public static HashSet<string>? ReadRuntimeVersionsInstalledInLocalMachine()
         {
-            var regkey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
-            var subKey = regkey.OpenSubKey(s_netCoreRegistryKeyPath + s_netCoreRegistryKeyName);
+            // TODO:
+            // We assume that the projects will run under the same architecture as VS.
+            // This will be the common case, but it does not cover situations where
+            // a project will run under emulation (e.g. an x64 build running on an ARM64
+            // system.
+            string? registryKeyPath = null;
+            if (RuntimeInformation.ProcessArchitecture == Architecture.X64)
+            {
+                registryKeyPath = s_x64NetCoreRegistryKeyPath;
+            }
+            else if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+            {
+                registryKeyPath = s_arm64NetCoreRegistryKeyPath;
+            }
 
             HashSet<string> runtimeVersions = new(StringComparer.OrdinalIgnoreCase);
 
-            foreach (string valueName in subKey.GetValueNames())
+            if (registryKeyPath is not null)
             {
-                // There is guarantee to always have $(Major).$(Minor)
-                string versionNumber = valueName.Substring(0, valueName.LastIndexOf('.'));
-                runtimeVersions.Add($"v{versionNumber}");
+                var regkey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry64);
+                var subKey = regkey.OpenSubKey(registryKeyPath + s_netCoreRegistryKeyName);
+
+                foreach (string valueName in subKey.GetValueNames())
+                {
+                    // There is guarantee to always have $(Major).$(Minor)
+                    string versionNumber = valueName.Substring(0, valueName.LastIndexOf('.'));
+                    runtimeVersions.Add($"v{versionNumber}");
+                }
             }
 
             return runtimeVersions;


### PR DESCRIPTION
Fixes [AB#1552807](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1552807).

The project system tries to check if projects in the solution depend on a version of the .NET runtime that isn't installed, and if so pops up a gold bar with a link to the appropriate component in the VS installer. As part of this, the `NetCoreRuntimeVersionsRegistryReader` attempts to find globally-installed .NET runtimes (that is, runtimes installed _outside_ the VS installer) by enumerating registry keys under a well-known path.

It turns out this path is correct on an x64 system, but not on an ARM64 system. The end result is that even if you have, say, the .NET 5.0 runtime installed on your ARM64 system we won't properly detect it, and we'll incorrectly pop up the gold bar.

Here we fix this issue by varying the registry path based on the VS process architecture.

Note this covers the common case but still misses some corner cases. Notably, if the build of a project targets x64 (rather than Any CPU or ARM64) it will need the x64 runtime installed to run properly under emulation and we won't detect that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8317)