### PR TITLE
Don't fail incremental build validation when disabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -122,11 +122,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return log.Fail("CriticalTasks", nameof(Resources.FUTD_CriticalBuildTasksRunning));
             }
 
-            if (state.IsDisabled)
-            {
-                return log.Fail("Disabled", nameof(Resources.FUTD_DisableFastUpToDateCheckTrue));
-            }
-
             if (validateFirstRun && lastSuccessfulBuildStartTimeUtc is null)
             {
                 // We haven't observed a successful built yet. Therefore we don't know whether the set
@@ -545,7 +540,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (log.Level >= LogLevel.Verbose)
                 {
                     log.Indent++;
-                   
+
                     foreach (string path in items)
                     {
                         string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
@@ -896,6 +891,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             logger.Indent++;
                         }
 
+                        if (implicitState.IsDisabled)
+                        {
+                            if (isValidationRun)
+                            {
+                                // We don't run validation if the FUTDC is disabled. So pretend we're up to date.
+                                return (true, checkedConfigurations);
+                            }
+                            else
+                            {
+                                logger.Fail("Disabled", nameof(Resources.FUTD_DisableFastUpToDateCheckTrue));
+                                return (false, checkedConfigurations);
+                            }
+                        }
+
                         string? path = _configuredProject.UnconfiguredProject.FullPath;
 
                         DateTime? lastSuccessfulBuildStartTimeUtc = path is null
@@ -913,7 +922,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         {
                             return (false, checkedConfigurations);
                         }
-                        
+
                         if (logConfigurations)
                         {
                             logger.Indent--;


### PR DESCRIPTION
Fixes #8342

If a project has disabled the fast up-to-date check, we should not be validating the correctness of its incremental build.

## Before

> WARNING: Potential build performance issue in 'Foo.csproj'. The project does not appear up-to-date after a successful build: The 'DisableFastUpToDateCheck' property is 'true', not up-to-date. See https://aka.ms/incremental-build-failure.

## After

```
Build started...
1>FastUpToDate: The 'DisableFastUpToDateCheck' property is 'true', not up-to-date. (NoTargetsProject)
1>FastUpToDate: Up-to-date check completed in 0.2 ms (NoTargetsProject)
1>------ Build started: Project: NoTargetsProject, Configuration: Debug Any CPU ------
========== Build: 1 succeeded, 0 failed, 0 up-to-date, 0 skipped ==========
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8377)