### PR TITLE
add descriptions to BuildPropertyPage.VisualBasic.xaml BoolProperties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -362,13 +362,13 @@
   <BoolProperty Name="RemoveIntegerChecks"
                 DisplayName="Remove integer overflow checks"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196163"
-                Description="Select this check box to remove integer overflow checking."
+                Description="Remove integer overflow checking."
                 Category="Advanced" />
 
   <BoolProperty Name="Optimize"
                 DisplayName="Enable optimizations"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196163"
-                Description="Select this check box to enable compiler optimizations."
+                Description="Enable compiler optimizations."
                 Category="Advanced" />
 
   <!-- TODO: Validation -->
@@ -403,13 +403,13 @@
   <BoolProperty Name="DefineDebug"
                 DisplayName="Define DEBUG constant"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196264"
-                Description="Whether to set a DEBUG constant."
+                Description="Specify DEBUG as a compilation constant."
                 Category="Advanced"/>
 
   <BoolProperty Name="DefineTrace"
                 DisplayName="Define TRACE constant"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196264"
-                Description="Whether to set a TRACE constant."
+                Description="Specify TRACE as a compilation constant."
                 Category="Advanced"/>
 
   <StringProperty Name="DefineConstants"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -362,11 +362,13 @@
   <BoolProperty Name="RemoveIntegerChecks"
                 DisplayName="Remove integer overflow checks"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196163"
+                Description="Select this check box to remove integer overflow checking."
                 Category="Advanced" />
 
   <BoolProperty Name="Optimize"
                 DisplayName="Enable optimizations"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196163"
+                Description="Select this check box to enable compiler optimizations."
                 Category="Advanced" />
 
   <!-- TODO: Validation -->
@@ -401,11 +403,13 @@
   <BoolProperty Name="DefineDebug"
                 DisplayName="Define DEBUG constant"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196264"
+                Description="Whether to set a DEBUG constant."
                 Category="Advanced"/>
 
   <BoolProperty Name="DefineTrace"
                 DisplayName="Define TRACE constant"
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2196264"
+                Description="Whether to set a TRACE constant."
                 Category="Advanced"/>
 
   <StringProperty Name="DefineConstants"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Definovat konstantu DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Generovat soubor dokumentace XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Zaregistrovat pro zprostředkovatele komunikace s objekty COM</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">DEBUG-Konstante definieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">XML-Dokumentationsdatei generieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Für COM-Interop registrieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Definir constante DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Generar archivo de documentación XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Registrarse para interoperabilidad COM</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Définir une constante DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Générer un fichier de documentation XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">S’inscrire à COM Interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Definire la costante DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Genera un file di documentazione XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Eseguire la registrazione per l'interoperabilità COM</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">DEBUG 定数の定義</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">XML ドキュメント ファイルを生成する</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">COM 相互運用機能の登録</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">DEBUG 상수 정의</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">XML 문서 파일 생성</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">COM interop 등록</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Zdefiniuj stałą DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Generuj plik dokumentacji XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Rejestruj w usłudze międzyoperacyjnej modelu COM</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Definir constante DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Gerar arquivo de documentação XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Registre-se para interoperabilidade COM</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">Определить константу DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">Создать файл документации XML</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">Зарегистрировать для COM-взаимодействия</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">DEBUG sabitini tanımla</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">XML belge dosyası oluştur</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">COM ile birlikte çalışma için kaydolun</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">定义 DEBUG 常量</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">生成 XML 文档文件</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">注册 COM 互操作</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
       <trans-unit id="BoolProperty|DefineDebug|Description">
-        <source>Whether to set a DEBUG constant.</source>
-        <target state="new">Whether to set a DEBUG constant.</target>
+        <source>Specify DEBUG as a compilation constant.</source>
+        <target state="new">Specify DEBUG as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
@@ -13,8 +13,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|Description">
-        <source>Whether to set a TRACE constant.</source>
-        <target state="new">Whether to set a TRACE constant.</target>
+        <source>Specify TRACE as a compilation constant.</source>
+        <target state="new">Specify TRACE as a compilation constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
-        <source>Select this check box to enable compiler optimizations.</source>
-        <target state="new">Select this check box to enable compiler optimizations.</target>
+        <source>Enable compiler optimizations.</source>
+        <target state="new">Enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -63,8 +63,8 @@
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
-        <source>Select this check box to remove integer overflow checking.</source>
-        <target state="new">Select this check box to remove integer overflow checking.</target>
+        <source>Remove integer overflow checking.</source>
+        <target state="new">Remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -2,9 +2,19 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../BuildPropertyPage.VisualBasic.xaml">
     <body>
+      <trans-unit id="BoolProperty|DefineDebug|Description">
+        <source>Whether to set a DEBUG constant.</source>
+        <target state="new">Whether to set a DEBUG constant.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|DefineDebug|DisplayName">
         <source>Define DEBUG constant</source>
         <target state="translated">定義 DEBUG 常數</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|DefineTrace|Description">
+        <source>Whether to set a TRACE constant.</source>
+        <target state="new">Whether to set a TRACE constant.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|DefineTrace|DisplayName">
@@ -20,6 +30,11 @@
       <trans-unit id="BoolProperty|GenerateDocumentationFile|DisplayName">
         <source>Generate XML documentation file</source>
         <target state="translated">產生 XML 文件檔案</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|Optimize|Description">
+        <source>Select this check box to enable compiler optimizations.</source>
+        <target state="new">Select this check box to enable compiler optimizations.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|Optimize|DisplayName">
@@ -45,6 +60,11 @@
       <trans-unit id="BoolProperty|RegisterForComInterop|DisplayName">
         <source>Register for COM interop</source>
         <target state="translated">註冊 COM Interop</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|RemoveIntegerChecks|Description">
+        <source>Select this check box to remove integer overflow checking.</source>
+        <target state="new">Select this check box to remove integer overflow checking.</target>
         <note />
       </trans-unit>
       <trans-unit id="BoolProperty|RemoveIntegerChecks|DisplayName">


### PR DESCRIPTION
Fixes #8244 😄 we just forgot to put descriptions for these properties, so when there is no variance, no description can be shown (leading to no checkbox context)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8388)