### PR TITLE
Add analyzer to enforce use of `is null` for null checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -216,6 +216,10 @@ csharp_using_directive_placement = outside_namespace:error
 csharp_prefer_static_local_function = true:warning
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:warning
 
+# CSInNull analyzer
+dotnet_diagnostic.CSIsNull001.severity = warning
+dotnet_diagnostic.CSIsNull002.severity = warning
+
 # Dotnet code analysis settings:
 [*.{cs,vb}]
 

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -52,6 +52,7 @@
 
     <!-- Analyzers-->
     <!-- Set PrivateAssets="all" to prevent consumers of our packages from picking up these analyzers transitively. -->
+    <PackageReference Include="CSharpIsNullAnalyzer"                           PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers"               PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"        PrivateAssets="all" />

--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -69,6 +69,7 @@
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 
     <!-- Analyzers -->
+    <PackageReference Update="CSharpIsNullAnalyzer"                                                   Version="0.1.300" />
     <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.2" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="3.11.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="3.11.0" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             get
             {
-                if (_projectPathToProjectConfigurationsMap == null)
+                if (_projectPathToProjectConfigurationsMap is null)
                 {
                     Interlocked.CompareExchange(ref _projectPathToProjectConfigurationsMap, new(), null);
                 }
@@ -180,7 +180,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public void RegisterProjectConfiguration(Guid projectGuid, ConfiguredProject project)
         {
-            if (project.ProjectConfiguration == null)
+            if (project.ProjectConfiguration is null)
             {
                 const string errorMessage = "Cannot register the project configuration for a null project configuration.";
                 TraceUtilities.TraceError(errorMessage);
@@ -427,7 +427,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if (_solutionCookie != VSConstants.VSCOOKIE_NIL)
             {
-                if (_vsSolution != null)
+                if (_vsSolution is not null)
                 {
                     Verify.HResult(_vsSolution.UnadviseSolutionEvents(_solutionCookie));
                     _solutionCookie = VSConstants.VSCOOKIE_NIL;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/DotNetNamespaceImportsList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/DotNetNamespaceImportsList.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
             // Due to that, and to avoid a deadlock when event handlers call back into us
             // while we're still initializing, we avoid firing the events the first time 
             // a value is applied.
-            if (previous != null)
+            if (previous is not null)
             {
                 DotNetVSImports imports = VSImports.Value;
                 ImmutableList<string> currentValue = value.Value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/DotNetVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/DotNetVSImports.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
                 _ => null
             };
 
-            if (importToRemove != null)
+            if (importToRemove is not null)
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             // We don't want to hold up reporting of a completed build on this.
             Guid outputPaneGuid = VSConstants.GUID_BuildOutputWindowPane;
 
-            if (_outputWindow.Value.GetPane(ref outputPaneGuid, out IVsOutputWindowPane? outputPane) == HResult.OK && outputPane != null)
+            if (_outputWindow.Value.GetPane(ref outputPaneGuid, out IVsOutputWindowPane? outputPane) == HResult.OK && outputPane is not null)
             {
                 string message = string.Format(VSResources.IncrementalBuildFailureWarningMessage_2, Path.GetFileName(_project.FullPath), failureDescription.TrimEnd(Delimiter.Period));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             string templateFilePath = ((Solution2)_dte.Value.Solution).GetProjectItemTemplate(templateFile, templateLanguage);
 
-            if (templateFilePath != null)
+            if (templateFilePath is not null)
             {
                 HierarchyId parentId = _projectVsServices.VsProject.GetHierarchyId(directoryName);
                 var result = new VSADDRESULT[1];

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -97,13 +97,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         {
             if (disposing)
             {
-                if (_launchProfileProviderLink != null)
+                if (_launchProfileProviderLink is not null)
                 {
                     _launchProfileProviderLink.Dispose();
                     _launchProfileProviderLink = null;
                 }
 
-                if (_debugProviderLink != null)
+                if (_debugProviderLink is not null)
                 {
                     _debugProviderLink.Dispose();
                     _debugProviderLink = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileEnumValuesGenerator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _listedValues = new AsyncLazy<ICollection<IEnumValue>>(delegate
             {
                 ILaunchSettings? curSnapshot = profileProvider.CurrentSnapshot;
-                if (curSnapshot != null)
+                if (curSnapshot is not null)
                 {
                     return Task.FromResult(GetEnumeratorEnumValues(curSnapshot));
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ErrorProfileDebugTargetsProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// </summary>
         public Task<IReadOnlyList<IDebugLaunchSettings>> QueryDebugTargetsAsync(DebugLaunchOptions launchOptions, ILaunchProfile activeProfile)
         {
-            if (activeProfile.OtherSettings != null &&
+            if (activeProfile.OtherSettings is not null &&
                 activeProfile.OtherSettings.TryGetValue("ErrorString", out object? objErrorString) &&
                 objErrorString is string errorString)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 info.LaunchDebugEngineGuid
             };
 
-            if (info.AdditionalDebugEngines != null)
+            if (info.AdditionalDebugEngines is not null)
             {
                 guids.AddRange(info.AdditionalDebugEngines);
             }
@@ -304,7 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private static string? GetSerializedEnvironmentString(IDictionary<string, string> environment)
         {
             // If no dictionary was set, or its empty, the debugger wants null for its environment block.
-            if (environment == null || environment.Count == 0)
+            if (environment is null || environment.Count == 0)
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             ILaunchProfile resolvedProfile = await _tokenReplacer.ReplaceTokensInProfileAsync(activeProfile);
 
             DebugLaunchSettings? consoleTarget = await GetConsoleTargetForProfileAsync(resolvedProfile, launchOptions, validateSettings);
-            return consoleTarget == null ? null : new[] { consoleTarget };
+            return consoleTarget is null ? null : new[] { consoleTarget };
         }
 
         /// <summary>
@@ -335,7 +335,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                         else
                         {
                             string? fullPathFromEnv = GetFullPathOfExeFromEnvironmentPath(exeName);
-                            if (fullPathFromEnv != null)
+                            if (fullPathFromEnv is not null)
                             {
                                 executable = fullPathFromEnv;
                             }
@@ -394,7 +394,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 if (!Strings.IsNullOrEmpty(remoteAuthenticationMode))
                 {
                     IRemoteAuthenticationProvider? remoteAuthenticationProvider = _remoteDebuggerAuthenticationService.FindProviderForAuthenticationMode(remoteAuthenticationMode);
-                    if (remoteAuthenticationProvider != null)
+                    if (remoteAuthenticationProvider is not null)
                     {
                         settings.PortSupplierGuid = remoteAuthenticationProvider.PortSupplierGuid;
                     }
@@ -542,7 +542,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             if (runCommand.IndexOf(Path.DirectorySeparatorChar) == -1)
             {
                 string? executable = GetFullPathOfExeFromEnvironmentPath(runCommand);
-                if (executable != null)
+                if (executable is not null)
                 {
                     runCommand = executable;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectHelper.cs
@@ -46,11 +46,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     {
                         string? projectPath = hier.GetProjectFilePath();
 
-                        if (projectPath != null)
+                        if (projectPath is not null)
                         {
                             T? export = _projectExportProvider.GetExport<T>(projectPath);
 
-                            if (export != null)
+                            if (export is not null)
                             {
                                 results.Add(export);
                             }
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
                     string? projectPath = hier?.GetProjectFilePath();
 
-                    if (projectPath != null)
+                    if (projectPath is not null)
                     {
                         results.Add(projectPath);
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectRegistrar.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
                 IVsStartupProjectsListService? startupProjectsListService = await _startupProjectsListService.GetValueOrNullAsync();
 
-                if (startupProjectsListService == null)
+                if (startupProjectsListService is null)
                 {
                     return;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             EnvDTE.Properties? properties = _dte.Value.get_Properties(category, page);
 
-            if (properties != null)
+            if (properties is not null)
             {
                 return (T)properties.Item(option).Value;
             }
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         {
             EnvDTE.Properties? properties = _dte.Value.get_Properties(category, page);
 
-            if (properties != null)
+            if (properties is not null)
             {
                 properties.Item(option).Value = newValue;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FSharp/FSharpProjectSelector.cs
@@ -53,8 +53,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.FSharp
 
             // If the project has either a Project-level SDK attribute or an Import-level SDK attribute, we'll open it with the new project system.
             // Check both namespace-qualified and unqualified forms to include projects with and without the xmlns attribute.
-            bool hasProjectElementWithSdkAttribute = doc.XPathSelectElement("/msb:Project[@Sdk]", nsm) != null || doc.XPathSelectElement("/Project[@Sdk]") != null;
-            bool hasImportElementWithSdkAttribute = doc.XPathSelectElement("/*/msb:Import[@Sdk]", nsm) != null || doc.XPathSelectElement("/*/Import[@Sdk]") != null;
+            bool hasProjectElementWithSdkAttribute = doc.XPathSelectElement("/msb:Project[@Sdk]", nsm) is not null || doc.XPathSelectElement("/Project[@Sdk]") is not null;
+            bool hasImportElementWithSdkAttribute = doc.XPathSelectElement("/*/msb:Import[@Sdk]", nsm) is not null || doc.XPathSelectElement("/*/Import[@Sdk]") is not null;
 
             if (hasProjectElementWithSdkAttribute || hasImportElementWithSdkAttribute)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -143,14 +143,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             if (!_disposedValue)
             {
-                if (disposing && _subscription != null)
+                if (disposing && _subscription is not null)
                 {
                     // Build manager APIs require UI thread access.
                     _threadingService.ExecuteSynchronously(async () =>
                     {
                         await _threadingService.SwitchToUIThread();
 
-                        if (_subscription != null)
+                        if (_subscription is not null)
                         {
                             // Unregister solution build events.
                             await _subscription.DisposeAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommand.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                     foreach (IActiveDebugFrameworkServices activeDebugFramework in activeDebugFrameworks)
                     {
                         List<string>? frameworks = await activeDebugFramework.GetProjectFrameworksAsync();
-                        if (frameworks != null && cmdIndex >= 0 && cmdIndex < frameworks.Count)
+                        if (frameworks is not null && cmdIndex >= 0 && cmdIndex < frameworks.Count)
                         {
                             await activeDebugFramework.SetActiveDebuggingFrameworkPropertyAsync(frameworks[cmdIndex]);
                             handled = true;
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                     {
                         frameworks = await activeDebugFramework.GetProjectFrameworksAsync();
 
-                        if (first == null)
+                        if (first is null)
                         {
                             first = frameworks;
                         }
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                     }
                 });
 
-                if (frameworks == null || frameworks.Count < 2)
+                if (frameworks is null || frameworks.Count < 2)
                 {
                     // Hide and disable the command
                     Visible = false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdater.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                     {
                         frameworks = await activeDebugFramework.GetProjectFrameworksAsync();
 
-                        if (first == null)
+                        if (first is null)
                         {
                             first = frameworks;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/AbstractDependencyExplorerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Dependencies/AbstractDependencyExplorerCommand.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
                 foreach (IProjectTree node in nodes)
                 {
                     string? path = await DependencyServices.GetBrowsePathAsync(_project, node);
-                    if (path == null)
+                    if (path is null)
                         continue;
 
                     Open(path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             IProjectTree? nodeToAddTo = GetNodeToAddTo(node);
 
-            if (nodeToAddTo != null && _addItemDialogService.CanAddNewOrExistingItemTo(nodeToAddTo) && CanAdd(node))
+            if (nodeToAddTo is not null && _addItemDialogService.CanAddNewOrExistingItemTo(nodeToAddTo) && CanAdd(node))
             {
                 return GetCommandStatusResult.Handled(commandText, CommandStatus.Enabled);
             }
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             IProjectTree? nodeToAddTo = GetNodeToAddTo(node);
 
-            if (nodeToAddTo == null)
+            if (nodeToAddTo is null)
             {
                 return false;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             UseWindow(configuredProject, serviceProvider, (hierarchy, window) =>
             {
-                if (window != null)
+                if (window is not null)
                 {
                     // We need to unselect the item if it is already selected to re-select it correctly.
                     window.ExpandItem(hierarchy, itemId, EXPANDFLAGS.EXPF_UnSelectItem);
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(serviceProvider, nameof(serviceProvider));
 
-            if (serviceProvider == null)
+            if (serviceProvider is null)
             {
                 throw new ArgumentNullException(nameof(serviceProvider));
             }
@@ -81,14 +81,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
             try
             {
-                if (ErrorHandler.Succeeded(shell.FindToolWindow(0, ref persistenceSlot, out IVsWindowFrame frame)) && frame != null)
+                if (ErrorHandler.Succeeded(shell.FindToolWindow(0, ref persistenceSlot, out IVsWindowFrame frame)) && frame is not null)
                 {
                     ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out pvar));
                 }
             }
             finally
             {
-                if (pvar != null)
+                if (pvar is not null)
                 {
                     uiHierarchyWindow = (IVsUIHierarchyWindow)pvar;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         private bool CanMove()
         {
-            return _action != OrderingMoveAction.NoOp && _target != null;
+            return _action != OrderingMoveAction.NoOp && _target is not null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(projectTree, MoveAction.Above) != null;
+            return GetSiblingByMoveAction(projectTree, MoveAction.Above) is not null;
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             Requires.NotNull(projectTree, nameof(projectTree));
 
-            return GetSiblingByMoveAction(projectTree, MoveAction.Below) != null;
+            return GetSiblingByMoveAction(projectTree, MoveAction.Below) is not null;
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(target, nameof(target));
 
             ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Above);
-            if (referenceElement == null)
+            if (referenceElement is null)
             {
                 return false;
             }
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(target, nameof(target));
 
             ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Below);
-            if (referenceElement == null)
+            if (referenceElement is null)
             {
                 return false;
             }
@@ -166,8 +166,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             }
 
             var excludeIncludes = elements.Select(x => x.Include).ToImmutableArray();
-            ProjectItemElement? referenceElement = GetChildren(newTarget!).Select(x => TryGetReferenceElement(project, x, excludeIncludes, MoveAction.Above)).FirstOrDefault(x => x != null);
-            if (referenceElement == null)
+            ProjectItemElement? referenceElement = GetChildren(newTarget!).Select(x => TryGetReferenceElement(project, x, excludeIncludes, MoveAction.Above)).FirstOrDefault(x => x is not null);
+            if (referenceElement is null)
             {
                 return false;
             }
@@ -236,7 +236,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                     // Technically it is possible to have more than one of the same item names.
                     // We only want to add one of them.
                     // Sanity check
-                    if (tree2.Item?.ItemName != null && hashSet.Add(tree2.Item.ItemName))
+                    if (tree2.Item?.ItemName is not null && hashSet.Add(tree2.Item.ItemName))
                     {
                         includes.Add(tree2.DisplayOrder, tree2.Item.ItemName);
                     }
@@ -281,7 +281,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             IProjectTree? parent = projectTree.Parent;
             int displayOrder = GetDisplayOrder(projectTree);
-            if (!IsValidDisplayOrder(displayOrder) || parent == null)
+            if (!IsValidDisplayOrder(displayOrder) || parent is null)
             {
                 return null;
             }
@@ -367,7 +367,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(referenceElement, nameof(referenceElement));
 
             ProjectElementContainer parent = referenceElement.Parent;
-            if (parent == null || !elements.Any())
+            if (parent is null || !elements.Any())
             {
                 return false;
             }
@@ -381,7 +381,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                     foreach (ProjectItemElement element in elements)
                     {
                         ProjectElementContainer elementParent = element.Parent;
-                        if (elementParent != null)
+                        if (elementParent is not null)
                         {
                             elementParent.RemoveChild(element);
                             parent.InsertBeforeChild(element, referenceElement);
@@ -401,7 +401,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                         ProjectItemElement element = elements[i];
 
                         ProjectElementContainer elementParent = element.Parent;
-                        if (elementParent != null)
+                        if (elementParent is not null)
                         {
                             elementParent.RemoveChild(element);
                             parent.InsertAfterChild(element, referenceElement);
@@ -433,12 +433,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
                 return false;
             }
 
-            if (referenceProjectTree != null)
+            if (referenceProjectTree is not null)
             {
                 // The reference element is the element for which moved items will be above or below it.
                 ProjectItemElement? referenceElement = TryGetReferenceElement(project, referenceProjectTree, ImmutableArray<string>.Empty, moveAction);
 
-                if (referenceElement != null)
+                if (referenceElement is not null)
                 {
                     ImmutableArray<ProjectItemElement> elements = GetItemElements(project, projectTree, ImmutableArray<string>.Empty);
                     return TryMoveElements(elements, referenceElement, moveAction);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactory.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
                 return GetContainedLanguageFactoryForFileAsync(filePath);
             });
 
-            return (hierarchy == null || containedLanguageFactory == null) ? HResult.Fail : HResult.OK;
+            return (hierarchy is null || containedLanguageFactory is null) ? HResult.Fail : HResult.OK;
         }
 
         private async Task<(HierarchyId itemid, IVsHierarchy? hierarchy, IVsContainedLanguageFactory? containedLanguageFactory)> GetContainedLanguageFactoryForFileAsync(string filePath)
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
             IVsContainedLanguageFactory? containedLanguageFactory = await _containedLanguageFactory.GetValueAsync();
 
-            if (containedLanguageFactory == null)
+            if (containedLanguageFactory is null)
                 return (HierarchyId.Nil, null, null);
 
             return (itemid, _projectVsServices.VsHierarchy, containedLanguageFactory);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -145,7 +145,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                 // them to actually contains changes, only nominate if there are any.
                 byte[] hash = RestoreHasher.CalculateHash(restoreInfo);
 
-                if (_latestHash != null && hash.AsSpan().SequenceEqual(_latestHash))
+                if (_latestHash is not null && hash.AsSpan().SequenceEqual(_latestHash))
                 {
                     _stopwatch.Reset();
                     _nuGetRestoreSuccesses++;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreComparer.ReferenceItemEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreComparer.ReferenceItemEqualityComparer.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
             public override int GetHashCode(IVsReferenceItem? obj)
             {
-                if (obj == null)
+                if (obj is null)
                     return 0;
 
                 return obj.Name.GetHashCode();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreComparer.ReferencePropertyEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreComparer.ReferencePropertyEqualityComparer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
             public override int GetHashCode(IVsReferenceProperty? obj)
             {
-                if (obj == null)
+                if (obj is null)
                     return 0;
 
                 return obj.Name.GetHashCode();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectCapabilitiesMissingVetoProjectLoad.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectCapabilitiesMissingVetoProjectLoad.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         public Task<bool> AllowProjectLoadAsync(bool isNewProject, ProjectConfiguration activeConfiguration, CancellationToken cancellationToken = default)
         {
             ProjectType? projectType = GetCurrentProjectType();
-            if (projectType == null)    // Unrecognized, probably a Shared Project
+            if (projectType is null)    // Unrecognized, probably a Shared Project
                 return TaskResult.True;
 
             foreach (string capability in projectType.Capabilities)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AvoidPersistingProjectGuidStorageProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             return _projectAccessor.OpenProjectXmlForReadAsync(_project, projectXml =>
             {
                 ProjectPropertyElement? property = FindProjectGuidProperty(projectXml);
-                if (property != null)
+                if (property is not null)
                 {
                     _isPersistedInProject = true;
 
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             return _projectAccessor.OpenProjectXmlForUpgradeableReadAsync(_project, async (projectXml, cancellationToken) =>
             {
                 ProjectPropertyElement property = FindProjectGuidProperty(projectXml);
-                if (property != null)
+                if (property is not null)
                 {
                     _isPersistedInProject = true;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/AbstractBuildEventValueProvider.AbstractBuildEventHelper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             {
                 // check if value already exists
                 string? unevaluatedPropertyValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
-                if (unevaluatedPropertyValue != null)
+                if (unevaluatedPropertyValue is not null)
                 {
                     return (true, unevaluatedPropertyValue);
                 }
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             {
                 ProjectTaskElement? execTask = FindExecTaskInTargets(projectXml);
 
-                if (execTask == null)
+                if (execTask is null)
                 {
                     return null;
                 }
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             public async Task<bool> TrySetPropertyAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
             {
                 string? currentValue = await defaultProperties.GetUnevaluatedPropertyValueAsync(BuildEvent);
-                if (currentValue == null)
+                if (currentValue is null)
                 {
                     return false;
                 }
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
                 {
                     ProjectTargetElement? target = FindTargetToRemove(projectXml);
 
-                    if (target != null)
+                    if (target is not null)
                     {
                         projectXml.RemoveChild(target);
                         return;
@@ -133,7 +133,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
             {
                 ProjectTaskElement? execTask = FindExecTaskInTargets(projectXml);
 
-                if (execTask != null)
+                if (execTask is not null)
                 {
                     SetExecParameter(execTask, unevaluatedPropertyValue);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         {
             ActiveConfiguredObjects<ConfiguredProject>? configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync();
 
-            if (configuredProjects == null)
+            if (configuredProjects is null)
             {
                 return "";
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.InterceptedProjectP
         {
             ActiveConfiguredObjects<ConfiguredProject>? configuredProjects = await _projectProvider.GetActiveConfiguredProjectsAsync();
 
-            if (configuredProjects == null)
+            if (configuredProjects is null)
             {
                 return "";
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectDesignerService.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
 
             IVsWindowFrame? frame = _projectVsServices.VsProject.OpenItemWithSpecific(HierarchyId.Root, projectDesignerGuid);
 
-            if (frame != null)
+            if (frame is not null)
             {   // Opened within Visual Studio
                 // Can only use Shell APIs on the UI thread
                 await _projectVsServices.ThreadingService.SwitchToUIThread();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/BuildMacroInfo.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// <returns>If the method succeeds, it returns S_OK. If it fails, it returns an error code.</returns>
         public int GetBuildMacroValue(string bstrBuildMacroName, out string? pbstrBuildMacroValue)
         {
-            if (_configuredProject == null)
+            if (_configuredProject is null)
             {
                 pbstrBuildMacroValue = null;
                 return HResult.Unexpected;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -97,13 +97,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         private void DebugPageControl_LayoutUpdated(object sender, EventArgs e)
         {
-            if (_customControlLayoutUpdateRequired && _mainGrid != null && DataContext is DebugPageViewModel viewModel)
+            if (_customControlLayoutUpdateRequired && _mainGrid is not null && DataContext is DebugPageViewModel viewModel)
             {
                 _customControlLayoutUpdateRequired = false;
 
                 // Get the control that was added to the grid
                 UserControl customControl = viewModel.ActiveProviderUserControl;
-                if (customControl != null)
+                if (customControl is not null)
                 {
                     if (customControl.Content is Grid childGrid && childGrid.ColumnDefinitions.Count == _mainGrid.ColumnDefinitions.Count)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.LaunchType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.LaunchType.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 if (obj is LaunchType oth)
                 {
-                    return CommandName?.Equals(oth.CommandName) ?? oth.CommandName == null;
+                    return CommandName?.Equals(oth.CommandName) ?? oth.CommandName is null;
                 }
 
                 return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageViewModel.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             get
             {
-                if (_projectThreadingService == null)
+                if (_projectThreadingService is null)
                 {
                     IUnconfiguredProjectVsServices projectVsServices = Project.Services.ExportProvider.GetExportedValue<IUnconfiguredProjectVsServices>();
                     _projectThreadingService = projectVsServices.ThreadingService;
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             get
             {
-                if (_remoteDebuggerAuthenticationService == null)
+                if (_remoteDebuggerAuthenticationService is null)
                 {
                     _remoteDebuggerAuthenticationService = Project.Services.ExportProvider.GetExportedValue<IRemoteDebuggerAuthenticationService>();
                 }
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     // Existing commands are shown in the UI as project
                     // since that is what is run when that command is selected. However, we don't want to just update the actual
                     // profile to this value - we want to treat them as equivalent.
-                    if (_selectedLaunchType != null)
+                    if (_selectedLaunchType is not null)
                     {
                         SelectedDebugProfile.CommandName = _selectedLaunchType.CommandName;
                         if (_selectedLaunchType.CommandName == ProfileCommandNames.Executable)
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                if (SelectedDebugProfile != null && SelectedDebugProfile.CommandLineArgs != value)
+                if (SelectedDebugProfile is not null && SelectedDebugProfile.CommandLineArgs != value)
                 {
                     SelectedDebugProfile.CommandLineArgs = value;
                     OnPropertyChanged(nameof(CommandLineArguments));
@@ -197,7 +197,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                if (SelectedDebugProfile != null && SelectedDebugProfile.ExecutablePath != value)
+                if (SelectedDebugProfile is not null && SelectedDebugProfile.ExecutablePath != value)
                 {
                     SelectedDebugProfile.ExecutablePath = value;
                     OnPropertyChanged(nameof(ExecutablePath));
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                if (SelectedDebugProfile != null && SelectedDebugProfile.LaunchUrl != value)
+                if (SelectedDebugProfile is not null && SelectedDebugProfile.LaunchUrl != value)
                 {
                     SelectedDebugProfile.LaunchUrl = value;
                     OnPropertyChanged(nameof(LaunchPage));
@@ -239,7 +239,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                if (SelectedDebugProfile != null && SelectedDebugProfile.WorkingDirectory != value)
+                if (SelectedDebugProfile is not null && SelectedDebugProfile.WorkingDirectory != value)
                 {
                     SelectedDebugProfile.WorkingDirectory = value;
                     OnPropertyChanged(nameof(WorkingDirectory));
@@ -306,7 +306,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                if (SelectedDebugProfile != null && SelectedDebugProfile.LaunchBrowser != value)
+                if (SelectedDebugProfile is not null && SelectedDebugProfile.LaunchBrowser != value)
                 {
                     SelectedDebugProfile.LaunchBrowser = value;
                     OnPropertyChanged(nameof(HasLaunchOption));
@@ -415,7 +415,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public bool SupportsLaunchUrl            => ActiveProviderSupportsProperty(UIProfilePropertyName.LaunchUrl);
         public bool SupportsEnvironmentVariables => ActiveProviderSupportsProperty(UIProfilePropertyName.EnvironmentVariables);
 
-        public bool IsProfileSelected => SelectedDebugProfile != null;
+        public bool IsProfileSelected => SelectedDebugProfile is not null;
 
         public ObservableCollection<IWritableLaunchProfile> LaunchProfiles { get; } = new ObservableCollection<IWritableLaunchProfile>();
 
@@ -446,7 +446,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
             set
             {
-                if (CurrentLaunchSettings != null && CurrentLaunchSettings.ActiveProfile != value)
+                if (CurrentLaunchSettings is not null && CurrentLaunchSettings.ActiveProfile != value)
                 {
                     IWritableLaunchProfile oldProfile = CurrentLaunchSettings.ActiveProfile;
                     CurrentLaunchSettings.ActiveProfile = value;
@@ -494,7 +494,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             get
             {
-                return EnvironmentVariables == null || _environmentVariablesValid;
+                return EnvironmentVariables is null || _environmentVariablesValid;
             }
             set
             {
@@ -535,7 +535,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             get
             {
-                if (SelectedLaunchType == null)
+                if (SelectedLaunchType is null)
                 {
                     return null;
                 }
@@ -641,7 +641,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             }
         }
 
-        public bool NewProfileEnabled => LaunchProfiles != null;
+        public bool NewProfileEnabled => LaunchProfiles is not null;
 
         public ICommand NewProfileCommand
         {
@@ -704,12 +704,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // so that we don't get notifications while the control is initializing. Note that this is likely the first time the 
             // custom control is asked for and we want to call it and have it created prior to setting the active profile
             UserControl customControl = ActiveProvider?.CustomUI;
-            if (customControl != null)
+            if (customControl is not null)
             {
                 ActiveProvider.ProfileSelected(CurrentLaunchSettings);
 
                 context = customControl.DataContext as INotifyPropertyChanged;
-                if (context != null)
+                if (context is not null)
                 {
                     context.PropertyChanged += OnCustomUIStateChanged;
                 }
@@ -809,7 +809,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         public virtual async Task SaveLaunchSettingsAsync()
         {
             ILaunchSettingsProvider provider = GetDebugProfileProvider();
-            if (EnvironmentVariables?.Count > 0 && SelectedDebugProfile != null)
+            if (EnvironmentVariables?.Count > 0 && SelectedDebugProfile is not null)
             {
                 SelectedDebugProfile.EnvironmentVariables.Clear();
                 foreach (NameValuePair kvp in EnvironmentVariables)
@@ -817,7 +817,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                     SelectedDebugProfile.EnvironmentVariables.Add(kvp.Name, kvp.Value);
                 }
             }
-            else if (SelectedDebugProfile != null)
+            else if (SelectedDebugProfile is not null)
             {
                 SelectedDebugProfile.EnvironmentVariables.Clear();
             }
@@ -827,7 +827,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         private void SetEnvironmentGrid(IWritableLaunchProfile oldProfile)
         {
-            if (EnvironmentVariables != null && oldProfile != null)
+            if (EnvironmentVariables is not null && oldProfile is not null)
             {
                 if (_environmentVariables.Count > 0)
                 {
@@ -846,7 +846,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 ((INotifyPropertyChanged)EnvironmentVariables).PropertyChanged -= DebugPageViewModel_EnvironmentVariables_PropertyChanged;
             }
 
-            if (SelectedDebugProfile != null)
+            if (SelectedDebugProfile is not null)
             {
                 EnvironmentVariables = SelectedDebugProfile.EnvironmentVariables.CreateList();
             }
@@ -906,10 +906,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                 NotifyProfileCollectionChanged();
 
                 // If we have a selection, we want to leave it as is
-                if (curProfileName == null || newSettings.Profiles.Find(p => LaunchProfile.IsSameProfileName(p.Name, curProfileName)) == null)
+                if (curProfileName is null || newSettings.Profiles.Find(p => LaunchProfile.IsSameProfileName(p.Name, curProfileName)) is null)
                 {
                     // Note that we have to be careful since the collection can be empty. 
-                    if (profiles.ActiveProfile != null && !string.IsNullOrEmpty(profiles.ActiveProfile.Name))
+                    if (profiles.ActiveProfile is not null && !string.IsNullOrEmpty(profiles.ActiveProfile.Name))
                     {
                         SelectedDebugProfile = LaunchProfiles.Single(p => LaunchProfile.IsSameProfileName(p.Name, profiles.ActiveProfile.Name));
                     }
@@ -943,7 +943,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         protected void InitializePropertyPage()
         {
-            if (_debugProfileProviderLink == null)
+            if (_debugProfileProviderLink is null)
             {
                 ILaunchSettingsProvider profileProvider = GetDebugProfileProvider();
                 _debugProfileProviderLink = profileProvider.SourceBlock.LinkToAsyncAction(
@@ -956,7 +956,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         private async Task OnLaunchSettingsChangedAsync(ILaunchSettings profiles)
         {
-            if (_firstSnapshotCompleteSource == null)
+            if (_firstSnapshotCompleteSource is null)
             {
                 await ProjectThreadingService.SwitchToUIThread();
             }
@@ -1052,12 +1052,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             // Populate the set of unique launch types from the list of providers since there can be duplicates with different priorities. However,
             // the command name will be the same so we can grab the first one for the purposes of populating the list
-            if (_providerLaunchTypes == null)
+            if (_providerLaunchTypes is null)
             {
                 _providerLaunchTypes = new List<LaunchType>();
                 foreach (Lazy<ILaunchSettingsUIProvider, IOrderPrecedenceMetadataView> provider in _uiProviders)
                 {
-                    if (_providerLaunchTypes.Find(launchType => launchType.CommandName.Equals(provider.Value.CommandName)) == null)
+                    if (_providerLaunchTypes.Find(launchType => launchType.CommandName.Equals(provider.Value.CommandName)) is null)
                     {
                         _providerLaunchTypes.Add(new LaunchType(provider.Value.CommandName, provider.Value.FriendlyName));
                     }
@@ -1068,12 +1068,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             LaunchType selectedLaunchType = null;
 
             _launchTypes = new List<LaunchType>();
-            if (selectedProfile != null)
+            if (selectedProfile is not null)
             {
                 _launchTypes.AddRange(_providerLaunchTypes);
 
                 selectedLaunchType = _launchTypes.Find(launchType => string.Equals(launchType.CommandName, selectedProfile.CommandName));
-                if (selectedLaunchType == null)
+                if (selectedLaunchType is null)
                 {
                     selectedLaunchType = new LaunchType(selectedProfile.CommandName, selectedProfile.CommandName);
                     _launchTypes.Insert(0, selectedLaunchType);
@@ -1103,7 +1103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         public override void ViewModelDetached()
         {
-            if (_debugProfileProviderLink != null)
+            if (_debugProfileProviderLink is not null)
             {
                 _debugProfileProviderLink.Dispose();
                 _debugProfileProviderLink = null;
@@ -1114,7 +1114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         protected virtual ILaunchSettingsProvider GetDebugProfileProvider()
         {
-            if (_launchSettingsProvider == null)
+            if (_launchSettingsProvider is null)
             {
                 _launchSettingsProvider = Project.Services.ExportProvider.GetExportedValue<ILaunchSettingsProvider>();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/PropertyPage.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             // any changes that happen during initialization
 
             Control parent = FromHandle(hWndParent);
-            if (parent != null)
+            if (parent is not null)
             {   // We're hosted in WinForms, make sure we 
                 // set Parent so that we inherit Font & Colors
                 Parent = parent;
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         public new void Move(RECT[] pRect)
         {
-            if (pRect == null || pRect.Length <= 0)
+            if (pRect is null || pRect.Length <= 0)
                 throw new ArgumentNullException(nameof(pRect));
 
             RECT r = pRect[0];
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         /// </summary>
         public int TranslateAccelerator(MSG[] pMsg)
         {
-            if (pMsg == null)
+            if (pMsg is null)
                 return VSConstants.E_POINTER;
 
             var m = Message.Create(pMsg[0].hwnd, (int)pMsg[0].message, pMsg[0].wParam, pMsg[0].lParam);
@@ -218,7 +218,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             // Preprocessing should be passed to the control whose handle the message refers to.
             Control target = FromChildHandle(m.HWnd);
-            if (target != null)
+            if (target is not null)
                 used = target.PreProcessMessage(ref m);
 
             if (used)
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
             // Returning S_FALSE (1) indicates we have not handled the message
             int result = 0;
-            if (_site != null)
+            if (_site is not null)
                 result = _site.TranslateAccelerator(pMsg);
             return result;
         }
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 #pragma warning disable RS0030 // Do not used banned APIs
                 _debugger = sp.GetService<IVsDebugger, IVsDebugger>();
 #pragma warning restore RS0030 // Do not used banned APIs
-                if (_debugger != null)
+                if (_debugger is not null)
                 {
                     _debugger.AdviseDebuggerEvents(this, out _debuggerCookie);
                     var dbgMode = new DBGMODE[1];
@@ -280,7 +280,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
             {
                 // If we have never configured anything (maybe a failure occurred on open so app designer is closing us). In this case
                 // do nothing
-                if (UnconfiguredProject != null)
+                if (UnconfiguredProject is not null)
                 {
                     SetObjects(isClosing: true);
                     UnconfiguredProject = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/WpfBasedPropertyPage.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
 
         private void OnControlStatusChanged(object sender, EventArgs e)
         {
-            if (_control == null)
+            if (_control is null)
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetEvaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetEvaluatedUIPropertyValueAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task SetValueAsync(IProperty property)
         {
-            if (_parameter.Value == null)
+            if (_parameter.Value is null)
             {
                 return property.DeleteAsync();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         protected override Task SetValueAsync(IProperty property)
         {
-            if (_parameter.Value == null)
+            if (_parameter.Value is null)
             {
                 return property.DeleteAsync();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Refactor/VisualStudioRefactorNotifyService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Refactor/VisualStudioRefactorNotifyService.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Refactor
         public void OnBeforeGlobalSymbolRenamed(string projectPath, IEnumerable<string> filePaths, string rqName, string newName)
         {
             IVsHierarchy? projectHierarchy = GetProjectHierarchy(projectPath);
-            if (projectHierarchy == null)
+            if (projectHierarchy is null)
             {
                 return;
             }
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Refactor
         public void OnAfterGlobalSymbolRenamed(string projectPath, IEnumerable<string> filePaths, string rqName, string newName)
         {
             IVsHierarchy? projectHierarchy = GetProjectHierarchy(projectPath);
-            if (projectHierarchy == null)
+            if (projectHierarchy is null)
             {
                 return;
             }
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Refactor
         private IVsHierarchy? GetProjectHierarchy(string projectPath)
         {
             Project? project = TryGetProjectFromPath(projectPath);
-            if (project == null)
+            if (project is null)
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var propertyNames = await metadata.GetPropertyNamesAsync();
             string? value = await metadata.GetEvaluatedPropertyValueAsync(ProjectReference.TreatAsUsedProperty);
 
-            return value != null && PropertySerializer.SimpleTypes.ToValue<bool>(value);
+            return value is not null && PropertySerializer.SimpleTypes.ToValue<bool>(value);
         }
 
         private async Task<IProjectItem?> GetProjectItemsAsync(ConfiguredProject selectedConfiguredProject,
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             IProjectItem? items = await GetProjectItemsAsync(selectedConfiguredProject, itemSpecification);
 
-            if (items != null)
+            if (items is not null)
             {
                 foreach ((string propertyName, string propertyValue) in projectPropertiesValues)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
         public int GetTargetFramework(out string? ppTargetFramework)
         {
-            if (_projectVsServices == null)
+            if (_projectVsServices is null)
             {
                 ppTargetFramework = null;
                 return HResult.Unexpected;
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
         public int ResolveAssemblyPathInTargetFx(string?[]? prgAssemblySpecs, uint cAssembliesToResolve, VsResolvedAssemblyPath[]? prgResolvedAssemblyPaths, out uint pcResolvedAssemblyPaths)
         {
-            if (prgAssemblySpecs == null || cAssembliesToResolve == 0 || prgResolvedAssemblyPaths == null || cAssembliesToResolve != prgAssemblySpecs.Length || cAssembliesToResolve != prgResolvedAssemblyPaths.Length)
+            if (prgAssemblySpecs is null || cAssembliesToResolve == 0 || prgResolvedAssemblyPaths is null || cAssembliesToResolve != prgAssemblySpecs.Length || cAssembliesToResolve != prgResolvedAssemblyPaths.Length)
             {
                 pcResolvedAssemblyPaths = 0;
                 return HResult.InvalidArg;
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                 return HResult.InvalidArg;
             }
 
-            if (_projectVsServices == null)
+            if (_projectVsServices is null)
             {
                 pcResolvedAssemblyPaths = 0;
                 return HResult.Unexpected;
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             for (int i = 0; i < assemblyName.Length; i++)
             {
                 string? resolvedPath = FindResolvedAssemblyPath(references, assemblyName[i]);
-                if (resolvedPath != null)
+                if (resolvedPath is not null)
                 {
                     assemblyPaths[resolvedReferencesCount] = new VsResolvedAssemblyPath()
                     {
@@ -111,11 +111,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             if (references.TryGetValue(assemblyName.Name, out ResolvedReference reference))
             {
                 // If the caller didn't specify a version, than they only want to match on name
-                if (assemblyName.Version == null)
+                if (assemblyName.Version is null)
                     return reference.ResolvedPath;
 
                 // If the reference is the same or higher than the requested version, then we consider it a match
-                if (reference.Version != null && reference.Version >= assemblyName.Version)
+                if (reference.Version is not null && reference.Version >= assemblyName.Version)
                     return reference.ResolvedPath;
             }
 
@@ -127,7 +127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var resolvedReferences = new Dictionary<string, ResolvedReference>(StringComparer.Ordinal);
 
             VSProject? project = GetVSProject();
-            if (project != null)
+            if (project is not null)
             {
                 foreach (Reference3 reference in project.References.OfType<Reference3>())
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/ReferenceCleanupService.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
             var references = new List<ProjectSystemReferenceInfo>();
 
-            foreach (var keyValuePair in s_mapReferenceTypeToHandler.Where(h => h.Value != null))
+            foreach (var keyValuePair in s_mapReferenceTypeToHandler.Where(h => h.Value is not null))
             {
                 references.AddRange(await keyValuePair.Value.GetReferencesAsync(selectedConfiguredProject, cancellationToken));
             }
@@ -106,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
             var referenceHandler = s_mapReferenceTypeToHandler[referenceUpdate.ReferenceInfo.ReferenceType];
 
             IProjectSystemUpdateReferenceOperation? command = null;
-            if (referenceHandler != null)
+            if (referenceHandler is not null)
             {
                 command = CreateCommand(referenceUpdate, referenceHandler, activeConfiguredProject, cancellationToken);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/RemoveReferenceCommand.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             await _referenceHandler.AddReferenceAsync(_selectedConfiguredProject, _itemSpecification);
 
-            if (_projectPropertiesValues != null)
+            if (_projectPropertiesValues is not null)
             {
                 await _referenceHandler.SetAttributesAsync(_selectedConfiguredProject, _itemSpecification, _projectPropertiesValues);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetTreatAsUsedAttributeCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/SetTreatAsUsedAttributeCommand.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             IProjectItem item = await GetProjectItemAsync();
 
-            if (item == null)
+            if (item is null)
             {
                 return false;
             }
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         {
             IProjectItem item = await GetProjectItemAsync();
 
-            if (item == null)
+            if (item is null)
             {
                 return false;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             }
 
             (bool result, Renamer.RenameDocumentActionSet? documentRenameResult) = await GetRenameSymbolsActionsAsync(project, oldFilePath, newFileWithExtension);
-            if (!result || documentRenameResult == null)
+            if (!result || documentRenameResult is null)
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridge.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             // Due to that, and to avoid a deadlock when event handlers call back into us
             // while we're still initializing, we avoid firing the events the first time 
             // a value is applied.
-            if (previous != null)
+            if (previous is not null)
             {
                 DesignTimeInputSnapshot currentValue = value.Value;
                 DesignTimeInputSnapshot previousValue = previous.Value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -110,7 +110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             // Ignore any file changes until we've received the first set of design time inputs (which shouldn't happen anyway)
             // That first update will send out all of the files so we're not losing anything
-            if (state == null)
+            if (state is null)
             {
                 return;
             }
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             var changedInputs = new List<DesignTimeInputFileChange>();
             // On the first call where we receive design time inputs we queue compilation of all of them, knowing that we'll only compile if the file write date requires it
-            if (previousState == null)
+            if (previousState is null)
             {
                 AddAllInputsToQueue(false);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
         protected override async Task DisposeCoreAsync(bool initialized)
         {
-            if (_compileActionBlock != null)
+            if (_compileActionBlock is not null)
             {
                 // This will stop our blocks taking any more input
                 _compileActionBlock.Complete();
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
                     // Grab the next file to compile off the queue
                     QueueItem? item = _queue.Pop();
-                    if (item == null)
+                    if (item is null)
                     {
                         break;
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -141,7 +141,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 _broadcastBlock?.Complete();
                 _dataSourceLink?.Dispose();
 
-                if (_actionBlock != null)
+                if (_actionBlock is not null)
                 {
                     _actionBlock.Complete();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollection.cs
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             foreach (AggregateContainsRelationCollectionSpan span in _spans)
             {
-                if (span.Items != null)
+                if (span.Items is not null)
                 {
                     foreach (IRelatableItem item in span.Items)
                     {
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 {
                     foreach (AggregateContainsRelationCollectionSpan span in _spans)
                     {
-                        if (span.Items == null)
+                        if (span.Items is null)
                         {
                             continue;
                         }
@@ -160,7 +160,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
                 foreach (AggregateContainsRelationCollectionSpan span in _spans)
                 {
-                    if (span.Items == null)
+                    if (span.Items is null)
                     {
                         continue;
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollectionSpan.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollectionSpan.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
             bool? srcConsumed = null;
 
-            for (int itemIndex = 0; Items != null && itemIndex < Items.Count; itemIndex++)
+            for (int itemIndex = 0; Items is not null && itemIndex < Items.Count; itemIndex++)
             {
                 if (srcConsumed != false && !src.MoveNext())
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             _sourceItem = Requires.NotNull(sourceItem, nameof(sourceItem));
 
-            if (collection != null)
+            if (collection is not null)
             {
                 SetCollection(collection);
             }
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         bool IAttachedCollectionSource.HasItems => _collection?.HasItems == true;
 
         // We are updating items until they are provided
-        bool IAsyncAttachedCollectionSource.IsUpdatingHasItems => _collection == null;
+        bool IAsyncAttachedCollectionSource.IsUpdatingHasItems => _collection is null;
 
         /// <summary>
         /// Sets the backing collection for this source, for cases where that collection was not available at the time
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         /// </exception>
         public void SetCollection(IAggregateRelationCollection collection)
         {
-            if (_collection != null)
+            if (_collection is not null)
             {
                 throw new InvalidOperationException("Backing collection has already been provided.");
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeConfiguredProjectSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeConfiguredProjectSearchContext.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public void SubmitResult(IRelatableItem? item)
         {
-            if (item == null)
+            if (item is null)
             {
                 return;
             }
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
             void PopulateAncestors(IRelatableItem childItem)
             {
-                if (childItem.ContainedByCollection != null)
+                if (childItem.ContainedByCollection is not null)
                 {
                     // We've already populated this item's ancestors. It's likely an ancestor of
                     // another search result. This also prevents runaway in case of cycles.
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 {
                     IEnumerable<IRelatableItem>? relationParentItems = relation.CreateContainedByItems(childItem);
 
-                    if (relationParentItems != null)
+                    if (relationParentItems is not null)
                     {
                         foreach (IRelatableItem parentItem in relationParentItems)
                         {
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                                 allParentItems.Add(hierarchyItem);
                             }
 
-                            if (deduplicateItem.ContainedByCollection == null)
+                            if (deduplicateItem.ContainedByCollection is null)
                             {
                                 PopulateAncestors(deduplicateItem);
                             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeProjectSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeProjectSearchContext.cs
@@ -44,14 +44,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
             IProjectTree targetRootNode;
 
-            if (_dependenciesNode.FindChildWithFlags(DependencyTreeFlags.TargetNode) == null)
+            if (_dependenciesNode.FindChildWithFlags(DependencyTreeFlags.TargetNode) is null)
             {
                 // Tree does not show any target nodes
                 targetRootNode = _dependenciesNode;
             }
             else
             {
-                if (configuredProject.Services.ProjectSubscription == null)
+                if (configuredProject.Services.ProjectSubscription is null)
                 {
                     return null;
                 }
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
                 IProjectTree? targetNode = _dependenciesNode.FindChildWithFlags(ProjectTreeFlags.Create("$TFM:" + tf));
 
-                if (targetNode == null)
+                if (targetNode is null)
                 {
                     TraceUtilities.TraceError("Should not fail to find the target node.");
                     return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public void SubmitResult(IRelatableItem? item)
         {
-            if (item == null || CancellationToken.IsCancellationRequested)
+            if (item is null || CancellationToken.IsCancellationRequested)
             {
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 IUnconfiguredProjectVsServices? projectVsServices = unconfiguredProject.Services.ExportProvider.GetExportedValue<IUnconfiguredProjectVsServices>();
                 IProjectTree? dependenciesNode = projectVsServices?.ProjectTree.CurrentTree?.FindChildWithFlags(DependencyTreeFlags.DependenciesRootNode);
 
-                if (projectVsServices != null && dependenciesNode != null)
+                if (projectVsServices is not null && dependenciesNode is not null)
                 {
                     var projectContext = new DependenciesTreeProjectSearchContext(context, unconfiguredProject, dependenciesNode, _hierarchyItemManager, projectVsServices, _relationProvider);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcher.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             Requires.NotNull(flagsString, nameof(flagsString));
 
-            if (_regex == null)
+            if (_regex is null)
             {
                 // We are testing against the empty set of flags, which always returns true
                 return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             s_targetFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.TargetNode) + @"\b)(?=.*\$TFM:(?<target>[^ ]+)\b).*$", RegexOptions.Compiled);
 
-            for (IVsHierarchyItem? parent = item; parent != null; parent = parent.Parent)
+            for (IVsHierarchyItem? parent = item; parent is not null; parent = parent.Parent)
             {
                 if (parent.TryGetFlagsString(out string? flagsString))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
             [BrowseObjectDisplayName(nameof(VSResources.FrameworkAssemblyPathDisplayName))]
             [BrowseObjectDescription(nameof(VSResources.FrameworkAssemblyPathDescription))]
-            public string Path => _item.Path != null
+            public string Path => _item.Path is not null
                 ? System.IO.Path.GetFullPath(System.IO.Path.Combine(_item.Framework.Path, _item.Path))
                 : "";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         {
             unchecked
             {
-                return (Path.GetHashCode() * 397) ^ (Profile != null ? Profile.GetHashCode() : 0);
+                return (Path.GetHashCode() * 397) ^ (Profile is not null ? Profile.GetHashCode() : 0);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                         //  We must filter to a specific profile
                         string? fileProfile = file.Attribute("Profile")?.Value;
 
-                        if (fileProfile == null)
+                        if (fileProfile is null)
                         {
                             // The file doesn't specify a profile, so skip it
                             continue;
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                     string? assemblyVersion = Pool(file.Attribute("AssemblyVersion")?.Value);
                     string? fileVersion = Pool(file.Attribute("FileVersion")?.Value);
 
-                    if (assemblyName != null)
+                    if (assemblyName is not null)
                     {
                         results.Add(new FrameworkReferenceAssemblyItem(assemblyName, path, assemblyVersion, fileVersion, framework));
                     }
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
                 string? Pool(string? s)
                 {
-                    if (s != null)
+                    if (s is not null)
                     {
                         if (pool.TryGetValue(s, out string existing))
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelatableItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelatableItemBase.cs
@@ -35,13 +35,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             IRelationProvider relationProvider,
             [NotNullWhen(returnValue: true)] out AggregateContainsRelationCollection? relationCollection)
         {
-            if (_containsCollection == null && AggregateContainsRelationCollection.TryCreate(this, relationProvider, out AggregateContainsRelationCollection? collection))
+            if (_containsCollection is null && AggregateContainsRelationCollection.TryCreate(this, relationProvider, out AggregateContainsRelationCollection? collection))
             {
                 _containsCollection = collection;
             }
 
             relationCollection = _containsCollection;
-            return relationCollection != null;
+            return relationCollection is not null;
         }
 
         bool IRelatableItem.TryGetProjectNode(IProjectTree targetRootNode, IRelatableItem item, [NotNullWhen(returnValue: true)] out IProjectTree? projectTree)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationAttachedCollectionSourceProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 // scoping.
                 yield return Relationships.Contains;
 
-                if (relatableItem.ContainedByCollection != null)
+                if (relatableItem.ContainedByCollection is not null)
                 {
                     yield return Relationships.ContainedBy;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/NavigateToProjectCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/NavigateToProjectCommand.cs
@@ -65,14 +65,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
         private async Task NavigateToAsync(IProjectTree node)
         {
             string? browsePath = await DependencyServices.GetBrowsePathAsync(_project, node);
-            if (browsePath == null)
+            if (browsePath is null)
                 return;
 
             await _threadingService.SwitchToUIThread();
 
             // Find the hierarchy based on the project file, and then select it
             var hierarchy = (IVsUIHierarchy?)_projectServices.GetHierarchyByProjectName(browsePath);
-            if (hierarchy == null || !_solutionExplorer.IsAvailable)
+            if (hierarchy is null || !_solutionExplorer.IsAvailable)
                 return;
 
             _ = _solutionExplorer.Select(hierarchy, HierarchyId.Root);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/ReferenceManagerCommandHandler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
         {
             string? identifier = GetReferenceProviderIdentifier(commandId);
 
-            if (identifier != null)
+            if (identifier is not null)
             {
                 _referencesUI.ShowReferenceManagerDialog(new Guid(identifier));
                 return true;
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
         private bool CanAddReference(long commandId)
         {
             string? identifier = GetReferenceProviderIdentifier(commandId);
-            if (identifier != null)
+            if (identifier is not null)
             {
                 Lazy<IVsReferenceManagerUserAsync>? user = ReferenceManagerUsers.FirstOrDefault(u => u.Metadata.ProviderContextIdentifier == identifier);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 return _orderedMap.TryGetValue(propertyContext.ItemName, out displayOrder);
             }
 
-            return propertyContext.Metadata != null &&
+            return propertyContext.Metadata is not null &&
                 propertyContext.Metadata.TryGetValue(FullPathProperty, out string fullPath) &&
                 _orderedMap.TryGetValue(fullPath, out displayOrder);
         }
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
                 if (TryGetDisplayOrder(propertyContext, out int displayOrder))
                 {
                     // sometimes these items temporarily have null item type. Ignore these cases
-                    if (propertyContext.ItemType != null)
+                    if (propertyContext.ItemType is not null)
                     {
                         propertyValues2.DisplayOrder = displayOrder;
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
                         _externalFilesManager.Value.TransferDocument(item.FilePath, item.FilePath, windowFrame);
 
                         // Show the document window
-                        if (windowFrame != null)
+                        if (windowFrame is not null)
                         {
                             ErrorHandler.ThrowOnFailure(windowFrame.Show());
                         }
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
                 }
             }
 
-            if (exceptions != null)
+            if (exceptions is not null)
             {
                 if (exceptions.Count == 1)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/AddItemDialogService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/AddItemDialogService.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
         private async Task<bool> ShowDialogAsync(IProjectTree node, __VSADDITEMFLAGS flags, string? localizedDirectoryName = null, string? localizedTemplateName = null)
         {
             string? path = _projectTree.TreeProvider.GetAddNewItemDirectory(node);
-            if (path == null)
+            if (path is null)
                 throw new ArgumentException("Node is marked with DisableAddItemFolder or DisableAddItemRecursiveFolder, call CanAddNewOrExistingItemTo before calling this method.", nameof(node));
 
             await _projectVsServices.ThreadingService.SwitchToUIThread();
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
             Guid addItemTemplateGuid = Guid.Empty;  // Let the dialog ask the hierarchy itself
 
             IVsAddProjectItemDlg? addProjectItemDialog = _addProjectItemDialog.Value;
-            if (addProjectItemDialog == null)
+            if (addProjectItemDialog is null)
                 return false;
 
             HResult result = addProjectItemDialog.AddProjectItemDlg(
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
 
         public bool CanAddNewOrExistingItemTo(IProjectTree node)
         {
-            return _projectTree.TreeProvider.GetAddNewItemDirectory(node) != null;
+            return _projectTree.TreeProvider.GetAddNewItemDirectory(node) is not null;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
@@ -42,7 +42,7 @@ internal partial class VsInfoBarService : IInfoBarService
             await _threadingService.SwitchToUIThread(cancellationToken);
 
             IVsInfoBarHost? host = FindMainWindowInfoBarHost();
-            if (host == null)
+            if (host is null)
             {
                 return;
             }
@@ -105,7 +105,7 @@ internal partial class VsInfoBarService : IInfoBarService
     private void AddInfoBar(IVsInfoBarHost host, string message, ImageMoniker image, InfoBarUI[] items)
     {
         IVsInfoBarUIElement? element = CreateInfoBarUIElement(message, image, items);
-        if (element != null)
+        if (element is not null)
         {
             var entry = new InfoBarEntry(message, element, items, OnClosed);
             _entries.Add(entry);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/NameValuePair.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
         private bool IsNamePropertyDuplicate()
         {
-            if (_parentCollection != null)
+            if (_parentCollection is not null)
             {
                 foreach (NameValuePair nvp in _parentCollection)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableList.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/ObservableList.cs
@@ -22,13 +22,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 
         protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
         {
-            if (e.OldItems != null)
+            if (e.OldItems is not null)
             {
                 foreach (INotifyPropertyChanged item in e.OldItems)
                     item.PropertyChanged -= OnItemPropertyChanged;
             }
 
-            if (e.NewItems != null)
+            if (e.NewItems is not null)
             {
                 foreach (INotifyPropertyChanged item in e.NewItems)
                     item.PropertyChanged += OnItemPropertyChanged;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/WpfHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Utilities/WpfHelper.cs
@@ -13,15 +13,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         {
             DataGridRow rowContainer = GetRow(dataGrid, row);
 
-            if (rowContainer != null)
+            if (rowContainer is not null)
             {
                 DataGridCellsPresenter? presenter = GetVisualChild<DataGridCellsPresenter>(rowContainer);
 
-                if (presenter != null)
+                if (presenter is not null)
                 {
                     // try to get the cell but it may possibly be virtualized
                     var cell = (DataGridCell)presenter.ItemContainerGenerator.ContainerFromIndex(column);
-                    if (cell == null)
+                    if (cell is null)
                     {
                         // now try to bring into view and retrieve the cell
                         dataGrid.ScrollIntoView(rowContainer, dataGrid.Columns[column]);
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
         public static DataGridRow GetRow(DataGrid dataGrid, int index)
         {
             var row = (DataGridRow)dataGrid.ItemContainerGenerator.ContainerFromIndex(index);
-            if (row == null)
+            if (row is null)
             {
                 // may be virtualized, bring into view and try again
                 dataGrid.ScrollIntoView(dataGrid.Items[index]);
@@ -54,11 +54,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
             {
                 var v = (Visual)VisualTreeHelper.GetChild(parent, i);
                 child = v as T;
-                if (child == null)
+                if (child is null)
                 {
                     child = GetVisualChild<T>(v);
                 }
-                if (child != null)
+                if (child is not null)
                 {
                     break;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             pfFilter = 0;
 
             var project = _project;
-            if (project == null)
+            if (project is null)
             {
                 return HResult.Unexpected;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -47,11 +47,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
 
             IProjectSpecificEditorInfo? editor = await GetDefaultEditorAsync(documentMoniker);
-            if (editor == null)
+            if (editor is null)
                 return null;
 
             SubTypeDescriptor? descriptor = await GetSubTypeDescriptorAsync(documentMoniker);
-            if (descriptor == null)
+            if (descriptor is null)
                 return null;
 
             bool isDefaultEditor = await _options.Value.GetUseDesignerByDefaultAsync(descriptor.SubType, descriptor.UseDesignerByDefault);
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
 
             SubTypeDescriptor? editorInfo = await GetSubTypeDescriptorAsync(documentMoniker);
-            if (editorInfo == null)
+            if (editorInfo is null)
                 return false;
 
             // 'useGlobalEditor' means use the default editor that is registered for source files
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         private async Task<IProjectSpecificEditorInfo?> GetDefaultEditorAsync(string documentMoniker)
         {
             IProjectSpecificEditorProvider? defaultProvider = GetDefaultEditorProvider();
-            if (defaultProvider == null)
+            if (defaultProvider is null)
                 return null;
 
             return await defaultProvider.GetSpecificEditorAsync(documentMoniker);
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         private async Task<SubTypeDescriptor?> GetSubTypeDescriptorAsync(string documentMoniker)
         {
             string? subType = await GetSubTypeAsync(documentMoniker);
-            if (subType != null)
+            if (subType is not null)
             {
                 foreach (SubTypeDescriptor descriptor in s_subTypeDescriptors)
                 {
@@ -99,13 +99,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         private async Task<string?> GetSubTypeAsync(string documentMoniker)
         {
             IProjectItemTree? item = await FindCompileItemByMonikerAsync(documentMoniker);
-            if (item == null)
+            if (item is null)
                 return null;
 
             ConfiguredProject? project = await _project.GetSuggestedConfiguredProjectAsync();
 
             IRule? browseObject = GetBrowseObjectProperties(project!, item);
-            if (browseObject == null)
+            if (browseObject is null)
                 return null;
 
             return await browseObject.GetPropertyValueAsync(Compile.SubTypeProperty);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/XprojProjectFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Xproj/XprojProjectFactory.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Xproj
         {
             _context.VerifyIsOnMainThread();
 
-            if (_cookie != VSConstants.VSCOOKIE_NIL && _registerProjectTypes != null)
+            if (_cookie != VSConstants.VSCOOKIE_NIL && _registerProjectTypes is not null)
             {
                 Verify.HResult(_registerProjectTypes.UnregisterProjectType(_cookie));
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.Shell
 #pragma warning disable RS0030 // Do not used banned APIs (deliberately adapting)
             service = _serviceProvider.GetService(serviceType);
 #pragma warning restore RS0030 // Do not used banned APIs
-            return service != null;
+            return service is not null;
         }
 
         private static HResult GetComInterfaceForObject(object instance, Guid iid, out IntPtr ppvObject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/SolutionExplorerWindow.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/SolutionExplorerWindow.cs
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Shell
             get
             {
                 _threadingService.VerifyOnUIThread();
-                return _solutionExplorer.Value != null;
+                return _solutionExplorer.Value is not null;
             }
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Shell
             _threadingService.VerifyOnUIThread();
 
             IVsUIHierarchyWindow2? window = _solutionExplorer.Value;
-            if (window == null)
+            if (window is null)
             {
                 throw new InvalidOperationException("Solution Explorer is not available in command-line mode.");
             }
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.Shell
 
         private static IVsUIHierarchyWindow2? GetUIHierarchyWindow(IVsUIService<IVsUIShell> shell, Guid persistenceSlot)
         {
-            if (ErrorHandler.Succeeded(shell.Value.FindToolWindow(0, ref persistenceSlot, out IVsWindowFrame? frame)) && frame != null)
+            if (ErrorHandler.Succeeded(shell.Value.FindToolWindow(0, ref persistenceSlot, out IVsWindowFrame? frame)) && frame is not null)
             {
                 ErrorHandler.ThrowOnFailure(frame.GetProperty((int)__VSFPROPID.VSFPROPID_DocView, out object? view));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.Build
 
                 if (!string.IsNullOrEmpty(s))
                 {
-                    if (seen == null)
+                    if (seen is null)
                     {
                         seen = new HashSet<string>(StringComparers.PropertyValues) { s };
                         yield return s;
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.Build
             Requires.NotNull(project, nameof(project));
             ProjectPropertyElement? property = GetProperty(project, propertyName);
 
-            if (property != null)
+            if (property is not null)
             {
                 return property;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/DictionaryEqualityComparer.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.Collections
                 return true;
             }
 
-            if (x == null || y == null)
+            if (x is null || y is null)
             {
                 return false;
             }
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.Collections
         {
             int hashCode = 0;
 
-            if (obj != null)
+            if (obj is not null)
             {
                 IEqualityComparer<TKey> keyComparer = obj.Comparer ?? EqualityComparer<TKey>.Default;
                 IEqualityComparer<TValue> valueComparer = EqualityComparer<TValue>.Default;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/EnumerableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/EnumerableExtensions.cs
@@ -51,13 +51,13 @@ namespace Microsoft.VisualStudio.Collections
             if (!ignoreDuplicateKeys)
                 return source.ToDictionary(keySelector, elementSelector, comparer);
 
-            if (source == null)
+            if (source is null)
                 throw new ArgumentNullException(nameof(source));
 
-            if (keySelector == null)
+            if (keySelector is null)
                 throw new ArgumentNullException(nameof(keySelector));
 
-            if (elementSelector == null)
+            if (elementSelector is null)
                 throw new ArgumentNullException(nameof(elementSelector));
 
             Dictionary<TKey, TElement> result = new(comparer);
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.Collections
             {
                 var key = keySelector(item);
 
-                if (key == null)
+                if (key is null)
                     throw new ArgumentNullException(nameof(key));
 
                 var element = elementSelector(item);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/SimpleFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/SimpleFileWatcher.cs
@@ -26,14 +26,14 @@ namespace Microsoft.VisualStudio.IO
                 Filter = fileFilter
             };
 
-            if (handler != null)
+            if (handler is not null)
             {
                 _fileWatcher.Created += handler;
                 _fileWatcher.Deleted += handler;
                 _fileWatcher.Changed += handler;
             }
 
-            if (renameHandler != null)
+            if (renameHandler is not null)
             {
                 _fileWatcher.Renamed += renameHandler;
             }
@@ -45,17 +45,17 @@ namespace Microsoft.VisualStudio.IO
 
         public void Dispose()
         {
-            if (_fileWatcher != null)
+            if (_fileWatcher is not null)
             {
                 _fileWatcher.EnableRaisingEvents = false;
-                if (_handler != null)
+                if (_handler is not null)
                 {
                     _fileWatcher.Created -= _handler;
                     _fileWatcher.Deleted -= _handler;
                     _fileWatcher.Changed -= _handler;
                     _handler = null;
                 }
-                if (_renameHandler != null)
+                if (_renameHandler is not null)
                 {
                     _fileWatcher.Renamed -= _renameHandler;
                     _renameHandler = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsFileExplorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsFileExplorer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.IO
             else
             {
                 string? parentPath = GetParentPath(path);
-                if (parentPath != null && _fileSystem.DirectoryExists(parentPath))
+                if (parentPath is not null && _fileSystem.DirectoryExists(parentPath))
                 {
                     OpenFolder(parentPath);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio
         {
             foreach (T? item in source)
             {
-                if (item != null)
+                if (item is not null)
                     yield return item;
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/ObjectPool.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
             // We will interlock only when we have a candidate. in a worst case we may miss some
             // recently returned objects. Not a big deal.
             T? inst = _firstItem;
-            if (inst == null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
+            if (inst is null || inst != Interlocked.CompareExchange(ref _firstItem, null, inst))
             {
                 inst = AllocateSlow();
             }
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
                 // We will interlock only when we have a candidate. in a worst case we may miss some
                 // recently returned objects. Not a big deal.
                 T? inst = items[i].Value;
-                if (inst != null)
+                if (inst is not null)
                 {
                     if (inst == Interlocked.CompareExchange(ref items[i].Value, null, inst))
                     {
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
         /// </remarks>
         internal void Free(T obj)
         {
-            if (_firstItem == null)
+            if (_firstItem is null)
             {
                 // Intentionally not using interlocked here. 
                 // In a worst case scenario two objects may be stored into same slot.
@@ -129,7 +129,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
             Element[] items = _items;
             for (int i = 0; i < items.Length; i++)
             {
-                if (items[i].Value == null)
+                if (items[i].Value is null)
                 {
                     // Intentionally not using interlocked here. 
                     // In a worst case scenario two objects may be stored into same slot.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
         public void Free()
         {
             ObjectPool<PooledArray<T>> pool = _pool;
-            if (pool != null)
+            if (pool is not null)
             {
                 // We do not want to retain (potentially indefinitely) very large builders 
                 // while the chance that we will need their size is diminishingly small.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractActiveConfiguredValue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractActiveConfiguredValue.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _activeConfiguredProjectProvider.Changed += OnActiveConfigurationChanged;
 
             ConfiguredProject? configuredProject = _activeConfiguredProjectProvider.ActiveConfiguredProject;
-            if (configuredProject == null)
+            if (configuredProject is null)
             {
                 _threadingService.ExecuteSynchronously(async () =>
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/AbstractMultiLifetimeComponent.cs
@@ -91,7 +91,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 }
             }
 
-            if (instance != null)
+            if (instance is not null)
             {
                 return instance.DisposeAsync();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             ActiveConfiguredObjects<ProjectConfiguration>? configurations = await GetActiveProjectConfigurationsAsync();
 
-            if (configurations == null)
+            if (configurations is null)
             {
                 return null;
             }
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             ProjectConfiguration? activeSolutionConfiguration = _services.ActiveConfiguredProjectProvider?.ActiveProjectConfiguration;
 
-            if (activeSolutionConfiguration == null)
+            if (activeSolutionConfiguration is null)
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         {
             ProjectConfiguration? activeConfig = _activeConfiguredProjectProvider.ActiveProjectConfiguration;
 
-            if (activeConfig == null)
+            if (activeConfig is null)
                 return false;
 
             return _configuredProject.ProjectConfiguration.EqualIgnoringTargetFramework(activeConfig);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -128,7 +128,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
         public IEnumerable<string> GetBestGuessDimensionNames(ImmutableArray<ProjectPropertyElement> properties)
         {
-            if (FindDimensionProperty(properties) != null)
+            if (FindDimensionProperty(properties) is not null)
                 return new string[] { DimensionName };
 
             return Array.Empty<string>();
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         public async Task<IEnumerable<KeyValuePair<string, string>>> GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProject project)
         {
             string? defaultValue = await FindDefaultValueFromDimensionPropertyAsync(project) ?? DimensionDefaultValue;
-            if (defaultValue != null)
+            if (defaultValue is not null)
                 return new[] { new KeyValuePair<string, string>(DimensionName, defaultValue) };
 
             return Enumerable.Empty<KeyValuePair<string, string>>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
             foreach (IProjectTree node in selectedNodes)
             {
                 string? path = await DependencyServices.GetBrowsePathAsync(_project, node);
-                if (path == null)
+                if (path is null)
                     continue;
 
                 // Note we leave trailing slashes to mimic what happens with normal folders

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             ImmutableDictionary<string, ConfiguredProject>? configProjects = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync();
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            if (configProjects == null)
+            if (configProjects is null)
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -332,7 +332,7 @@ internal static class LaunchSettingsJsonEncoding
             if (!reader.Read())
                 throw new JsonReaderException($"Unexpected end of JSON data at {reader.LineNumber}:{reader.LinePosition}.");
 
-            if (handler != null)
+            if (handler is not null)
             {
                 jsonSerializer ??= JsonSerializer.CreateDefault();
                 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -195,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             // Subscribe to changes to the broadcast block using the idle scheduler. This should filter out a lot of the intermediate
             // states that files can be in.
-            if (_projectSubscriptionService != null)
+            if (_projectSubscriptionService is not null)
             {
                 // The use of AsyncLazy with dataflow can allow state stored in the execution context to leak through. The downstream affect is
                 // calls to say, get properties, may fail. To avoid this, we capture the execution context here, and it will be reapplied when
@@ -230,7 +230,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 {
                     ruleSnapshot.Properties.TryGetValue(ProjectDebugger.ActiveDebugProfileProperty, out string activeProfile);
                     ILaunchSettings snapshot = CurrentSnapshot;
-                    if (snapshot == null || !LaunchProfile.IsSameProfileName(activeProfile, snapshot.ActiveProfile?.Name))
+                    if (snapshot is null || !LaunchProfile.IsSameProfileName(activeProfile, snapshot.ActiveProfile?.Name))
                     {
                         // Updates need to be sequenced
                         await _sequentialTaskQueue.ExecuteTask(async () =>
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected async Task UpdateActiveProfileInSnapshotAsync(string updatedActiveProfileName)
         {
             ILaunchSettings snapshot = CurrentSnapshot;
-            if (snapshot == null || await SettingsFileHasChangedAsync())
+            if (snapshot is null || await SettingsFileHasChangedAsync())
             {
                 await UpdateProfilesAsync(updatedActiveProfileName);
                 return;
@@ -274,7 +274,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 // If the name of the new active profile wasn't provided we'll continue to use the
                 // current one.
-                if (updatedActiveProfileName == null)
+                if (updatedActiveProfileName is null)
                 {
                     ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync();
                     if (await props.ActiveDebugProfile.GetValueAsync() is IEnumValue activeProfileVal)
@@ -298,7 +298,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 // If we have a previous snapshot, merge in in-memory profiles
                 ILaunchSettings prevSnapshot = CurrentSnapshot;
-                if (prevSnapshot != null)
+                if (prevSnapshot is not null)
                 {
                     MergeExistingInMemoryProfiles(ref profiles, prevSnapshot.Profiles);
                     MergeExistingInMemoryGlobalSettings(ref globalSettings, prevSnapshot.GlobalSettings);
@@ -318,7 +318,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 // However, if we have never created a snapshot it means there is some error in the file and we want
                 // to have the user see that, so we add a dummy profile which will bind to an existing debugger which will
                 // display the error when run
-                if (CurrentSnapshot == null)
+                if (CurrentSnapshot is null)
                 {
                     var errorProfile = new LaunchProfile(
                         name: Resources.NoActionProfileName,
@@ -341,7 +341,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     if (profile.IsInMemoryObject() && !string.Equals(profile.CommandName, ErrorProfileCommandName))
                     {
                         // Does it already have one with this name?
-                        if (newProfiles.FirstOrDefault((p1, p2) => LaunchProfile.IsSameProfileName(p1.Name, p2.Name), profile) == null)
+                        if (newProfiles.FirstOrDefault((p1, p2) => LaunchProfile.IsSameProfileName(p1.Name, p2.Name), profile) is null)
                         {
                             // Create a new one from the existing in-memory profile and insert it in the same location, or the end if it
                             // is beyond the end of the list
@@ -481,7 +481,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         protected async Task CheckoutSettingsFileAsync()
         {
             Lazy<ISourceCodeControlIntegration, IOrderPrecedenceMetadataView>? sourceControlIntegration = SourceControlIntegrations.FirstOrDefault();
-            if (sourceControlIntegration?.Value != null)
+            if (sourceControlIntegration?.Value is not null)
             {
                 string fileName = await GetLaunchSettingsFilePathAsync();
 
@@ -547,7 +547,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         private void CleanupFileWatcher()
         {
-            if (FileWatcher != null)
+            if (FileWatcher is not null)
             {
                 FileWatcher.Dispose();
                 FileWatcher = null;
@@ -560,7 +560,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         private void WatchLaunchSettingsFile()
         {
-            if (FileWatcher == null)
+            if (FileWatcher is null)
             {
                 FileChangeScheduler?.Dispose();
 
@@ -595,7 +595,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             if (disposing)
             {
                 CleanupFileWatcher();
-                if (FileChangeScheduler != null)
+                if (FileChangeScheduler is not null)
                 {
                     FileChangeScheduler.Dispose();
                     FileChangeScheduler = null;
@@ -603,19 +603,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 _sequentialTaskQueue.Dispose();
 
-                if (_versionedBroadcastBlock != null)
+                if (_versionedBroadcastBlock is not null)
                 {
                     _versionedBroadcastBlock.Complete();
                     _versionedBroadcastBlock = null;
                 }
 
-                if (_broadcastBlock != null)
+                if (_broadcastBlock is not null)
                 {
                     _broadcastBlock.Complete();
                     _broadcastBlock = null;
                 }
 
-                if (_projectRuleSubscriptionLink != null)
+                if (_projectRuleSubscriptionLink is not null)
                 {
                     _projectRuleSubscriptionLink.Dispose();
                     _projectRuleSubscriptionLink = null;
@@ -667,7 +667,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </summary>
         public async Task<ILaunchSettings?> WaitForFirstSnapshot(int timeout)
         {
-            if (CurrentSnapshot != null)
+            if (CurrentSnapshot is not null)
             {
                 return CurrentSnapshot;
             }
@@ -706,7 +706,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 }
 
                 ImmutableList<ILaunchProfile> profiles;
-                if (existingProfile != null)
+                if (existingProfile is not null)
                 {
                     profiles = currentSettings.Profiles.Remove(existingProfile);
                 }
@@ -745,7 +745,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             {
                 ILaunchSettings currentSettings = await GetSnapshotThrowIfErrorsAsync();
                 ILaunchProfile existingProfile = currentSettings.Profiles.FirstOrDefault(p => LaunchProfile.IsSameProfileName(p.Name, profileName));
-                if (existingProfile != null)
+                if (existingProfile is not null)
                 {
                     ImmutableList<ILaunchProfile> profiles = currentSettings.Profiles.Remove(existingProfile);
 
@@ -901,10 +901,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // see: https://github.com/dotnet/project-system/issues/2316.
 
             string? folder = null;
-            if (_appDesignerSpecialFileProvider.Value != null)
+            if (_appDesignerSpecialFileProvider.Value is not null)
                 folder = await _appDesignerSpecialFileProvider.Value.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath);
 
-            if (folder == null)  // AppDesigner capability not present, or the project has set AppDesignerFolder to empty
+            if (folder is null)  // AppDesigner capability not present, or the project has set AppDesignerFolder to empty
                 folder = Path.GetDirectoryName(_commonProjectServices.Project.FullPath);
 
             return Path.Combine(folder, LaunchSettingsFilename);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/WritableLaunchSettings.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         public WritableLaunchSettings(ILaunchSettings settings)
         {
-            if (settings.Profiles != null)
+            if (settings.Profiles is not null)
             {
                 foreach (ILaunchProfile profile in settings.Profiles)
                 {
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 GlobalSettings.Add(key, value);
             }
 
-            if (settings.ActiveProfile != null)
+            if (settings.ActiveProfile is not null)
             {
                 ActiveProfile = Profiles.Find(profile => LaunchProfile.IsSameProfileName(profile.Name, settings.ActiveProfile.Name));
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public bool Equals(TargetFramework? obj)
         {
-            return obj != null && TargetFrameworkAlias.Equals(obj.TargetFrameworkAlias, StringComparisons.FrameworkIdentifiers);
+            return obj is not null && TargetFrameworkAlias.Equals(obj.TargetFrameworkAlias, StringComparisons.FrameworkIdentifiers);
         }
 
         public static bool operator ==(TargetFramework? left, TargetFramework? right)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectTreeExtensions.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             IRule? properties = node.BrowseObjectProperties;
 
-            if (properties?.Schema == null || !project.Services.PropertyPagesCatalog.SourceBlock.TryReceive(null, out IProjectVersionedValue<IProjectCatalogSnapshot>? catalogSnapshot))
+            if (properties?.Schema is null || !project.Services.PropertyPagesCatalog.SourceBlock.TryReceive(null, out IProjectVersionedValue<IProjectCatalogSnapshot>? catalogSnapshot))
                 return properties;
 
             // We let the snapshot be out of date with the "live" project

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageProviderAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageProviderAggregator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
             {
                 ProjectImageMoniker? image = provider.Value.GetProjectImage(key);
 
-                if (image != null)
+                if (image is not null)
                 {
                     return image;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/BatchLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/BatchLogger.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public void Dispose()
         {
-            if (_builder != null)
+            if (_builder is not null)
             {
                 _outputService.WriteLine(_builder.ToString());
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public bool IsNonUserEditable(string filePath)
         {
             return IsNonModifiable(filePath)
-                   || (ProjectExtensionsPath != null && filePath.StartsWith(ProjectExtensionsPath, StringComparisons.Paths));
+                   || (ProjectExtensionsPath is not null && filePath.StartsWith(ProjectExtensionsPath, StringComparisons.Paths));
         }
 
         /// <summary>
@@ -153,11 +153,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <returns><see langword="true"/> if the file is non-modifiable, otherwise <see langword="false"/>.</returns>
         public bool IsNonModifiable(string filePath)
         {
-            return (_programFiles64 != null && filePath.StartsWith(_programFiles64, StringComparisons.Paths))
+            return (_programFiles64 is not null && filePath.StartsWith(_programFiles64, StringComparisons.Paths))
                    || filePath.StartsWith(_programFiles86, StringComparisons.Paths)
                    || filePath.StartsWith(_windows, StringComparisons.Paths)
                    || _nuGetPackageFolders.Any(nugetFolder => filePath.StartsWith(nugetFolder, StringComparisons.Paths))
-                   || (_vsInstallationDirectory != null && filePath.StartsWith(_vsInstallationDirectory, StringComparisons.Paths));
+                   || (_vsInstallationDirectory is not null && filePath.StartsWith(_vsInstallationDirectory, StringComparisons.Paths));
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             string? relativePath = provider.GetAddNewItemDirectory(target);
 
-            if (relativePath == null)
+            if (relativePath is null)
                 return null;
 
             string? projectFilePath = provider.GetPath(target.Root);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/SourceAssemblyAttributePropertyValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/SourceAssemblyAttributePropertyValueProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private Project? GetActiveProject()
         {
             ProjectId? activeProjectId = _getActiveProjectId();
-            if (activeProjectId == null)
+            if (activeProjectId is null)
             {
                 return null;
             }
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public async Task<string?> GetPropertyValueAsync()
         {
             Project? project = GetActiveProject();
-            if (project == null)
+            if (project is null)
             {
                 return null;
             }
@@ -61,18 +61,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public async Task SetPropertyValueAsync(string value)
         {
             Project? project = GetActiveProject();
-            if (project == null)
+            if (project is null)
             {
                 return;
             }
 
             AttributeData? attribute = await GetAttributeAsync(_assemblyAttributeFullName, project);
-            if (attribute == null)
+            if (attribute is null)
             {
                 return;
             }
 
-            if (attribute.ApplicationSyntaxReference == null)
+            if (attribute.ApplicationSyntaxReference is null)
             {
                 return;
             }
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         private static async Task<AttributeData?> GetAttributeAsync(string assemblyAttributeFullName, Project project)
         {
-            if (project == null)
+            if (project is null)
             {
                 return null;
             }
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             ImmutableArray<AttributeData>? assemblyAttributes = compilation?.Assembly.GetAttributes();
 
             INamedTypeSymbol? attributeTypeSymbol = compilation?.GetTypeByMetadataName(assemblyAttributeFullName);
-            if (attributeTypeSymbol == null)
+            if (attributeTypeSymbol is null)
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DotNetImportsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DotNetImportsEnumProvider.cs
@@ -33,9 +33,9 @@ internal class DotNetImportsEnumProvider : IDynamicEnumValuesProvider, IDynamicE
         Project? project = _workspace.CurrentSolution.Projects.FirstOrDefault(
             proj => StringComparers.Paths.Equals(proj.FilePath, _unconfiguredProject.FullPath));
 
-        Compilation? compilation = project == null ? null : await project.GetCompilationAsync();
+        Compilation? compilation = project is null ? null : await project.GetCompilationAsync();
 
-        if (compilation == null)
+        if (compilation is null)
         {
             return Enumerable.Empty<string>();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
 
             string existingPropertyValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ConfigurationGeneral.ApplicationIconProperty);
             IProjectItem? existingItem = await GetExistingContentItemAsync(existingPropertyValue);
-            if (existingItem != null)
+            if (existingItem is not null)
             {
                 await existingItem.SetUnevaluatedIncludeAsync(propertyValue);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             ComplexTargetFramework storedProperties = await GetStoredPropertiesAsync();
 
-            if (storedProperties.TargetFrameworkMoniker != null)
+            if (storedProperties.TargetFrameworkMoniker is not null)
             {
                 // Changing the Target Framework Moniker
                 if (StringComparers.PropertyLiteralValues.Equals(propertyName, InterceptedTargetFrameworkProperty))
@@ -247,7 +247,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             IImmutableDictionary<string, string>? targetFrameworkProperties = targetFrameworkRuleSnapshot.GetProjectItemProperties(targetFrameworkMoniker);
 
-            if (targetFrameworkProperties != null &&
+            if (targetFrameworkProperties is not null &&
                 targetFrameworkProperties.TryGetValue(SupportedTargetFramework.AliasProperty, out string? targetFrameworkAlias))
             {
                 return targetFrameworkAlias;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 valueToSet = unevaluatedPropertyValue;
             }
 
-            if (valueToSet != null)
+            if (valueToSet is not null)
             {
                 await base.SetPropertyValueAsync(propertyName, valueToSet, dimensionalConditions);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageFilePropertyValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/PackagePropertyPage/PackageFilePropertyValueProviderBase.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
             // <PackagePath></PackagePath> node, which causes the value during pack to default to "content;contentFiles" which is not the intended directory.
             // See discussion here for more details: https://github.com/dotnet/project-system/issues/7642
             string packagePath = @"\";
-            if (existingItem != null)
+            if (existingItem is not null)
             {
                 packagePath = await existingItem.Metadata.GetEvaluatedPropertyValueAsync(PackagePathMetadataName);
                 // The new filepath is the same as the current. No item changes are required.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
             string? targetFrameworkMoniker = (string?)await configuration.TargetFrameworkMoniker.GetValueAsync();
 
-            if (targetFrameworkMoniker != null)
+            if (targetFrameworkMoniker is not null)
             {
                 var targetFramework = new FrameworkName(targetFrameworkMoniker);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchTargetPropertyPageEnumProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             {
                 var catalogProvider = _configuredProject.Services.PropertyPagesCatalog;
 
-                if (catalogProvider == null)
+                if (catalogProvider is null)
                 {
                     return Array.Empty<IEnumValue>();
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/MetadataExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/MetadataExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <returns><see langword="true"/> if the property was found with a non-empty value, otherwise <see langword="false"/>.</returns>
         public static bool TryGetStringProperty(this IImmutableDictionary<string, string> properties, string key, [NotNullWhen(returnValue: true)] out string? stringValue)
         {
-            if (properties != null &&
+            if (properties is not null &&
                 properties.TryGetValue(key, out stringValue) &&
                 !string.IsNullOrEmpty(stringValue))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedValuesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SupportedValuesProvider.cs
@@ -77,9 +77,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             public int Compare(string x, string y)
             {
                 // sort nulls to the start
-                if (x == null)
-                    return y == null ? 0 : -1;
-                if (y == null)
+                if (x is null)
+                    return y is null ? 0 : -1;
+                if (y is null)
                     return 1;
 
                 var ix = 0;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractAppXamlSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractAppXamlSpecialFileProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             // First look for the actual App.xaml first
             IProjectTree? node = FindAppXamlFile(root);
-            if (node == null)
+            if (node is null)
             {
                 // Otherwise, find a candidate that we might be able to add to the project
                 node = await base.FindFileAsync(provider, root);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameSpecialFileProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         protected override Task<string?> GetDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root)
         {
             string? projectPath = provider.GetRootedAddNewItemDirectory(root);
-            if (projectPath == null)  // Root has DisableAddItem
+            if (projectPath is null)  // Root has DisableAddItem
                 return TaskResult.Null<string>();
 
             string path = Path.Combine(projectPath, _fileName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
@@ -21,10 +21,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             // Search AppDesigner folder first if it exists
             IProjectTree? appDesignerFolder = await GetAppDesignerFolderAsync(provider, root);
-            if (appDesignerFolder != null)
+            if (appDesignerFolder is not null)
             {
                 IProjectTree? node = await base.FindFileAsync(provider, appDesignerFolder);
-                if (node != null)
+                if (node is not null)
                     return node;
             }
 
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             // AppDesigner folder first if it exists
             string? appDesignerPath = await GetAppDesignerFolderPathAsync();
-            if (appDesignerPath != null)
+            if (appDesignerPath is not null)
             {
                 return GetDefaultFile(appDesignerPath);
             }
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         private async Task<IProjectTree?> GetAppDesignerFolderAsync(IProjectTreeProvider provider, IProjectTree root)
         {
             string? appDesignerPath = await GetAppDesignerFolderPathAsync();
-            if (appDesignerPath == null)
+            if (appDesignerPath is null)
                 return null;
 
             return provider.FindByPath(root, appDesignerPath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractSpecialFileProvider.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
 
             // Attempt to find an existing file/folder first
             string? path = await FindFileAsync(state.TreeProvider, state.Tree, flags);
-            if (path == null)
+            if (path is null)
             {
                 // Otherwise, fall back and create it
                 path = await CreateDefaultFileAsync(state.TreeProvider, state.Tree, flags);
@@ -40,11 +40,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         private async Task<string?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root, SpecialFileFlags flags)
         {
             IProjectTree? node = await FindFileAsync(provider, root);
-            if (node == null)
+            if (node is null)
                 return null;
 
             string? path = GetFilePath(provider, node);
-            if (path != null && flags.HasFlag(SpecialFileFlags.CreateIfNotExist))
+            if (path is not null && flags.HasFlag(SpecialFileFlags.CreateIfNotExist))
             {
                 // Similar to legacy, we only verify state if we've been asked to create it
                 await VerifyStateAsync(node, path);
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             string? path = await GetDefaultFileAsync(provider, root);
 
-            if (path != null && flags.HasFlag(SpecialFileFlags.CreateIfNotExist))
+            if (path is not null && flags.HasFlag(SpecialFileFlags.CreateIfNotExist))
             {
                 await CreateFileAsync(path);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         {
             // First look for the actual AppDesigner folder
             IProjectTree? folder = FindAppDesignerFolder(root);
-            if (folder == null)
+            if (folder is null)
             {
                 // Otherwise, find a location that is a candidate
                 folder = await FindAppDesignerFolderCandidateAsync(provider, root);
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         protected override async Task<string?> GetDefaultFileAsync(IProjectTreeProvider provider, IProjectTree root)
         {
             string? projectPath = provider.GetRootedAddNewItemDirectory(root);
-            if (projectPath == null)  // Root has DisableAddItem
+            if (projectPath is null)  // Root has DisableAddItem
                 return null;
 
             string? folderName = await GetDefaultAppDesignerFolderNameAsync();
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         private async Task<IProjectTree?> FindAppDesignerFolderCandidateAsync(IProjectTreeProvider provider, IProjectTree root)
         {
             string? path = await GetDefaultFileAsync(provider, root);
-            if (path == null)
+            if (path is null)
                 return null;
 
             return provider.FindByPath(root, path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         protected override async Task<IProjectTree?> FindFileAsync(IProjectTreeProvider provider, IProjectTree root)
         {
             string? path = await GetAppManifestPathFromPropertiesAsync();
-            if (path == null)
+            if (path is null)
                 return await base.FindFileAsync(provider, root);
 
             return provider.FindByPath(root, path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContextProvider.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
             ImmutableDictionary<string, ConfiguredProject>? configuredProjectsMap = await _activeConfiguredProjectsProvider.GetActiveConfiguredProjectsMapAsync();
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            if (configuredProjectsMap == null)
+            if (configuredProjectsMap is null)
             {
                 throw new InvalidOperationException("There are no active configured projects.");
             }
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
                 ConfigurationGeneral configurationGeneralProperties = await projectProperties.GetConfigurationGeneralPropertiesAsync();
                 object? targetObject = await configurationGeneralProperties.TargetFramework.GetValueAsync();
 
-                if (targetObject == null)
+                if (targetObject is null)
                 {
                     return TargetFramework.Empty;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -105,13 +105,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // If the node's FilePath is null, we are going to return null regardless of whether
             // this node belongs to the dependencies tree or not, so avoid extra work by retuning
             // immediately here.
-            if (node.FilePath == null)
+            if (node.FilePath is null)
             {
                 return null;
             }
 
             // Walk up from node through all its ancestors.
-            for (IProjectTree? step = node; step != null; step = step.Parent)
+            for (IProjectTree? step = node; step is not null; step = step.Parent)
             {
                 if (step.Flags.Contains(DependencyTreeFlags.DependenciesRootNode))
                 {
@@ -199,7 +199,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 // Handle the removal of normal reference Item Nodes (this excludes any shared import nodes).
                 foreach (IProjectTree node in referenceItemNodes)
                 {
-                    if (node.BrowseObjectProperties?.Context == null)
+                    if (node.BrowseObjectProperties?.Context is null)
                     {
                         // If node does not have an IRule with valid ProjectPropertiesContext we can not
                         // get its itemsSpec. If nodes provided by custom IProjectDependenciesSubTreeProvider
@@ -216,8 +216,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                             (item, t) => string.Equals(item.ItemType, t, StringComparisons.ItemTypes),
                             nodeItemContext.ItemType);
 
-                    Report.IfNot(unresolvedReferenceItem != null, "Cannot find reference to remove.");
-                    if (unresolvedReferenceItem != null)
+                    Report.IfNot(unresolvedReferenceItem is not null, "Cannot find reference to remove.");
+                    if (unresolvedReferenceItem is not null)
                     {
                         project.RemoveItem(unresolvedReferenceItem);
                     }
@@ -378,7 +378,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             // Take the highest priority view provider
             IDependenciesTreeViewProvider? viewProvider = _viewProviders.FirstOrDefault()?.Value;
 
-            if (viewProvider == null)
+            if (viewProvider is null)
             {
                 return;
             }
@@ -496,9 +496,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 itemType: dependency.SchemaItemType,
                 itemName: itemSpec);
 
-            Rule? schema = dependency.SchemaName != null ? browseObjectsCatalog.GetSchema(dependency.SchemaName) : null;
+            Rule? schema = dependency.SchemaName is not null ? browseObjectsCatalog.GetSchema(dependency.SchemaName) : null;
 
-            if (schema == null)
+            if (schema is null)
             {
                 // Since we have no browse object, we still need to create *something* so
                 // that standard property pages can pop up.
@@ -524,12 +524,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             async Task<IImmutableDictionary<string, IPropertyPagesCatalog>> GetNamedCatalogsAsync()
             {
-                if (catalogs != null)
+                if (catalogs is not null)
                 {
                     return catalogs.NamedCatalogs;
                 }
 
-                if (_namedCatalogs == null)
+                if (_namedCatalogs is null)
                 {
                     Assumes.NotNull(ActiveConfiguredProject);
                     Assumes.Present(ActiveConfiguredProject.Services.PropertyPagesCatalog);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeViewProvider.cs
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     else
                     {
                         IProjectTree? node = dependenciesTree.FindChildWithCaption(targetFramework.TargetFrameworkAlias);
-                        bool shouldAddTargetNode = node == null;
+                        bool shouldAddTargetNode = node is null;
                         IDependencyViewModel targetViewModel = _viewModelFactory.CreateTargetViewModel(targetedSnapshot.TargetFramework, targetedSnapshot.MaximumVisibleDiagnosticLevel);
 
                         node = CreateOrUpdateNode(
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
             IProjectTree RememberNewNodes(IProjectTree rootNode, IEnumerable<IProjectTree> newNodes)
             {
-                if (newNodes != null)
+                if (newNodes is not null)
                 {
                     currentNodes.AddRange(newNodes);
                 }
@@ -197,18 +197,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                     providerType,
                     targetedSnapshot.GetMaximumVisibleDiagnosticLevelForProvider(providerType));
 
-                if (subTreeViewModel == null)
+                if (subTreeViewModel is null)
                 {
                     // In theory this should never happen, as it means we have a dependency model of a type
                     // that no provider claims. https://github.com/dotnet/project-system/issues/3653
                     continue;
                 }
 
-                IProjectTree? subTreeNode = subtreeFlag != null
+                IProjectTree? subTreeNode = subtreeFlag is not null
                     ? rootNode.FindChildWithFlags(subtreeFlag.Value)
                     : rootNode.FindChildWithCaption(subTreeViewModel.Caption);
 
-                bool isNewSubTreeNode = subTreeNode == null;
+                bool isNewSubTreeNode = subTreeNode is null;
 
                 ProjectTreeFlags excludedFlags = targetedSnapshot.TargetFramework.Equals(TargetFramework.Any)
                     ? ProjectTreeFlags.Create(ProjectTreeFlags.Common.BubbleUp)
@@ -257,7 +257,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             foreach (IDependency dependency in dependencies)
             {
                 IProjectTree? dependencyNode = rootNode.FindChildWithCaption(dependency.Caption);
-                bool isNewDependencyNode = dependencyNode == null;
+                bool isNewDependencyNode = dependencyNode is null;
 
                 // NOTE this project system supports multiple implicit configuration dimensions (such as target framework)
                 // which is a concept not modelled by DTE/VSLangProj. In order to produce a sensible view of the project
@@ -284,7 +284,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 rootNode = parent;
             }
 
-            return currentNodes != null // shouldCleanup
+            return currentNodes is not null
                 ? CleanupOldNodes(rootNode, currentNodes)
                 : rootNode;
         }
@@ -334,7 +334,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             ProjectTreeFlags? additionalFlags = null,
             ProjectTreeFlags? excludedFlags = null)
         {
-            if (node != null)
+            if (node is not null)
             {
                 return UpdateTreeNode();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyIconSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyIconSet.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         public bool Equals(DependencyIconSet? other)
         {
-            return other != null
+            return other is not null
                 && Icon.Id == other.Icon.Id
                 && ExpandedIcon.Id == other.ExpandedIcon.Id
                 && UnresolvedIcon.Id == other.UnresolvedIcon.Id

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             Requires.NotNull(node, nameof(node));
 
             string? path = await GetMaybeRelativeBrowsePathAsync(project, node);
-            if (path == null)
+            if (path is null)
                 return null;
 
             return project.MakeRooted(path);
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                 return await GetSharedAssetsProjectAsync(project, node);
             }
 
-            if (node.BrowseObjectProperties == null)
+            if (node.BrowseObjectProperties is null)
                 return null;
 
             // This property typically only exists for "Resolved" dependencies with exception 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             _project = project;
             _safeProjectGuidService = safeProjectGuidService;
 
-            if (telemetryService != null)
+            if (telemetryService is not null)
             {
                 _telemetryService = telemetryService;
                 _stateByFramework = new Dictionary<TargetFramework, TelemetryState>();
@@ -60,12 +60,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         public void InitializeTargetFrameworkRules(ImmutableArray<TargetFramework> targetFrameworks, IReadOnlyCollection<string> rules)
         {
-            if (_stateByFramework == null)
+            if (_stateByFramework is null)
                 return;
 
             lock (_stateUpdateLock)
             {
-                if (_stateByFramework == null)
+                if (_stateByFramework is null)
                     return;
 
                 foreach (TargetFramework targetFramework in targetFrameworks)
@@ -85,12 +85,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         public void ObserveTargetFrameworkRules(TargetFramework targetFramework, IEnumerable<string> rules)
         {
-            if (_stateByFramework == null)
+            if (_stateByFramework is null)
                 return;
 
             lock (_stateUpdateLock)
             {
-                if (_stateByFramework == null)
+                if (_stateByFramework is null)
                     return;
 
                 if (_stateByFramework.TryGetValue(targetFramework, out TelemetryState telemetryState))
@@ -105,7 +105,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         public async ValueTask ObserveTreeUpdateCompletedAsync(bool hasUnresolvedDependency)
         {
-            if (_stateByFramework == null)
+            if (_stateByFramework is null)
                 return;
 
             Assumes.NotNull(_telemetryService);
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             bool observedAllRules;
             lock (_stateUpdateLock)
             {
-                if (_stateByFramework == null)
+                if (_stateByFramework is null)
                     return;
 
                 observedAllRules = _stateByFramework.All(state => state.Value.ObservedAllRules());
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         protected override void Dispose(bool disposing)
         {
-            if (disposing && _telemetryService != null && _dependenciesSnapshot != null && _projectId != null)
+            if (disposing && _telemetryService is not null && _dependenciesSnapshot is not null && _projectId is not null)
             {
                 var data = new List<TargetData>();
                 int totalDependencyCount = 0;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/AssemblyDependencyModel.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             {
                 string? fusionName = properties.GetStringProperty(ResolvedAssemblyReference.FusionNameProperty);
 
-                return fusionName == null ? path : new AssemblyName(fusionName).Name;
+                return fusionName is null ? path : new AssemblyName(fusionName).Name;
             }
 
             return path;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
                     ConfigurationGeneral projectProperties = await _projectVsServices.ActiveConfiguredProjectProperties.GetConfigurationGeneralPropertiesAsync();
                     Task<object?>? task = projectProperties?.NETCoreSdkVersion?.GetValueAsync();
-                    string? version = task == null ? string.Empty : (string?)await task;
+                    string? version = task is null ? string.Empty : (string?)await task;
                     string? projectId = await GetProjectIdAsync();
 
                     if (Strings.IsNullOrEmpty(version) || Strings.IsNullOrEmpty(projectId))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             var dependencyById = previousSnapshot.Dependencies.ToDictionary(IDependencyExtensions.GetDependencyId);
 
-            if (changes != null && changes.RemovedNodes.Count != 0)
+            if (changes is not null && changes.RemovedNodes.Count != 0)
             {
                 foreach (IDependencyModel removed in changes.RemovedNodes)
                 {
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 anyChanges = true;
             }
 
-            if (changes != null && changes.AddedNodes.Count != 0)
+            if (changes is not null && changes.AddedNodes.Count != 0)
             {
                 foreach (IDependencyModel added in changes.AddedNodes)
                 {
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                     // Check whether we have a match of form "Caption (Suffix)".
                     string? suffix = GetSuffix(other);
 
-                    if (suffix != null)
+                    if (suffix is not null)
                     {
                         int expectedItemSpecIndex = dependency.Caption.Length + 2; // " (".Length
                         int expectedLength = expectedItemSpecIndex + suffix.Length + 1; // ")".Length
@@ -132,7 +132,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
 
             if (shouldApplyAlias)
             {
-                if (matchingDependency != null)
+                if (matchingDependency is not null)
                 {
                     // Change the matching dependency's caption too
                     IDependency modifiedMatching = matchingDependency.WithCaption(caption: GetAlias(matchingDependency));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesChangesBuilder.cs
@@ -50,14 +50,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
         public IDependenciesChanges? TryBuildChanges()
         {
-            if (_added == null && _removed == null)
+            if (_added is null && _removed is null)
             {
                 return null;
             }
 
             return new DependenciesChanges(
-                _added == null ? ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_added),
-                _removed == null ? ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_removed));
+                _added is null ? ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_added),
+                _removed is null ? ImmutableList<IDependencyModel>.Empty : ImmutableArray.CreateRange(_removed));
         }
 
         public bool HasResolvedItem(TargetFramework targetFramework, string providerType, string dependencyId)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                 AggregateCrossTargetProjectContext? previousContext = Current;
 
                 // Check if we have already computed the project context.
-                if (previousContext != null)
+                if (previousContext is not null)
                 {
                     // For non-cross targeting projects, we can use the current project context if the TargetFramework hasn't changed.
                     // For cross-targeting projects, we need to verify that the current project context matches latest frameworks targeted by the project.
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     {
                         TargetFramework? targetFramework = _targetFrameworkProvider.GetTargetFramework(targetFrameworkMoniker);
 
-                        if (targetFramework == null || !previousContext.TargetFrameworks.Contains(targetFramework))
+                        if (targetFramework is null || !previousContext.TargetFrameworks.Contains(targetFramework))
                         {
                             // Differing TargetFramework
                             return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -260,7 +260,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     activeTargetFramework),
                 token);
 
-            if (updatedSnapshot != null)
+            if (updatedSnapshot is not null)
             {
                 _dependencyTreeTelemetryService.ObserveSnapshot(updatedSnapshot);
             }
@@ -287,7 +287,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
         {
             // If "TargetFrameworks" property has changed, we need to refresh the project context and subscriptions.
             // If no context exists yet, create one.
-            if (HasTargetFrameworksChanged() || _context.Current == null)
+            if (HasTargetFrameworksChanged() || _context.Current is null)
             {
                 return UpdateProjectContextAndSubscriptionsAsync();
             }
@@ -314,7 +314,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             {
                 AggregateCrossTargetProjectContext? newProjectContext = await _context.TryUpdateCurrentAggregateProjectContextAsync();
 
-                if (newProjectContext != null)
+                if (newProjectContext is not null)
                 {
                     _snapshot.TryUpdate(previousSnapshot => previousSnapshot.SetTargets(newProjectContext.TargetFrameworks, newProjectContext.ActiveTargetFramework));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                     {
                         AggregateCrossTargetProjectContext? currentAggregateContext = await _provider!.GetCurrentAggregateProjectContextAsync(cancellationToken);
 
-                        if (currentAggregateContext == null)
+                        if (currentAggregateContext is null)
                         {
                             return;
                         }
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                         // Get the target framework to update for this change.
                         TargetFramework? targetFrameworkToUpdate = currentAggregateContext.GetProjectFramework(GetProjectConfiguration(e));
 
-                        if (targetFrameworkToUpdate == null)
+                        if (targetFrameworkToUpdate is null)
                         {
                             return;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
             IDependenciesChanges? changes = changesBuilder.TryBuildChanges();
 
-            if (changes != null)
+            if (changes is not null)
             {
                 RaiseDependenciesChanged(targetFrameworkToUpdate, changes, currentAggregateContext, catalogs);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
         {
             IDependencyModel? model = CreateDependencyModelForRule(addedItem, evaluationRuleSnapshot, projectChange.After, isResolvedItem, changesBuilder, targetFramework, projectFullPath);
 
-            if (model != null && (isEvaluatedItemSpec == null || isEvaluatedItemSpec(model.Id)))
+            if (model is not null && (isEvaluatedItemSpec is null || isEvaluatedItemSpec(model.Id)))
             {
                 changesBuilder.Added(targetFramework, model);
             }
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
             IImmutableDictionary<string, string>? evaluationProperties = evaluationRuleSnapshot.GetProjectItemProperties(originalItemSpec);
 
-            if (evaluationProperties == null)
+            if (evaluationProperties is null)
             {
                 if (ResolvedItemRequiresEvaluatedItem)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
                 string? dependencyType = properties.GetStringProperty(ProjectItemMetadata.Type);
 
-                if (dependencyType != null)
+                if (dependencyType is not null)
                 {
                     // LEGACY MODE
                     //
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
 
             IImmutableDictionary<string, string>? evaluationProperties = evaluationRuleSnapshot.GetProjectItemProperties(originalItemSpec);
 
-            if (evaluationProperties == null)
+            if (evaluationProperties is null)
             {
                 // This package is present in build results, but not in evaluation.
                 // We disallow packages which are not present in evaluation.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/PackageContentProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/PackageContentProjectTreePropertiesProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
             // Package content items always come in as linked items, so to reduce
             // the number of items we look at, we limit ourselves to them
             if (propertyValues.Flags.Contains(ProjectTreeFlags.LinkedItem) &&
-                propertyContext.Metadata != null &&
+                propertyContext.Metadata is not null &&
                 propertyContext.Metadata.TryGetValue(None.NuGetPackageIdProperty, out string packageId) && packageId.Length > 0)
             {
                 propertyValues.Flags |= ProjectTreeFlags.UserReadOnly;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -112,7 +112,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                                 // This avoids a race condition between the (locked) changing of _showAllFiles and the (locked) changing
                                 // of _subscriptions. Even if there is a race, the right number of toggles will occur and the end result
                                 // will be correct.
-                                if (_subscriptions == null)
+                                if (_subscriptions is null)
                                 {
                                     SetUpTree();
                                 }
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                             (currentTree, configuredProjectExports, token) =>
                             {
                                 // Update (make visible) or create a new tree if no prior one exists
-                                IProjectTree tree = currentTree == null
+                                IProjectTree tree = currentTree is null
                                     ? NewTree(Resources.ImportsTreeNodeName, icon: s_rootIcon, flags: s_projectImportsTreeRootFlags)
                                     : currentTree.Value.Tree.SetVisible(true);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectRootImageProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectRootImageProjectTreePropertiesProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
         {
             ProjectImageMoniker? icon = _imageProvider.GetProjectImage(imageKey);
 
-            if (icon != null)
+            if (icon is not null)
             {
                 propertyValues.Icon = icon;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [AppliesTo(ProjectCapability.DotNet)]
         public Task OnProjectFactoryCompleted()
         {
-            if (_loadedInHostListener != null)
+            if (_loadedInHostListener is not null)
             {
                 return _loadedInHostListener.StartListeningAsync();
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             public void EnsureInitialized()
             {
-                if (_link != null || _disposed != 0)
+                if (_link is not null || _disposed != 0)
                 {
                     // Already initialized or disposed
                     return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -311,7 +311,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<(string Path, string? ItemType, bool IsRequired)> CollectDefaultInputs()
             {
-                if (state.MSBuildProjectFullPath != null)
+                if (state.MSBuildProjectFullPath is not null)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingProjectFileInputs));
                     log.Indent++;
@@ -320,7 +320,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     yield return (Path: state.MSBuildProjectFullPath, ItemType: null, IsRequired: true);
                 }
 
-                if (state.NewestImportInput != null)
+                if (state.NewestImportInput is not null)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingNewestImportInput));
                     log.Indent++;
@@ -540,7 +540,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (log.Level >= LogLevel.Verbose)
                 {
                     log.Indent++;
-
+                   
                     foreach (string path in items)
                     {
                         string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
@@ -624,7 +624,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 DateTime? sourceTime = timestampCache.GetTimestampUtc(source);
 
-                if (sourceTime != null)
+                if (sourceTime is not null)
                 {
                     log.Indent++;
                     log.Info(nameof(Resources.FUTD_SourceFileTimeAndPath_2), sourceTime, source);
@@ -637,7 +637,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 DateTime? destinationTime = timestampCache.GetTimestampUtc(destination);
 
-                if (destinationTime != null)
+                if (destinationTime is not null)
                 {
                     log.Indent++;
                     log.Info(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destination);
@@ -694,7 +694,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                     DateTime? sourceTime = timestampCache.GetTimestampUtc(sourcePath);
 
-                    if (sourceTime != null)
+                    if (sourceTime is not null)
                     {
                         log.Info(nameof(Resources.FUTD_SourceFileTimeAndPath_2), sourceTime, sourcePath);
                     }
@@ -706,7 +706,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     string destinationPath = Path.Combine(outputFullPath, filename);
                     DateTime? destinationTime = timestampCache.GetTimestampUtc(destinationPath);
 
-                    if (destinationTime != null)
+                    if (destinationTime is not null)
                     {
                         log.Info(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destinationPath);
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -413,7 +413,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 foreach ((string item, IImmutableDictionary<string, string> metadata) in projectChangeDescription.After.Items)
                 {
-                    if (metadataPredicate != null && !metadataPredicate(metadata))
+                    if (metadataPredicate is not null && !metadataPredicate(metadata))
                     {
                         continue;
                     }
@@ -421,7 +421,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     string? setNames = metadata.GetStringProperty(setPropertyName);
                     string kindName = metadata.GetStringProperty(kindPropertyName) ?? BuildUpToDateCheck.DefaultKindName;
 
-                    if (setNames != null)
+                    if (setNames is not null)
                     {
                         foreach (string setName in new LazyStringSplit(setNames, ';'))
                         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableBag.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         {
             ImmutableHashSet<IDisposable>? disposables = Interlocked.Exchange(ref _disposables, null);
 
-            if (disposables != null)
+            if (disposables is not null)
             {
                 foreach (IDisposable? item in disposables)
                 {
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
         /// <param name="disposable">The value to be included in this disposable bag.</param>
         public void Add(IDisposable? disposable)
         {
-            if (disposable == null)
+            if (disposable is null)
             {
                 return;
             }
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
                 ref _disposables,
                 (set, item) =>
                 {
-                    if (set == null)
+                    if (set is null)
                     {
                         shouldDisposeArgument = true;
                         return null!;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/CancellationSeries.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         ~CancellationSeries()
         {
             Debug.Assert(
-                Environment.HasShutdownStarted || _cts == null,
+                Environment.HasShutdownStarted || _cts is null,
                 "Instance of CancellationSeries not disposed before being finalized",
                 "Stack at construction:{0}{1}",
                 Environment.NewLine,
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
 
             CancellationTokenSource? priorSource = Interlocked.Exchange(ref _cts, nextSource);
 
-            if (priorSource == null)
+            if (priorSource is null)
             {
                 nextSource.Dispose();
 
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
 
             CancellationTokenSource? source = Interlocked.Exchange(ref _cts, null);
 
-            if (source == null)
+            if (source is null)
             {
                 // Already disposed
                 return;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Construction/Project.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 "PropertyGroup",
                 new XElement("TargetFrameworks", TargetFrameworks)));
 
-            if (_referencedProjects != null)
+            if (_referencedProjects is not null)
             {
                 XElement.Add(new XElement(
                     "ItemGroup",
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         new XAttribute("Include", $"..\\{p.RelativeProjectFilePath}")))));
             }
 
-            if (_assemblyReferences != null)
+            if (_assemblyReferences is not null)
             {
                 XElement.Add(new XElement(
                     "ItemGroup",
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         new XAttribute("Include", p.Name)))));
             }
 
-            if (_packageReferences != null)
+            if (_packageReferences is not null)
             {
                 XElement.Add(new XElement(
                     "ItemGroup",
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             XElement.Save(Path.Combine(solutionRoot, RelativeProjectFilePath));
 
-            if (_files != null)
+            if (_files is not null)
             {
                 foreach (var file in _files)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Diagnostics/WarningIgnorerLogger.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Diagnostics/WarningIgnorerLogger.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.Diagnostics
         {
             // Set the base TestContext
             var property = typeof(TestContextLogger).GetProperty("TestContext", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-            if (property == null)
+            if (property is null)
                 throw new InvalidOperationException("Unable to find TestContextLogger.TestContext. Has it been renamed?");
 
             property.SetValue(this, context);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
@@ -80,17 +80,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             void VerifyNode(Node? expect, SolutionExplorerItemTestExtension? actual, int depth = 0)
             {
-                Assert.IsTrue(expect != null || actual != null);
+                Assert.IsTrue(expect is not null || actual is not null);
 
                 var thisSame = true;
 
-                if (actual != null && expect?.Text != null && expect.Text != actual.Name)
+                if (actual is not null && expect?.Text is not null && expect.Text != actual.Name)
                 {
                     same = false;
                     thisSame = false;
                 }
 
-                if (actual != null && expect?.Icon != null && !AssertExtensions.AreEqual(expect.Icon.Value, actual.ExpandedIconMoniker))
+                if (actual is not null && expect?.Icon != null && !AssertExtensions.AreEqual(expect.Icon.Value, actual.ExpandedIconMoniker))
                 {
                     same = false;
                     thisSame = false;
@@ -100,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     ? "null"
                     : ImageMonikerDebuggerDisplay.FromImageMoniker(actual.ExpandedIconMoniker.Value.ToImageMoniker());
 
-                if (expect != null)
+                if (expect is not null)
                 {
                     expectOutput
                         .Append(' ', depth * 4)
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             : actualIcon);
                 }
 
-                if (actual != null)
+                if (actual is not null)
                 {
                     actualOutput
                         .Append(' ', depth * 4)
@@ -121,9 +121,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                         .AppendLine(thisSame ? "" : " 🐛");
                 }
 
-                if (expect?.Children != null)
+                if (expect?.Children is not null)
                 {
-                    if (actual?.IsExpanded == false && expect.Children != null && expect.Children.Count != 0)
+                    if (actual?.IsExpanded == false && expect.Children is not null && expect.Children.Count != 0)
                     {
                         actual.Expand();
                     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get
                 {
                     MutableProjectTree root = this;
-                    while (root.Parent != null)
+                    while (root.Parent is not null)
                     {
                         root = root.Parent;
                     }
@@ -192,21 +192,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool IProjectTree.TryFindImmediateChild(string caption, out IProjectTree subtree)
             {
                 subtree = Children.FirstOrDefault(c => c.Caption == caption);
-                return subtree != null;
+                return subtree is not null;
             }
 
             public IProjectTree SetProperties(string? caption = null, string? filePath = null, IRule? browseObjectProperties = null, ProjectImageMoniker? icon = null, ProjectImageMoniker? expandedIcon = null, bool? visible = null, ProjectTreeFlags? flags = null, IProjectPropertiesContext? context = null, IPropertySheet? propertySheet = null, bool? isLinked = null, bool resetFilePath = false, bool resetBrowseObjectProperties = false, bool resetIcon = false, bool resetExpandedIcon = false)
             {
-                if (caption != null)
+                if (caption is not null)
                     Caption = caption;
 
-                if (filePath != null)
+                if (filePath is not null)
                     FilePath = filePath;
 
                 if (visible != null)
                     Visible = visible.Value;
 
-                if (flags != null)
+                if (flags is not null)
                     Flags = flags.Value;
 
                 return this;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             {
                 current = ReadNextProjectItem(current);
 
-            } while (current != null);
+            } while (current is not null);
 
             return root;
         }
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 indent++;
             }
 
-            if (parent == null)
+            if (parent is null)
                 throw FormatException(ProjectTreeFormatError.MultipleRoots, "Encountered another project root, when tree can only have one.");
 
             MutableProjectTree tree = ReadProjectItem();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreePropertiesProviderExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreePropertiesProviderExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 get
                 {
                     IProjectTree? parent = _tree.Parent;
-                    if (parent == null)
+                    if (parent is null)
                         return ProjectTreeFlags.Empty;
 
                     return parent.Flags;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             if (!_options.HasFlag(ProjectTreeWriterOptions.SubType))
                 return;
 
-            if (tree.BrowseObjectProperties != null)
+            if (tree.BrowseObjectProperties is not null)
             {
                 _builder.Append(", SubType: ");
                 _builder.Append(tree.BrowseObjectProperties.GetPropertyValueAsync("SubType").Result);
@@ -215,7 +215,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             _builder.AppendFormat(", {0}: {{", name);
 
-            if (icon != null)
+            if (icon is not null)
             {
                 _builder.AppendFormat("{1} {2}", name, icon.Guid.ToString("D").ToUpperInvariant(), icon.Id);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.IO
 
         public string GetFullPath(string path)
         {
-            if (_currentDirectory != null)
+            if (_currentDirectory is not null)
             {
                 var pathRoot = Path.GetPathRoot(path);
                 if (pathRoot == @"\")

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicitlyTriggeredBuildManagerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicitlyTriggeredBuildManagerFactory.cs
@@ -14,19 +14,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         {
             var mock = new Mock<IImplicitlyTriggeredBuildManager2>();
 
-            if (onImplicitBuildStart != null)
+            if (onImplicitBuildStart is not null)
             {
                 mock.Setup(t => t.OnBuildStart())
                     .Callback(onImplicitBuildStart);
             }
 
-            if (onImplicitBuildEndOrCancel != null)
+            if (onImplicitBuildEndOrCancel is not null)
             {
                 mock.Setup(t => t.OnBuildEndOrCancel())
                     .Callback(onImplicitBuildEndOrCancel);
             }
 
-            if (onImplictBuildStartWithStartupPaths != null)
+            if (onImplictBuildStartWithStartupPaths is not null)
             {
                 mock.Setup(t => t.OnBuildStart(It.IsAny<ImmutableArray<string>>()))
                     .Callback(onImplictBuildStartWithStartupPaths);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IInterceptingPropertyValueProvider>();
 
-            if (onGetEvaluatedPropertyValue != null)
+            if (onGetEvaluatedPropertyValue is not null)
             {
                 mock.Setup(t => t.OnGetEvaluatedPropertyValueAsync(
                     It.IsAny<string>(),
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                      .Returns<string, string, IProjectProperties>((n, u, p) => Task.FromResult(onGetEvaluatedPropertyValue(u, p)));
             }
 
-            if (onGetUnevaluatedPropertyValue != null)
+            if (onGetUnevaluatedPropertyValue is not null)
             {
                 mock.Setup(t => t.OnGetUnevaluatedPropertyValueAsync(
                     It.IsAny<string>(),
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                      .Returns<string, string, IProjectProperties>((n, u, p) => Task.FromResult(onGetUnevaluatedPropertyValue(u, p)));
             }
 
-            if (onSetPropertyValue != null)
+            if (onSetPropertyValue is not null)
             {
                 mock.Setup(t => t.OnSetPropertyValueAsync(
                     It.IsAny<string>(),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 launchSettingsMock.Setup(t => t.GlobalSettings).Returns(initialGlobalSettings);
             }
 
-            if (activeProfileName != null)
+            if (activeProfileName is not null)
             {
                 var activeLaunchProfile = launchProfiles?.FirstOrDefault(p => p.Name == activeProfileName)
                     ?? new LaunchProfile(name: activeProfileName, commandName: null);
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             settingsProviderMock.Setup(t => t.WaitForFirstSnapshot(It.IsAny<int>())).Returns(Task.FromResult<ILaunchSettings?>(launchSettings));
             settingsProviderMock.SetupGet(t => t.CurrentSnapshot).Returns(launchSettings);
 
-            if (setActiveProfileCallback != null)
+            if (setActiveProfileCallback is not null)
             {
                 settingsProviderMock.Setup(t => t.SetActiveProfileAsync(It.IsAny<string>()))
                     .Returns<string>(v =>
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     });
             }
 
-            if (updateLaunchSettingsCallback != null)
+            if (updateLaunchSettingsCallback is not null)
             {
                 settingsProviderMock.Setup(t => t.UpdateAndSaveSettingsAsync(It.IsAny<ILaunchSettings>()))
                     .Returns<ILaunchSettings>(v =>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IMockDependenciesViewModelFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 mock.Setup(x => x.GetDependenciesRootIcon(It.IsAny<DiagnosticLevel>())).Returns(getDependenciesRootIcon.Value);
             }
 
-            if (createRootViewModel != null)
+            if (createRootViewModel is not null)
             {
                 foreach (var d in createRootViewModel)
                 {
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 }
             }
 
-            if (createTargetViewModel != null)
+            if (createTargetViewModel is not null)
             {
                 foreach (var d in createTargetViewModel)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectDependenciesSubTreeProviderFactory.cs
@@ -14,17 +14,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IProjectDependenciesSubTreeProvider2>(mockBehavior);
 
-            if (providerType != null)
+            if (providerType is not null)
             {
                 mock.Setup(x => x.ProviderType).Returns(providerType);
             }
 
-            if (createRootDependencyNode != null)
+            if (createRootDependencyNode is not null)
             {
                 mock.Setup(x => x.CreateRootDependencyNode()).Returns(createRootDependencyNode);
             }
 
-            if (groupNodeFlags != null)
+            if (groupNodeFlags is not null)
             {
                 mock.SetupGet(x => x.GroupNodeFlag).Returns(groupNodeFlags.Value);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesProviderFactory.cs
@@ -10,13 +10,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IProjectPropertiesProvider>();
 
-            if (props != null)
+            if (props is not null)
             {
                 mock.Setup(t => t.GetProperties(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
                                 .Returns(props);
             }
 
-            if (commonProps != null)
+            if (commonProps is not null)
             {
                 mock.Setup(t => t.GetCommonProperties()).Returns(commonProps);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectRuleSnapshotFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectRuleSnapshotFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             mock.SetupGet(r => r.Properties)
                 .Returns(dictionary);
 
-            if (items != null)
+            if (items is not null)
             {
                 mock.SetupGet(c => c.Items).Returns(items);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectServiceFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.Setup(p => p.Services)
                    .Returns(services);
 
-            if (scope != null)
+            if (scope is not null)
             {
                 mock.Setup(p => p.LoadedUnconfiguredProjects)
                     .Returns(new[] { UnconfiguredProjectFactory.Create(scope: scope, configuredProject: configuredProject) });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             IImmutableDictionary<string, IProjectChangeDescription> projectChanges;
             ProjectConfiguration projectConfiguration;
 
-            if (CurrentState != null)
+            if (CurrentState is not null)
             {
                 currentState = CurrentState.Select(x => new KeyValuePair<string, IProjectRuleSnapshot>(x.Key, x.Value)).ToImmutableDictionary();
             }
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 currentState = ImmutableDictionary<string, IProjectRuleSnapshot>.Empty;
             }
 
-            if (ProjectChanges != null)
+            if (ProjectChanges is not null)
             {
                 projectChanges = ProjectChanges.Select(x => new KeyValuePair<string, IProjectChangeDescription>(x.Key, x.Value.ToActualModel())).ToImmutableDictionary();
             }
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 projectChanges = ImmutableDictionary<string, IProjectChangeDescription>.Empty;
             }
 
-            if (ProjectConfiguration != null)
+            if (ProjectConfiguration is not null)
             {
                 projectConfiguration = ProjectConfiguration.ToActualModel();
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceStateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectTreeServiceStateFactory.cs
@@ -18,13 +18,13 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IProjectTreeServiceState>();
 
-            if (treeAction != null)
+            if (treeAction is not null)
             {
                 mock.SetupGet<IProjectTree?>(s => s.Tree)
                     .Returns(treeAction);
             }
 
-            if (treeProviderAction != null)
+            if (treeProviderAction is not null)
             {
                 mock.SetupGet(s => s.TreeProvider)
                     .Returns(treeProviderAction);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyPagesCatalogFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyPagesCatalogFactory.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             property.As<IEvaluatedProperty>().Setup(p => p.GetEvaluatedValueAtEndAsync()).ReturnsAsync(value.ToString());
             property.As<IEvaluatedProperty>().Setup(p => p.GetEvaluatedValueAsync()).ReturnsAsync(value.ToString());
 
-            if (setValues != null)
+            if (setValues is not null)
             {
                 property.Setup(p => p.SetValueAsync(It.IsAny<object>()))
                         .Callback<object>(setValues.Add)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyPagesCatalogProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyPagesCatalogProviderFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 .Setup(o => o.GetCatalogAsync(It.IsAny<string>(), CancellationToken.None))
                 .Returns((string name, CancellationToken token) => Task.FromResult(catalogsByContext[name]));
 
-            if (memoryOnlyCatalog != null)
+            if (memoryOnlyCatalog is not null)
             {
                 catalogProvider
                     .Setup(o => o.GetMemoryOnlyCatalog(It.IsAny<string>()))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IRuleFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IRuleFactory.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var rule = new Mock<IRule>();
 
-            if (properties != null)
+            if (properties is not null)
             {
                 rule.Setup(o => o.GetProperty(It.IsAny<string>()))
                     .Returns((string propertyName) =>
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                     });
             }
 
-            if (schema != null)
+            if (schema is not null)
             {
                 rule.Setup(o => o.Schema)
                     .Returns(schema);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
@@ -10,23 +10,23 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IUnconfiguredProjectCommonServices>();
 
-            if (project != null)
+            if (project is not null)
                 mock.Setup(s => s.Project)
                     .Returns(project);
 
-            if (threadingService != null)
+            if (threadingService is not null)
                 mock.Setup(s => s.ThreadingService)
                     .Returns(threadingService);
 
-            if (configuredProject != null)
+            if (configuredProject is not null)
                 mock.Setup(s => s.ActiveConfiguredProject)
                     .Returns(configuredProject);
 
-            if (projectProperties != null)
+            if (projectProperties is not null)
                 mock.Setup(s => s.ActiveConfiguredProjectProperties)
                     .Returns(projectProperties);
 
-            if (projectAccessor != null)
+            if (projectAccessor is not null)
                 mock.Setup(s => s.ProjectAccessor)
                     .Returns(projectAccessor);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectServicesFactory.cs
@@ -8,25 +8,25 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IUnconfiguredProjectServices>();
 
-            if (asyncTaskService != null)
+            if (asyncTaskService is not null)
             {
                 mock.Setup(s => s.ProjectAsynchronousTasks)
                     .Returns(asyncTaskService);
             }
 
-            if (activeConfiguredProjectProvider != null)
+            if (activeConfiguredProjectProvider is not null)
             {
                 mock.Setup(s => s.ActiveConfiguredProjectProvider)
                     .Returns(activeConfiguredProjectProvider);
             }
 
-            if (projectConfigurationsService != null)
+            if (projectConfigurationsService is not null)
             {
                 mock.Setup(s => s.ProjectConfigurationsService)
                     .Returns(projectConfigurationsService);
             }
 
-            if (projectService != null)
+            if (projectService is not null)
             {
                 mock.Setup(s => s.ProjectService)
                     .Returns(projectService);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextMockFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextMockFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             context.SetupGet(c => c.ProjectFilePath)
                 .Returns(project.FullPath);
 
-            if (addDynamicFile != null)
+            if (addDynamicFile is not null)
             {
                 context.Setup(c => c.AddDynamicFile(It.IsAny<string>(), It.IsAny<IEnumerable<string>>()))
                     .Callback<string, IEnumerable<string>>((p1, p2) => addDynamicFile(p1));
@@ -45,13 +45,13 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             context.SetupGet(c => c.ProjectFilePath)
                 .Returns(project.FullPath);
 
-            if (addSourceFile != null)
+            if (addSourceFile is not null)
             {
                 context.Setup(c => c.AddSourceFile(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<IEnumerable<string>>(), It.IsAny<SourceCodeKind>()))
                     .Callback<string, bool, IEnumerable<string>, SourceCodeKind>((p1, p2, p3, p4) => addSourceFile(p1));
             }
 
-            if (removeSourceFile != null)
+            if (removeSourceFile is not null)
             {
                 context.Setup(c => c.RemoveSourceFile(It.IsAny<string>()))
                     .Callback(removeSourceFile);
@@ -67,13 +67,13 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
             context.SetupGet(c => c.ProjectFilePath)
                 .Returns(project.FullPath);
 
-            if (addMetadataReference != null)
+            if (addMetadataReference is not null)
             {
                 context.Setup(c => c.AddMetadataReference(It.IsAny<string>(), It.IsAny<MetadataReferenceProperties>()))
                     .Callback<string, MetadataReferenceProperties>((p1, p2) => addMetadataReference(p1));
             }
 
-            if (removeMetadataReference != null)
+            if (removeMetadataReference is not null)
             {
                 context.Setup(c => c.RemoveMetadataReference(It.IsAny<string>()))
                     .Callback(removeMetadataReference);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestDependencyModel.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestDependencyModel.cs
@@ -37,11 +37,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Id == dependency.Id
                    && ProviderType == dependency.ProviderType
                    && Flags == dependency.Flags
-                   && (Caption == null || Caption == dependency.Caption)
-                   && (OriginalItemSpec == null || OriginalItemSpec == dependency.OriginalItemSpec)
-                   && (Path == null || Path == dependency.FilePath)
-                   && (SchemaName == null || SchemaName == dependency.SchemaName)
-                   && (SchemaItemType == null || !Flags.Contains(DependencyTreeFlags.Dependency) || SchemaItemType == dependency.SchemaItemType)
+                   && (Caption is null || Caption == dependency.Caption)
+                   && (OriginalItemSpec is null || OriginalItemSpec == dependency.OriginalItemSpec)
+                   && (Path is null || Path == dependency.FilePath)
+                   && (SchemaName is null || SchemaName == dependency.SchemaName)
+                   && (SchemaItemType is null || !Flags.Contains(DependencyTreeFlags.Dependency) || SchemaItemType == dependency.SchemaItemType)
                    && Resolved == dependency.Resolved
                    && Implicit == dependency.Implicit
                    && Visible == dependency.Visible
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private static bool Equals(IImmutableDictionary<string, string> a, IImmutableDictionary<string, string> b)
         {
             // Allow b to have whatever if we didn't specify any properties
-            if (a == null || a.Count == 0)
+            if (a is null || a.Count == 0)
                 return true;
 
             return a.Count == b.Count &&

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestProjectTree.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/TestProjectTree.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public IProjectTree Remove(IProjectTree subtree)
         {
             var nodeToRemove = Children.FirstOrDefault(ReferenceEquals, subtree);
-            if (nodeToRemove != null)
+            if (nodeToRemove is not null)
             {
                 Children.Remove(nodeToRemove);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var service = IProjectServiceFactory.Create();
 
-            if (unconfiguredProjectServices == null)
+            if (unconfiguredProjectServices is null)
             {
                 var unconfiguredProjectServicesMock = new Mock<UnconfiguredProjectServices>();
 
@@ -93,7 +93,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             project.Setup(u => u.GetSuggestedConfiguredProjectAsync()).ReturnsAsync(configuredProject);
 
-            if (projectEncoding != null)
+            if (projectEncoding is not null)
             {
                 project.Setup(u => u.GetFileEncodingAsync()).ReturnsAsync(projectEncoding);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsProviderTests.cs
@@ -147,7 +147,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             var provider = new ActiveConfiguredProjectsProvider(services, project);
 
-            if (dimensionProviders != null)
+            if (dimensionProviders is not null)
             {
                 foreach (var dimensionProvider in dimensionProviders)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
@@ -567,7 +567,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
         private static void AssertDefaultOrEmpty(BaseProjectConfigurationDimensionProvider provider, IEnumerable<KeyValuePair<string, string>> result)
         {
-            if (provider.DimensionDefaultValue != null)
+            if (provider.DimensionDefaultValue is not null)
             {
                 Assert.Single(result);
                 Assert.Equal(provider.DimensionName, result.First().Key);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var data = new LaunchProfile(
                 name: null,
                 commandName: null,
-                otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugMachineProperty, value)));
+                otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugMachineProperty, value)));
 
             Assert.Equal(expected, data.RemoteDebugMachine());
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/FileItemServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/FileItemServicesTests.cs
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public void GetLogicalFolderNames_Returns(string basePath, string fullPath, string link, params string[] expected)
         {
             var metadata = ImmutableDictionary<string, string>.Empty;
-            if (link != null)
+            if (link is not null)
             {
                 metadata = metadata.SetItem(Compile.LinkProperty, link);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Func<ProjectId>? getActiveProjectId = null)
             : base(delegatedProvider: IProjectPropertiesProviderFactory.Create(defaultProperties ?? IProjectPropertiesFactory.MockWithProperty("").Object),
                   instanceProvider: instanceProvider ?? IProjectInstancePropertiesProviderFactory.Create(),
-                  interceptingValueProviders: interceptingProvider == null ?
+                  interceptingValueProviders: interceptingProvider is null ?
                     new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
                         () => IInterceptingPropertyValueProviderFactory.Create(),
                         IInterceptingPropertyValueProviderMetadataFactory.Create("TestPropertyName")) } :
@@ -278,7 +278,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("""[assembly: System.Reflection.AssemblyInformationalVersionAttribute("2016.2")]""", "Version", "2016.2", null)]
         internal async Task SourceFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
         {
-            var interceptingProvider = interceptingProviderType != null ?
+            var interceptingProvider = interceptingProviderType is not null ?
                 new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
                     valueFactory: () => (IInterceptingPropertyValueProvider)Activator.CreateInstance(interceptingProviderType),
                     metadata: IInterceptingPropertyValueProviderMetadataFactory.Create(propertyName)) :
@@ -352,7 +352,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("Version", null, "2016.2", "2016.2", null)]
         internal async Task ProjectFileProperties_WithInterception_SetEvaluatedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
         {
-            var interceptingProvider = interceptingProviderType != null ?
+            var interceptingProvider = interceptingProviderType is not null ?
                 new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
                     valueFactory: () => (IInterceptingPropertyValueProvider)Activator.CreateInstance(interceptingProviderType),
                     metadata: IInterceptingPropertyValueProviderMetadataFactory.Create(propertyName)) :

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/DependencyRuleTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
                     .Element(XName.Get(dataSourceElementName, MSBuildNamespace))
                     ?.Element(XName.Get("DataSource", MSBuildNamespace));
 
-                if (dataSource == null)
+                if (dataSource is null)
                 {
                     throw new Xunit.Sdk.XunitException($"Resolved dependency rule {ruleName} has visible, non-readonly property {property.Attribute("Name")} with no {dataSourceElementName} value.");
                 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ExportedRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ExportedRuleTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             MemberInfo member = typeof(RuleExporter).GetField(name);
 
-            Assert.True(member != null, $"Rule '{fullPath}' has not been exported by {nameof(RuleExporter)}. Export this rule from a member called {name}.");
+            Assert.True(member is not null, $"Rule '{fullPath}' has not been exported by {nameof(RuleExporter)}. Export this rule from a member called {name}.");
         }
 
         [Theory]
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         {
             var attribute = member.GetCustomAttribute<AppliesToAttribute>();
 
-            Assert.True(attribute != null, $"'{GetTypeQualifiedName(member)}' must be marked with [AppliesTo]");
+            Assert.True(attribute is not null, $"'{GetTypeQualifiedName(member)}' must be marked with [AppliesTo]");
         }
 
         [Theory]
@@ -59,10 +59,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             foreach (MemberInfo member in members)
             {
                 var attribute = member.GetCustomAttribute<AppliesToAttribute>();
-                if (attribute == null)
+                if (attribute is null)
                     continue; // Another test will catch this
 
-                if (appliesTo == null)
+                if (appliesTo is null)
                 {
                     appliesTo = attribute.AppliesTo;
                 }
@@ -108,7 +108,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             using Stream stream = assembly.GetManifestResourceStream(attribute.XamlResourceStreamName);
 
-            Assert.True(stream != null, $"The rule '{attribute.XamlResourceStreamName}' indicated by '{GetTypeQualifiedName(member)}' does not exist in assembly '{attribute.XamlResourceAssemblyName}'.");
+            Assert.True(stream is not null, $"The rule '{attribute.XamlResourceStreamName}' indicated by '{GetTypeQualifiedName(member)}' does not exist in assembly '{attribute.XamlResourceAssemblyName}'.");
         }
 
         private static string GetTypeQualifiedName(MemberInfo member)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/ItemRuleTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             {
                 var attribute = element.Attribute("ItemType");
 
-                if (attribute != null)
+                if (attribute is not null)
                 {
                     Assert.Equal(ruleName, attribute.Value);
                 }
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             foreach (XElement element in rule.Elements())
             {
                 var nameAttribute = element.Attribute("Name");
-                if (nameAttribute == null)
+                if (nameAttribute is null)
                 {
                     continue;
                 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             var sourceType = dataSource?.Attribute("SourceType");
             var msBuildTarget = dataSource?.Attribute("MSBuildTarget");
 
-            if (sourceType != null)
+            if (sourceType is not null)
             {
                 if (sourceType.Value == "TargetResults")
                 {
@@ -136,14 +136,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             var dataSource = root.XPathSelectElement(@"/msb:Rule/msb:Rule.DataSource/msb:DataSource", namespaceManager);
 
             var itemType = dataSource?.Attribute("ItemType");
-            if (itemType != null)
+            if (itemType is not null)
             {
                 foreach (var property in GetProperties(root))
                 {
                     var element = GetDataSource(property);
 
                     var propertyItemType = element?.Attribute("ItemType");
-                    if (propertyItemType != null)
+                    if (propertyItemType is not null)
                     {
                         Assert.Equal(itemType?.Value, propertyItemType.Value);
                     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/RuleServices.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/RuleServices.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             foreach (var member in GetAllExportedMembers())
             {
                 var attribute = member.GetCustomAttribute<ExportRuleAttribute>();
-                if (attribute != null)
+                if (attribute is not null)
                     yield return attribute.RuleName;
             }
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -686,7 +686,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
             IImmutableDictionary<string, string> projectTreeSettings = ImmutableStringDictionary<string>.EmptyOrdinal;
             IImmutableDictionary<string, IProjectRuleSnapshot> ruleSnapshots = IProjectRuleSnapshotsFactory.Create();
 
-            if (folderName != null)
+            if (folderName is not null)
                 ruleSnapshots = ruleSnapshots.Add(AppDesigner.SchemaName, AppDesigner.FolderNameProperty, folderName);
 
             if (contentOnlyVisibleInShowAllFiles != null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTestBase.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 var snapshots = ImmutableStringDictionary<IProjectRuleSnapshot>.EmptyOrdinal;
                 var changes = ImmutableStringDictionary<IProjectChangeDescription>.EmptyOrdinal;
 
-                if (snapshotBySchemaName != null)
+                if (snapshotBySchemaName is not null)
                 {
                     foreach ((string schemaName, IProjectRuleSnapshotModel model) in snapshotBySchemaName)
                     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 sourceSnapshot,
                 itemRemovedFromSourceSnapshot: itemRemovedFromSourceSnapshot);
 
-            if (lastItemsChangedAtUtc != null)
+            if (lastItemsChangedAtUtc is not null)
             {
                 configuredInput = configuredInput.WithLastItemsChangedAtUtc(lastItemsChangedAtUtc.Value);
             }
@@ -1990,7 +1990,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             writer.Assert();
 
-            if (telemetryReason != null)
+            if (telemetryReason is not null)
                 AssertTelemetryFailureEvent(telemetryReason, ignoreKinds);
             else
                 Assert.Empty(_telemetryEvents);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IActiveConfiguredProjectSubscriptionServiceFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             mock.SetupGet(s => s.ProjectRuleSource)
                 .Returns(IProjectValueDataSourceFactory.CreateInstance<IProjectSubscriptionUpdate>);
 
-            if (sourceItemsRuleSource != null)
+            if (sourceItemsRuleSource is not null)
             {
                 mock.SetupGet(s => s.SourceItemsRuleSource)
                     .Returns(() => sourceItemsRuleSource);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ISolutionBuildManagerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/ISolutionBuildManagerFactory.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             buildManager.Setup(b => b.QueryBuildManagerBusy())
                 .Returns(isBusy);
 
-            if (hierarchyToBuild != null)
+            if (hierarchyToBuild is not null)
             {
                 void onBuildStartedWithReturn(IVsHierarchy[] _, uint[] __, uint ___)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
@@ -19,35 +19,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                                                                Func<UnconfiguredProject>? unconfiguredProjectCreator = null)
         {
             var mock = new Mock<IUnconfiguredProjectVsServices>();
-            if (hierarchyCreator != null)
+            if (hierarchyCreator is not null)
             {
                 mock.SetupGet(h => h.VsHierarchy)
                     .Returns(hierarchyCreator);
             }
 
-            var threadingService = threadingServiceCreator == null ? IProjectThreadingServiceFactory.Create() : threadingServiceCreator();
+            var threadingService = threadingServiceCreator is null ? IProjectThreadingServiceFactory.Create() : threadingServiceCreator();
 
             mock.SetupGet(h => h.ThreadingService)
                 .Returns(threadingService);
 
-            if (projectCreator != null)
+            if (projectCreator is not null)
             {
                 mock.SetupGet(h => h.VsProject)
                     .Returns(projectCreator());
             }
 
-            if (configuredProjectCreator != null)
+            if (configuredProjectCreator is not null)
             {
                 mock.SetupGet(h => h.ActiveConfiguredProject)
                     .Returns(configuredProjectCreator);
             }
 
-            if (projectProperties != null)
+            if (projectProperties is not null)
             {
                 mock.SetupGet(h => h.ActiveConfiguredProjectProperties).Returns(projectProperties());
             }
 
-            if (unconfiguredProjectCreator != null)
+            if (unconfiguredProjectCreator is not null)
             {
                 mock.SetupGet(h => h.Project).Returns(unconfiguredProjectCreator());
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsUpgradeLoggerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsUpgradeLoggerFactory.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
 
         public override bool Equals(object obj)
         {
-            if (obj == null)
+            if (obj is null)
             {
                 return false;
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/Reference3Factory.cs
@@ -33,7 +33,7 @@ namespace VSLangProj80
                 .Returns(path);
 
             mock.SetupGet(r => r.Resolved)
-                .Returns(path != null);
+                .Returns(path is not null);
 
             mock.SetupGet(r => r.Type)
                 .Returns(type);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             contractsRequiringAppliesTo.Add(import.ImportDefinition.ContractName, contractTypes);
                         }
 
-                        if (null != import.ImportingSiteElementType)
+                        if (import.ImportingSiteElementType is not null)
                         {
                             contractTypes.Add(import.ImportingSiteElementType);
                         }
@@ -153,7 +153,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 var contractName = assemblyAttribute.ContractName;
                 var contractType = assemblyAttribute.ContractType;
 
-                if (contractName != null || contractType != null)
+                if (contractName is not null || contractType is not null)
                 {
                     AddContractMetadata(contracts, contractName ?? contractType!.FullName, assemblyAttribute.Scope, assemblyAttribute.Provider, assemblyAttribute.Cardinality);
                 }
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         private static bool IsAppliesToRequired(ImportDefinitionBinding import)
         {
             Type appliesToView = typeof(IAppliesToMetadataView);
-            return import.MetadataType != null && appliesToView.IsAssignableFrom(import.MetadataType);
+            return import.MetadataType is not null && appliesToView.IsAssignableFrom(import.MetadataType);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             foreach ((ImportDefinitionBinding import, IReadOnlyList<ExportDefinitionBinding> exports) in part.SatisfyingExports)
             {
                 var importingProperty = import.ImportingMember as PropertyInfo;
-                if (importingProperty == null)  // We don't verify ImportingConstructor, only check properties.
+                if (importingProperty is null)  // We don't verify ImportingConstructor, only check properties.
                     return;
 
                 Type memberType = importingProperty.PropertyType;
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
                 // Single import
                 ExportDefinitionBinding exportBinding = exports.SingleOrDefault();
-                if (exportBinding != null)
+                if (exportBinding is not null)
                 {
                     string? appliesTo = GetAppliesToMetadata(exportBinding.ExportDefinition);
                     if (!string.IsNullOrEmpty(appliesTo) && !ContainsExpression(appliesTo))
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                             foreach (ExportDefinition exportDefinition in part.Definition.ExportDefinitions.Select(p => p.Value))
                             {
                                 string? requiredAppliesTo = GetAppliesToMetadata(exportDefinition);
-                                if (requiredAppliesTo == null ||
+                                if (requiredAppliesTo is null ||
                                     !ContainsExpression(requiredAppliesTo))
                                 {
                                     Assert.Fail($"{part.Definition.Type.FullName}.{ importingProperty.Name} needs to check AppliesTo metadata of the imported component.");
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                     continue;
 
                 exportDefinition.Metadata.TryGetValue(nameof(AppliesToAttribute.AppliesTo), out object? metadata);
-                if (null != metadata)
+                if (metadata is not null)
                     appliesToMetadata.Add((string)metadata);
             }
 
@@ -164,7 +164,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 {
                     hasParameterlessConstructor = true;
                 }
-                else if (constructor.GetCustomAttribute<ImportingConstructorAttribute>() != null)
+                else if (constructor.GetCustomAttribute<ImportingConstructorAttribute>() is not null)
                 {
                     importingConstructors++;
                 }
@@ -198,7 +198,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 if (contractsRequiringMetadata.TryGetValue(exportDefinition.ContractName, out ISet<Type> contractTypes))
                 {
                     Type exportType;
-                    if (memberRef == null)
+                    if (memberRef is null)
                     {
                         exportType = definition.Type;
                     }
@@ -372,7 +372,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </summary>
         private static bool IsSubclassOfGenericType(Type genericType, Type type)
         {
-            while (type != null && type != typeof(object))
+            while (type is not null && type != typeof(object))
             {
                 Type currentType = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
                 if (genericType == currentType)
@@ -392,7 +392,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <returns>returns null if the metadata cannot be found.</returns>
         private static string? GetAppliesToMetadata(ExportDefinition exportDefinition)
         {
-            if (exportDefinition.Metadata.TryGetValue(nameof(AppliesToAttribute.AppliesTo), out object? appliesToMetadata) && null != appliesToMetadata)
+            if (exportDefinition.Metadata.TryGetValue(nameof(AppliesToAttribute.AppliesTo), out object? appliesToMetadata) && appliesToMetadata is not null)
             {
                 return (string)appliesToMetadata;
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProviderTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             _launchSettingsProviderMoq.Setup(x => x.ActiveProfile).Returns(() => _activeProfile);
             _launchSettingsProviderMoq.Setup(x => x.WaitForFirstSnapshot(It.IsAny<int>())).Returns(() =>
-                _activeProfile != null ?
+                _activeProfile is not null ?
                     Task.FromResult((ILaunchSettings?)new LaunchSettings(new List<ILaunchProfile> { _activeProfile }, null, _activeProfile.Name)) :
                     Task.FromResult((ILaunchSettings?)LaunchSettings.Empty));
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var activeProfile = new LaunchProfile("run", null, executablePath: ".\\test.exe");
             var targets = await debugger.QueryDebugTargetsAsync(0, activeProfile);
             Assert.Single(targets);
-            if (outdir == null || outdir == @"doesntExist\")
+            if (outdir is null || outdir == @"doesntExist\")
             {
                 Assert.Equal(@"c:\test\project\test.exe", targets[0].Executable);
                 Assert.Equal(@"c:\test\project", targets[0].CurrentDirectory);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/ReferenceCleanupServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/ReferenceCleanupServiceTests.cs
@@ -201,7 +201,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
                 item.As<IProjectItem>().Setup(c => c.Metadata.GetEvaluatedPropertyValueAsync(ProjectReference.TreatAsUsedProperty))
                     .ReturnsAsync(evaluatedValue);
 
-                if (s_item == null && item is Mock<IUnresolvedPackageReference> packageItem)
+                if (s_item is null && item is Mock<IUnresolvedPackageReference> packageItem)
                 {
                     s_item = packageItem;
                 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
@@ -296,7 +296,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             }
 
             // root namespace and project folder have changed if its the first time we've sent inputs
-            if (_lastIntermediateOutputPath == null)
+            if (_lastIntermediateOutputPath is null)
             {
                 ruleUpdate +=
                     """

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         private void SendDesignTimeInputs(DesignTimeInputs? inputs = null, string[]? changedFiles = null)
         {
             // Make everything full paths here, to allow for easier test authoring
-            if (inputs != null)
+            if (inputs is not null)
             {
                 inputs = new DesignTimeInputs(inputs.Inputs.Select(f => Path.Combine(_projectFolder, f)), inputs.SharedInputs.Select(f => Path.Combine(_projectFolder, f)));
             }
@@ -355,7 +355,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             }
 
             IEnumerable<DesignTimeInputFileChange> changes;
-            if (changedFiles != null)
+            if (changedFiles is not null)
             {
                 changes = changedFiles.Select(f => new DesignTimeInputFileChange(Path.Combine(_projectFolder, f), false));
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensionsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
             var result = item.TryFindTarget(out string? actualConfiguration);
 
-            Assert.Equal(actualConfiguration != null, result);
+            Assert.Equal(actualConfiguration is not null, result);
             Assert.Equal(expectedConfiguration, actualConfiguration);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
 
             var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create(fullPath: "X:\\Project\\"));
 
-            var metadata = rootedPath == null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
+            var metadata = rootedPath is null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
 
             var context = GetContext(itemName, itemType, isFolder, ProjectTreeFlags.ProjectRoot, metadata);
             var values = GetInitialValues();
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
 
             var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create(fullPath: "X:\\Project\\"));
 
-            var metadata = rootedPath == null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
+            var metadata = rootedPath is null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
 
             var context = GetContext(itemName, itemType, isFolder, ProjectTreeFlags.ProjectRoot, metadata);
             var values = GetInitialValues();
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             solutionTree.ForEach(item =>
             {
                 var rootedPath = item.rootedPath;
-                var metadata = rootedPath == null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
+                var metadata = rootedPath is null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
 
                 var context = GetContext(item.itemName, item.itemType, item.isFolder,
                     item.isUnderProjectRoot ? ProjectTreeFlags.ProjectRoot : ProjectTreeFlags.Empty, metadata);
@@ -202,7 +202,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create(fullPath: "X:\\Project\\"));
 
             bool isUnderProjectRoot = rootedPath?.Contains("Tables") != true;
-            var metadata = rootedPath == null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
+            var metadata = rootedPath is null ? null : new Dictionary<string, string> { { "FullPath", rootedPath } }.ToImmutableDictionary();
 
             var context = GetContext(itemName, itemType, isFolder,
                 isUnderProjectRoot ? ProjectTreeFlags.ProjectRoot : ProjectTreeFlags.Empty,
@@ -237,7 +237,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Order
             var provider = new TreeItemOrderPropertyProvider(orderedItems, UnconfiguredProjectFactory.Create(fullPath: "X:\\Project\\"));
 
             bool isUnderProjectRoot = rootedPath?.Contains("Tables") != true;
-            var metadata = rootedPath == null ? null : new Dictionary<string, string> { { "FullPath", rootedPath }, { "Link", linkPath ?? "" } }.ToImmutableDictionary();
+            var metadata = rootedPath is null ? null : new Dictionary<string, string> { { "FullPath", rootedPath }, { "Link", linkPath ?? "" } }.ToImmutableDictionary();
 
             var context = GetContext(itemName, itemType, isFolder,
                 isUnderProjectRoot ? ProjectTreeFlags.ProjectRoot : ProjectTreeFlags.Empty,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.Setup
 
             var ruleFilesByCulture = Directory.EnumerateFiles(rulesPath, "*", SearchOption.AllDirectories)
                 .Select(ParseRepoFile)
-                .Where(pair => pair.Culture != null)
+                .Where(pair => pair.Culture is not null)
                 .ToLookup(pair => pair.Culture, pair => pair.File);
 
             var setupCultures = setupFilesByCulture.Select(p => p.Key);
@@ -142,7 +142,7 @@ namespace Microsoft.VisualStudio.Setup
                 var fileMatch = _swrFilePattern.Match(line);
                 if (fileMatch.Success)
                 {
-                    if (folder == null)
+                    if (folder is null)
                         throw new FileFormatException("'file' entry appears before a 'folder' entry.");
                     var file = fileMatch.Groups["path"].Value;
                     yield return (folder, file);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.Telemetry
 
         private static VsTelemetryService CreateInstance(Action<TelemetryEvent>? action = null)
         {
-            if (action == null)
+            if (action is null)
                 return new VsTelemetryService();
 
             // Override PostEventToSession to avoid actually sending to telemetry


### PR DESCRIPTION
Seems like we prefer `is null` over `== null` during PR reviews.

Here's an analyzer that does that for us.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8345)