### PR TITLE
Don't activate the language service in command line mode

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHostEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHostEnvironment.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices;
+
+[Export(typeof(ILanguageServiceHostEnvironment))]
+internal sealed class LanguageServiceHostEnvironment : ILanguageServiceHostEnvironment
+{
+    private readonly AsyncLazy<bool> _isEnabled;
+
+    [ImportingConstructor]
+    public LanguageServiceHostEnvironment(IVsUIService<SVsShell, IVsShell> vsShell, JoinableTaskContext joinableTaskContext)
+    {
+        _isEnabled = new(
+            async () =>
+            {
+                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
+                // If VS is running in command line mode (e.g. "devenv.exe /build my.sln"),
+                // the language service host is not enabled.
+
+                return ErrorHandler.Succeeded(vsShell.Value.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object resultObj))
+                    && resultObj is bool result
+                    && !result; // negate: enabled when not in command line mode
+            },
+            joinableTaskContext.Factory);
+    }
+
+    public Task<bool> IsEnabledAsync(CancellationToken cancellationToken) => _isEnabled.GetValueAsync(cancellationToken);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHostEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ILanguageServiceHostEnvironment.cs
@@ -1,0 +1,18 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+
+[ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
+internal interface ILanguageServiceHostEnvironment
+{
+    /// <summary>
+    /// Gets whether the language service host should be enabled in this environment.
+    /// </summary>
+    /// <remarks>
+    /// For example, within VS, the language service should not be initialised when running
+    /// in command line mode.
+    /// </remarks>
+    Task<bool> IsEnabledAsync(CancellationToken cancellationToken);
+}


### PR DESCRIPTION
Fixes #3832.

When VS is running in command line mode (i.e. `devenv.exe /build`) we don't need to fire up the language service.