### PR TITLE
Fix scheduling of evaluation/build data application

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -384,7 +384,7 @@ dotnet_diagnostic.IDE1006WithoutSuggestion.severity = suggestion
 
 
 # Microsoft.VisualStudio.Threading.Analyzers
-dotnet_diagnostic.VSTHRD200.severity = error    # Naming styles                                 Task Open()                                         Task OpenAsync()
+dotnet_diagnostic.VSTHRD200.severity = error    # Use Async suffix for async methods                                         Task OpenAsync()
 dotnet_diagnostic.VSTHRD010.severity = none     # Visual Studio service should be used on main thread explicitly.
 dotnet_diagnostic.VSTHRD103.severity = none     # Call async methods when in an async method.
 dotnet_diagnostic.VSTHRD108.severity = none     # Thread affinity checks should be unconditional.

--- a/.editorconfig
+++ b/.editorconfig
@@ -390,6 +390,7 @@ dotnet_diagnostic.VSTHRD103.severity = none     # Call async methods when in an 
 dotnet_diagnostic.VSTHRD108.severity = none     # Thread affinity checks should be unconditional.
 dotnet_diagnostic.VSTHRD003.severity = none     # Avoid awaiting or returning a Task representing work that was not started within your context as that can lead to deadlocks
 dotnet_diagnostic.VSTHRD111.severity = none     # Use ConfigureAwait(true).
+dotnet_diagnostic.VSTHRD100.severity = error    # Avoid async void methods
 
 # Microsoft.VisualStudio.SDK.Analyzers
 dotnet_diagnostic.VSSDK006.severity = none      # Check whether the result of GetService calls is null

--- a/.editorconfig
+++ b/.editorconfig
@@ -382,8 +382,9 @@ dotnet_diagnostic.IDE0090.severity = warning      # Use new(...)
 dotnet_diagnostic.IDE1006.severity = warning      # Naming styles                                 Task Open()                                         Task OpenAsync()
 dotnet_diagnostic.IDE1006WithoutSuggestion.severity = suggestion
 
-
 # Microsoft.VisualStudio.Threading.Analyzers
+# https://github.com/microsoft/vs-threading/blob/main/doc/analyzers/index.md
+
 dotnet_diagnostic.VSTHRD200.severity = error    # Use Async suffix for async methods                                         Task OpenAsync()
 dotnet_diagnostic.VSTHRD010.severity = none     # Visual Studio service should be used on main thread explicitly.
 dotnet_diagnostic.VSTHRD103.severity = none     # Call async methods when in an async method.


### PR DESCRIPTION
Follows from #8321

Previously the code intended to make build updates wait for the application of initial evaluation data had two problems:

1. The `await` occurred within the `ApplyProjectBuild` callback provided to `OnProjectChangedAsync`, however that method attempts to dereference the `ContextId` which is invalid until the first evaluation data has been applied. This commit moves the `await` earlier to prevent this.

2. The `ApplyProjectBuild` callback was `async void` which is an anti-pattern in general. In this particular case, it broke the expectation that a lock is held throughout the operation, as the first yield within the async method would return control to the caller, which would then release the lock while the remainder of the `async void` method continued unprotected.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8340)