### PR TITLE
Use nuget.config instead of RestoreSources

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 # Set these files to XML (coloring) in PRs
 *.vsmanproj linguist-language=XML
 *.swixproj linguist-language=XML
+*.config linguist-language=XML
 
 ###############################################################################
 # Set default behavior for command prompt diff.

--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -1,40 +1,6 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Project>
 
-  <PropertyGroup>
-    <RestoreSources>
-      $(RestoreSources);
-      <!-- CPS components including: Microsoft.VisualStudio.ProjectSystem -->
-      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json;
-      <!-- Microsoft.VisualStudio components -->
-      https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json;
-      <!--
-        Various packages including:
-        Microsoft.DiaSymReader.Pdb2Pdb
-        Microsoft.CodeAnalysis
-        Microsoft.CodeAnalysis.Features
-        NuGet.VisualStudio
-      -->
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json;
-      <!--
-        Various packages including:
-        xunit
-        xunit.assert
-        xunit.extensibility.core
-        xunit.extensibility.execution
-        XliffTasks
-        Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild
-       -->
-      https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json;
-      <!--
-        Public components including:
-        Nerdbank.GitVersioning
-        Codecov
-      -->
-      https://api.nuget.org/v3/index.json;
-    </RestoreSources>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Infrastructure -->
     <PackageReference Update="MicroBuild.Core.Sentinel"                                               Version="1.0.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,42 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information. -->
+
+<!-- Reference documentation: https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file -->
+<!-- TODO: Migrate to Central Feed Services (CFS) when public feeds with upstream sources are available. -->
+<!-- For details: https://eng.ms/docs/cloud-ai-platform/developer-services/one-engineering-system-1es/1es-docs/secure-supply-chain/project-artemis/central-feed-services-cfs -->
+<configuration>
+  <packageSources>
+    <clear />
+    <!-- CPS components including: Microsoft.VisualStudio.ProjectSystem -->
+    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
+    <!-- Microsoft.VisualStudio components -->
+    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <!--
+      Various packages including:
+        Microsoft.DiaSymReader.Pdb2Pdb
+        Microsoft.CodeAnalysis
+        Microsoft.CodeAnalysis.Features
+        NuGet.VisualStudio
+    -->
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <!--
+      Various packages including:
+        xunit
+        xunit.assert
+        xunit.extensibility.core
+        xunit.extensibility.execution
+        XliffTasks
+        Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild
+    -->
+    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
+    <!--
+      Public components including:
+        Nerdbank.GitVersioning
+        Codecov
+    -->
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <!-- Clear the machine-defined disabled package sources, which may include one of our package sources defined above. -->
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
### Description
This is part of an effort for [Central Feed Services (CFS)](https://eng.ms/docs/cloud-ai-platform/developer-services/one-engineering-system-1es/1es-docs/secure-supply-chain/project-artemis/central-feed-services-cfs). The tooling they make for validating feeds being used in a repo rely on a `nuget.config` file at the root. I've moved our feeds from being declared in `RestoreSources` in Packages.targets to a nuget.config at the root. Currently, public feeds in Azure DevOps do not support upstream sources, so this won't be consolidated to a single feed yet.

### Official Build
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6542168&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8395)