### PR TITLE
Fix shared project after rename from "build" to "eng"

### DIFF
--- a/eng/eng.shproj
+++ b/eng/eng.shproj
@@ -8,6 +8,6 @@
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
   <PropertyGroup />
-  <Import Project="build.projitems" Label="Shared" />
+  <Import Project="eng.projitems" Label="Shared" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
 </Project>


### PR DESCRIPTION
### Before

![image](https://user-images.githubusercontent.com/350947/180702571-ffe5486e-a374-4284-9acc-c0191dca4c03.png)

(Nothing to expand.)

### After

![image](https://user-images.githubusercontent.com/350947/180702508-079a8c56-4349-42b5-848e-3918495c7c0e.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8341)