### PR TITLE
add "My" namespace to generated settings type

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -144,7 +144,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 '   appropriate code.
                 '
                 Dim projectRootNamespace As String = String.Empty
-
+                If isVB Then
+                    projectRootNamespace = GetProjectRootNamespace()
+                End If
+                
                 ' then get the CodeCompileUnit for this .settings file
                 '
                 Dim generatedClass As CodeTypeDeclaration = Nothing
@@ -253,7 +256,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             Dim ns as CodeNamespace
             
             If IsVb Then
-                ns = New CodeNamespace()
+                ns = New CodeNamespace(MyNamespaceName)
             Else
                 ns = New CodeNamespace(DesignerFramework.DesignUtil.GenerateValidLanguageIndependentNamespace(DefaultNamespace))
             End If
@@ -578,10 +581,14 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="defaultNamespace">namespace into which we are generating (may be String.Empty)</param>
         ''' <param name="typeName">the type of the settings-class we are generating</param>
-        Private Shared Function GetFullTypeName(defaultNamespace As String, typeName As String) As String
+        Private Shared Function GetFullTypeName(projectRootNamespace As String, defaultNamespace As String, typeName As String) As String
 
             Dim fullTypeName As String = String.Empty
 
+            If projectRootNamespace <> "" Then
+                fullTypeName = projectRootNamespace & "."
+            End If
+            
             If defaultNamespace <> "" Then
                 fullTypeName &= defaultNamespace & "."
             End If
@@ -665,7 +672,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 .HasSet = False
             }
 
-            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(defaultNamespace, GeneratedType.Name)) With {
+            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name)) With {
                 .Options = CodeTypeReferenceOptions.GlobalReference
             }
             SettingProperty.Type = fullTypeReference


### PR DESCRIPTION
To fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1589004?src=WorkItemMention&src-action=artifact_link, we need to add "My" namespace to the MySettings class. 
![image](https://user-images.githubusercontent.com/20359921/183784237-dc0a9976-e661-442b-8fdd-a644473fe461.png)

This works for .net framework 4.8 VB, as well as .net core VB and .net core C#, but before approving it, another pair of eyes on the generated file would be nice


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8391)