### PR TITLE
Set .nupkg version as prerelease

### DIFF
--- a/version.json
+++ b/version.json
@@ -3,9 +3,6 @@
   "version": "17.4",
   "assemblyVersion": "17.4",
   "buildNumberOffset": 0,
-  "publicReleaseRefSpec": [
-    "^refs/heads/main$"
-  ],
   "cloudBuild": {
     "buildNumber": {
       "enabled": true,


### PR DESCRIPTION
Documentation here: https://github.com/dotnet/Nerdbank.GitVersioning/blob/main/doc/versionJson.md#file-format
Public package feed (for reference): https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl/NuGet/Microsoft.VisualStudio.ProjectSystem.Managed

This removes `publicReleaseRefSpec` for `main` from the `version.json` since we don't actually create non-prerelease `.nupkg` currently. Creating non-prerelease packages causes the build to fail as we rely on prerelease packages. The way NuGet pack works is that *release packages cannot depend on prerelease packages*. Removing  `publicReleaseRefSpec` from `version.json` will only affect the `.nupkg` version number and no other version numbers in the build. I checked that interaction by looking the build I did yesterday from the separate branch.

### Example
For context, before this PR (on `main`):
> Successfully created package 'D:\a\_work\1\s\artifacts\Release\packages\Microsoft.VisualStudio.ProjectSystem.Managed.17.4.6.nupkg'.

After this PR (on `main`):
> Successfully created package 'D:\a\_work\1\s\artifacts\Release\packages\Microsoft.VisualStudio.ProjectSystem.Managed.17.4.6-gb72e5fc7f9.nupkg'.

Adding a `-` in SemVer marks the package as prerelease. It don't matter what comes after the `-`. In this case, that value is the commit ID.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8323)