### PR TITLE
[17.4] Fix launch profile JSON parsing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -306,7 +306,7 @@ internal static class LaunchSettingsJsonEncoding
                 {
                     JsonToken.Boolean => (bool)reader.Value!,
                     JsonToken.Integer => checked((int)(long)reader.Value!),
-                    JsonToken.StartObject => (jsonSerializer ??= JsonSerializer.CreateDefault()).Deserialize<Dictionary<string, string>>(reader),
+                    JsonToken.StartObject => (jsonSerializer ??= JsonSerializer.CreateDefault()).Deserialize<Dictionary<string, object>>(reader),
                     JsonToken.String => (string)reader.Value!,
                     _ => null
                 };

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsJsonEncodingTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsJsonEncodingTests.cs
@@ -51,6 +51,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     "ASPNET_ENVIRONMENT": "Development",
                     "ASPNET_APPLICATIONBASE": "c:\\Users\\billhie\\Documents\\projects\\WebApplication8\\src\\WebApplication8"
                   }
+                },
+                "Docker Compose": {
+                  "commandName": "DockerCompose",
+                  "commandVersion": "1.0",
+                  "composeProfile": {
+                    "includes": [
+                      "web1"
+                    ]
+                  }
                 }
               },
               "string": "hello",
@@ -66,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var (profiles, globalSettings) = LaunchSettingsJsonEncoding.FromJson(new StringReader(json), _providers);
 
-            Assert.Equal(4, profiles.Length);
+            Assert.Equal(5, profiles.Length);
 
             var profile = profiles[0];
             Assert.Equal("IIS Express", profile.Name);
@@ -110,6 +119,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(2, profile.EnvironmentVariables.Length);
             Assert.Equal(("ASPNET_ENVIRONMENT", "Development"), profile.EnvironmentVariables[0]);
             Assert.Equal(("ASPNET_APPLICATIONBASE", @"c:\Users\billhie\Documents\projects\WebApplication8\src\WebApplication8"), profile.EnvironmentVariables[1]);
+            Assert.False(profile.IsInMemoryObject());
+
+            profile = profiles[4];
+            Assert.Equal("Docker Compose", profile.Name);
+            Assert.Equal("DockerCompose", profile.CommandName);
+            Assert.Null(profile.WorkingDirectory);
+            Assert.Null(profile.ExecutablePath);
+            Assert.False(profile.LaunchBrowser);
+            Assert.Null(profile.LaunchUrl);
+            Assert.Empty(profile.EnvironmentVariables);
+            Assert.Equal(2, profile.OtherSettings.Length);
+            Assert.Equal("commandVersion", profile.OtherSettings[0].Key);
+            Assert.Equal("1.0", profile.OtherSettings[0].Value);
+            Assert.Equal("composeProfile", profile.OtherSettings[1].Key);
+            var composeProfiles = Assert.IsType<Dictionary<string, object>>(profile.OtherSettings[1].Value);
+            var includes = Assert.IsType<JArray>(composeProfiles["includes"]);
+            Assert.Single(includes);
+            Assert.Equal("web1", includes[0]);
             Assert.False(profile.IsInMemoryObject());
 
             Assert.Equal(5, globalSettings.Length);


### PR DESCRIPTION
Fixes #8360

Other settings do not always need to have string values. Docker Compose projects use arrays here. This used to work, and was broken during a rewrite of the JSON parsing code.

This commit fixes the issue and extends our test coverage to ensure it doesn't regress again in future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8365)