### PR TITLE
Old (slow) link causes intermittent link check failures

### DIFF
--- a/docs/feature-comparison.md
+++ b/docs/feature-comparison.md
@@ -65,4 +65,4 @@ Code Metrics                                                                | �
 Code Clones                                                                 | ●        | ●
 Fakes                                                                       | ●        | ● (16.7)
 T4 Templates                                                                | ●        | 
-[Automation Extenders](https://msdn.microsoft.com/en-us/library/0y92k2w2.aspx)| ●      | ●
+[Automation Extenders](https://docs.microsoft.com/previous-versions/0y92k2w2(v=vs.140))| ●      | ●


### PR DESCRIPTION
[This link](https://msdn.microsoft.com/en-us/library/0y92k2w2.aspx) is very old and has slow redirection. Updated to have [current link](https://docs.microsoft.com/previous-versions/0y92k2w2(v=vs.140)) directly to the doc.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8332)