### PR TITLE
Ignore intermittent 406 response on markdown link

### DIFF
--- a/.github/workflows/markdown-link-check-config.json
+++ b/.github/workflows/markdown-link-check-config.json
@@ -1,20 +1,11 @@
 {
   "ignorePatterns": [
-    {
-      "pattern": "^https:\/\/.*\\.visualstudio\\.com"
-    },
-    {
-      "pattern": "^https:\/\/dev\\.azure\\.com"
-    },
-    {
-      "pattern": "^https:\/\/aka\\.ms"
-    },
-    {
-      "pattern": ".*❓.*"
-    },
-    {
-      "pattern": "^https:\/\/www\\.microsoft\\.com"
-    }
+    { "pattern": "^https:\/\/.*\\.visualstudio\\.com" },
+    { "pattern": "^https:\/\/dev\\.azure\\.com" },
+    { "pattern": "^https:\/\/aka\\.ms" },
+    { "pattern": ".*❓.*" },
+    { "pattern": "^https:\/\/www\\.microsoft\\.com" },
+    { "pattern": "^*GitHubCreateMergePRs\/config\\.xml" }
   ],
   "replacementPatterns": [
     {


### PR DESCRIPTION
The https://github.com/dotnet/roslyn-tools/blob/main/src/GitHubCreateMergePRs/config.xml link from [branch-checklist.md](https://github.com/dotnet/project-system/blob/main/.github/ISSUE_TEMPLATE/branch-checklist.md) intermittently is getting a 406 response. We'll just ignore it. Also reduced whitespace to make reading the patterns easier.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8349)