### PR TITLE
Create Application.myapp if none exists during property access/set

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -15,8 +15,8 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
     private readonly IProjectThreadingService _threadingService;
     private readonly IPhysicalProjectTreeStorage _storage;
     private DocData? _docData;
-    private MyAppDocument? myAppDocument;
-    private string _absolutePath;
+    private MyAppDocument? _myAppDocument;
+    private readonly string _absolutePath;
 
     private const string MySubMainProperty = "MySubMain";
     private const string MainFormProperty = "MainForm";
@@ -63,7 +63,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
 
     private void DocData_Modifying(object sender, EventArgs e)
     {
-        myAppDocument = null;
+        _myAppDocument = null;
     }
 
     private async Task<MyAppDocument?> TryGetMyAppFileAsync()
@@ -88,7 +88,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
         {
             _docData = new DocData(_serviceProvider, _absolutePath);
             _docData.Modifying += DocData_Modifying;
-            myAppDocument = new MyAppDocument(_docData);
+            _myAppDocument = new MyAppDocument(_docData);
         }
         catch (NullReferenceException)
         {
@@ -98,7 +98,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
 
         await TaskScheduler.Default;
 
-        return myAppDocument;
+        return _myAppDocument;
     }
 
     private async Task SetPropertyAsync(string propertyName, string value)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -90,7 +90,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
             _docData.Modifying += DocData_Modifying;
             myAppDocument = new MyAppDocument(_docData);
         }
-        catch (Exception)
+        catch (NullReferenceException)
         {
             // If we've reached here, the file write succeeded but the file may have been deleted by the time UI thread is switched to
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -70,7 +70,6 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
     {
         if (_docData?.Data is null)
         {
-            await TaskScheduler.Default;
             // Create My Project directory if it doesn't exist. If it does, nothing happens
             await _storage.CreateFolderAsync("My Project");
 
@@ -94,6 +93,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
         catch (Exception)
         {
             // If we've reached here, the file write succeeded but the file may have been deleted by the time UI thread is switched to
+            return null;
         }
 
         await TaskScheduler.Default;


### PR DESCRIPTION
This PR modifies the MyAppFileAccessor to check if the Application.myapp file exists in the project when obtaining a MyAppDocument instance (when reading/setting a property). If none exists, one is created with the contents being the default winforms template.

Fixes #8258