### PR TITLE
Fix broken removal of shared project references

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModel.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
     internal class SharedProjectDependencyModel : DependencyModel
     {
         private static readonly DependencyFlagCache s_flagCache = new(
-            resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse,
-            unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse,
+            resolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse + ProjectTreeFlags.FileSystemEntity,
+            unresolved: DependencyTreeFlags.ProjectDependency + DependencyTreeFlags.SharedProjectDependency + DependencyTreeFlags.SupportsBrowse + ProjectTreeFlags.FileSystemEntity,
             remove: DependencyTreeFlags.SupportsRuleProperties);
 
         private static readonly DependencyIconSet s_iconSet = new(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Models/SharedProjectDependencyModelTests.cs
@@ -40,7 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.ResolvedDependencyFlags -
-                DependencyTreeFlags.SupportsRuleProperties,
+                DependencyTreeFlags.SupportsRuleProperties +
+                ProjectTreeFlags.FileSystemEntity,
                 model.Flags);
         }
 
@@ -74,7 +75,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.SharedProjectDependency +
                 DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.UnresolvedDependencyFlags -
-                DependencyTreeFlags.SupportsRuleProperties,
+                DependencyTreeFlags.SupportsRuleProperties +
+                ProjectTreeFlags.FileSystemEntity,
                 model.Flags);
         }
 
@@ -109,7 +111,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
                 DependencyTreeFlags.SupportsBrowse +
                 DependencyTreeFlags.ResolvedDependencyFlags -
                 DependencyTreeFlags.SupportsRuleProperties -
-                DependencyTreeFlags.SupportsRemove,
+                DependencyTreeFlags.SupportsRemove +
+                ProjectTreeFlags.FileSystemEntity,
                 model.Flags);
         }
     }


### PR DESCRIPTION
Fixes #8305
Relates to #8045 and #8202

In 17.2, CPS made a change to how paths are used for non-file items in the tree. These changes improve the performance of searching the dependency tree by path, as the pseudo-id used for items not having paths allows a fast lookup.

As these shared project dependency tree items were created without the `ProjectTreeFlags.FileSystemEntity`, they were not having their `IProjectTree.FilePath` property populated, which meant that attempts to manually remove the shared project reference from the project failed, as the item to be removed could not be identified.

This change adds a flag to these items so that the `FilePath` property is populated, which allows removal to occur correctly.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8329)