### PR TITLE
Removing the unsafe code from the stable hash algorithm.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -15,7 +15,6 @@
     <Summary>Microsoft VisualStudio Managed Project System</Summary>
     <PackageTags>Roslyn Managed Project System VisualStudio</PackageTags>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemHashing.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.ItemHashing.cs
@@ -46,28 +46,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </remarks>
         internal static int GetStableHashCode(string str)
         {
-            unsafe
+            int hash1 = 5381;
+            int hash2 = hash1;
+
+            int i = 0;
+            while (i < str.Length)
             {
-                fixed (char* src = str)
-                {
-                    int hash1 = 5381;
-                    int hash2 = hash1;
+                char c = str[i];
 
-                    int c;
-                    char* s = src;
-                    while ((c = s[0]) != 0)
-                    {
-                        hash1 = ((hash1 << 5) + hash1) ^ c;
-                        c = s[1];
-                        if (c == 0)
-                            break;
-                        hash2 = ((hash2 << 5) + hash2) ^ c;
-                        s += 2;
-                    }
+                hash1 = ((hash1 << 5) + hash1) ^ c;
 
-                    return hash1 + (hash2 * 1566083941);
-                }
+                i++;
+                if (i == str.Length)
+                    break;
+
+                c = str[i];
+                hash2 = ((hash2 << 5) + hash2) ^ c;
+
+                i++;
             }
+
+            return hash1 + (hash2 * 1566083941);
         }
     }
 }


### PR DESCRIPTION
Current implementation of `GetStableHashCode()` is broken for Linux or Mac (depends on UTF-8 strings) while the CLR may have chosen to stick with Utf16.

Removing the unsafe codes removes the dependency upon the internal representation of the string in memory.

This is to make it work correctly on any platform.

-----------------------------
Benchmark

|                   Method |     Mean |     Error |    StdDev |
|------------------------- |---------:|----------:|----------:|
| GetStableHashCodeUnsafe | 7.068 ns | 0.1463 ns | 0.1796 ns |
| GetStableHashCodeSafe | 9.247 ns | 0.1851 ns | 0.1641 ns |
| CalculateStringGetHashCode | 6.655 ns | 0.1581 ns | 0.2110 ns |
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8379)