### PR TITLE
Fix duplicate package publish

### DIFF
--- a/.github/ISSUE_TEMPLATE/branch-checklist.md
+++ b/.github/ISSUE_TEMPLATE/branch-checklist.md
@@ -19,13 +19,13 @@ _Descriptions of these steps can be found in the team OneNote._
 - [ ] Create branch on GitHub at that commit
   - [ ] https://github.com/dotnet/project-system/tree/dev17.❓.x
 - [ ] For branches not matching `dev*` or `feature/*` (usually we skip these)
-  - [ ] Update the [YAML file](https://github.com/dotnet/project-system/blob/main/build/ci/unit-tests.yml) to support CI/PR builds
+  - [ ] Update the [YAML file](..\\..\eng\pipelines\unit-tests.yml) to support CI/PR builds
   - [ ] Update the [signed build definition](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9675) to build the new branch
 - [ ] Update Roslyn Tools [config.xml](https://github.com/dotnet/roslyn-tools/blob/main/src/GitHubCreateMergePRs/config.xml) file to flow branch changes to the latest dev branch
   - [ ] dotnet/roslyn-tools PR: https://github.com/dotnet/roslyn-tools/pull/❓
 - [ ] Update [Versions.props](..\\..\eng\imports\Versions.props) (via `<ProjectSystemVersion>`) and [version.json](..\\..\version.json) (via `"version"` and `"assemblyVersion"`) to match the version of VS, if needed
-    - [ ] In new branch: https://github.com/dotnet/project-system/blob/dev17.❓.x/build/import/Versions.props
-    - [ ] In `main`: https://github.com/dotnet/project-system/blob/main/build/import/Versions.props
+    - [ ] In new branch: https://github.com/dotnet/project-system/blob/dev17.❓.x/eng/imports/Versions.props
+    - [ ] In `main`: https://github.com/dotnet/project-system/blob/main/eng/imports/Versions.props
 - [ ] Clone existing release definition to insert this branch into VS (see OneNote)
 - [ ] Update [README.md](https://github.com/dotnet/project-system/blob/main/README.md) (in `main`) if we need new badges
 - [ ] Update [MSFTBot milestone tracking](https://aka.ms/fabricbotconfig)

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -286,6 +286,9 @@ steps:
     packagesToPush: 'artifacts\$(BuildConfiguration)\packages\*.nupkg'
     nuGetFeedType: 'external'
     publishFeedCredentials: azure-public/vs-impl
+    # This allows the task to succeed if duplicate packages exist. Packages cannot be overridden in a feed.
+    # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget?view=azure-devops#arguments
+    allowPackageConflicts: true
 
 # Publishes the packages to https://dev.azure.com/DevDiv/DevDiv/_artifacts/feed/VS
 # The RoslynInsertionTool will republish these contents from the VS feed to https://dev.azure.com/DevDiv/DevDiv/_artifacts/feed/VS-CoreXtFeeds
@@ -297,6 +300,8 @@ steps:
     # Feed Endpoint: https://devdiv.pkgs.visualstudio.com/_packaging/VS/nuget/v3/index.json
     # Requires VssFeedId despite documentation here: https://docs.microsoft.com/en-us/azure/devops/pipelines/artifacts/nuget?view=azure-devops&tabs=yaml#publish-a-package
     publishVstsFeed: '97a41293-2972-4f48-8c0e-05493ae82010'
+    # This allows the task to succeed if duplicate packages exist. Packages cannot be overridden in a feed.
+    # See: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget?view=azure-devops#arguments
     allowPackageConflicts: true
 
 ###################################################################################################################################################################


### PR DESCRIPTION
Prerequisite PR: https://github.com/dotnet/project-system/pull/8328

Our new version numbering (via [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning)) will not change the version number if there are no new commits in a build. When running our [official pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9675), this will cause the build to fail as it will try to publish the package again to the `azure-public` feed. To avoid this failure, we use `allowPackageConflicts: true` which tells the task not to fail when a *409 Conflict* occurs when it tries to upload the same package again. We had this flag on for our `DevDiv/VS` publish, but not our `azure-public` one.

### UI Description of `allowPackageConflicts`
![image](https://user-images.githubusercontent.com/17788297/179628793-9204b139-3b0b-4476-991b-d50ad544b1ae.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8331)