### PR TITLE
Enable HighDpiMode property in the Project Properties UI.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -33,19 +33,19 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
         ' Constants for properties to be generated.
         Private Const MyNamespaceName As String = "My"
-        Private Const _mainFormFieldName As String = "MainForm"
-        Private Const _singleInstanceFieldName As String = "IsSingleInstance"
-        Private Const _shutdownModeFieldName As String = "ShutDownStyle"
-        Private Const _enableVisualStylesFieldName As String = "EnableVisualStyles"
-        Private Const _saveMySettingsOnExitFieldName As String = "SaveMySettingsOnExit"
-        Private Const _splashScreenFieldName As String = "SplashScreen"
-        Private Const _highDpiModeFieldName As String = "HighDpiMode"
+        Private Const MainFormFieldName As String = "MainForm"
+        Private Const SingleInstanceFieldName As String = "IsSingleInstance"
+        Private Const ShutdownModeFieldName As String = "ShutDownStyle"
+        Private Const EnableVisualStylesFieldName As String = "EnableVisualStyles"
+        Private Const SaveMySettingsOnExitFieldName As String = "SaveMySettingsOnExit"
+        Private Const SplashScreenFieldName As String = "SplashScreen"
+        Private Const HighDpiModeFieldName As String = "HighDpiMode"
 
-        Private Const _highDpiMode_DpiUnaware = "DpiUnaware"
-        Private Const _highDpiMode_SystemAware = "SystemAware"
-        Private Const _highDpiMode_PerMonitor = "PerMonitor"
-        Private Const _highDpiMode_PerMonitorV2 = "PerMonitorV2"
-        Private Const _highDpiMode_DpiUnawareGdiScaled = "DpiUnawareGdiScaled"
+        Private Const HighDpiMode_DpiUnaware = "DpiUnaware"
+        Private Const HighDpiMode_SystemAware = "SystemAware"
+        Private Const HighDpiMode_PerMonitor = "PerMonitor"
+        Private Const HighDpiMode_PerMonitorV2 = "PerMonitorV2"
+        Private Const HighDpiMode_DpiUnawareGdiScaled = "DpiUnawareGdiScaled"
 
         Friend Const SingleFileGeneratorName As String = "MyApplicationCodeGenerator"
 
@@ -213,17 +213,17 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 '    Me.EnableVisualStyles = <True/False>
                 '    Me.SaveMySettingsOnExit = <True/False>                
                 '
-                AddFieldPrimitiveAssignment(Constructor, _singleInstanceFieldName, MyApplication.SingleInstance)
-                AddFieldPrimitiveAssignment(Constructor, _enableVisualStylesFieldName, MyApplication.EnableVisualStyles)
-                AddFieldPrimitiveAssignment(Constructor, _saveMySettingsOnExitFieldName, MyApplication.SaveMySettingsOnExit)
+                AddFieldPrimitiveAssignment(Constructor, SingleInstanceFieldName, MyApplication.SingleInstance)
+                AddFieldPrimitiveAssignment(Constructor, EnableVisualStylesFieldName, MyApplication.EnableVisualStyles)
+                AddFieldPrimitiveAssignment(Constructor, SaveMySettingsOnExitFieldName, MyApplication.SaveMySettingsOnExit)
 
                 '    Me.ShutDownStyle = ApplicationServices.ShutdownMode.xxx
                 Dim EnumType As Type
                 EnumType = GetType(ApplicationServices.ShutdownMode)
                 If MyApplication.ShutdownMode = ApplicationServices.ShutdownMode.AfterAllFormsClose Then
-                    AddFieldAssignment(Constructor, _shutdownModeFieldName, EnumType, "AfterAllFormsClose")
+                    AddFieldAssignment(Constructor, ShutdownModeFieldName, EnumType, "AfterAllFormsClose")
                 ElseIf MyApplication.ShutdownMode = ApplicationServices.ShutdownMode.AfterMainFormCloses Then
-                    AddFieldAssignment(Constructor, _shutdownModeFieldName, EnumType, "AfterMainFormCloses")
+                    AddFieldAssignment(Constructor, ShutdownModeFieldName, EnumType, "AfterMainFormCloses")
                 Else
                     Debug.Fail("Unexpected MyApplication.ShutdownMode")
                 End If
@@ -232,23 +232,23 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 Dim HighDpiValue As String
                 Select Case MyApplication.HighDpiMode
                     Case 0
-                        HighDpiValue = _highDpiMode_DpiUnaware
+                        HighDpiValue = HighDpiMode_DpiUnaware
                     Case 1
-                        HighDpiValue = _highDpiMode_SystemAware
+                        HighDpiValue = HighDpiMode_SystemAware
                     Case 2
-                        HighDpiValue = _highDpiMode_PerMonitor
+                        HighDpiValue = HighDpiMode_PerMonitor
                     Case 3
-                        HighDpiValue = _highDpiMode_PerMonitorV2
+                        HighDpiValue = HighDpiMode_PerMonitorV2
                     Case 4
-                        HighDpiValue = _highDpiMode_DpiUnawareGdiScaled
+                        HighDpiValue = HighDpiMode_DpiUnawareGdiScaled
                     Case Else
-                        HighDpiValue = ""
+                        HighDpiValue = String.Empty
                 End Select
-                AddFieldAssignment(Constructor, _highDpiModeFieldName, _highDpiModeFieldName, HighDpiValue)
+                AddFieldAssignment(Constructor, HighDpiModeFieldName, HighDpiModeFieldName, HighDpiValue)
 
                 GeneratedType.Members.Add(Constructor)
 
-                If MyApplication.MainFormNoRootNS <> "" Then
+                If MyApplication.MainFormNoRootNS <> String.Empty Then
                     'Create OnCreateMainForm override
                     '
                     '  GENERATED CODE:
@@ -289,12 +289,12 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                             .Name = "OnCreateMainForm"
                         }
                         AddAttribute(OnCreateMainForm, DebuggerStepThroughAttribute, True)
-                        AddDefaultFormAssignment(OnCreateMainForm, _mainFormFieldName, ProjectRootNamespace, MyApplication.MainFormNoRootNS)
+                        AddDefaultFormAssignment(OnCreateMainForm, MainFormFieldName, ProjectRootNamespace, MyApplication.MainFormNoRootNS)
                         GeneratedType.Members.Add(OnCreateMainForm)
                     End If
                 End If
 
-                If MyApplication.SplashScreenNoRootNS <> "" Then
+                If MyApplication.SplashScreenNoRootNS <> String.Empty Then
                     'Create OnCreateSplashScreen override
                     '
                     '  GENERATED CODE:
@@ -322,7 +322,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                             .Name = "OnCreateSplashScreen"
                         }
                         AddAttribute(OnCreateSplashScreen, DebuggerStepThroughAttribute, True)
-                        AddDefaultFormAssignment(OnCreateSplashScreen, _splashScreenFieldName, ProjectRootNamespace, MyApplication.SplashScreenNoRootNS)
+                        AddDefaultFormAssignment(OnCreateSplashScreen, SplashScreenFieldName, ProjectRootNamespace, MyApplication.SplashScreenNoRootNS)
                         GeneratedType.Members.Add(OnCreateSplashScreen)
                     End If
                 End If
@@ -395,8 +395,8 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
         ' Overload of AddFieldAssignment to accept a String instead of a Type for EnumType '
         ' Background: For the case of HighDpiMode, the actual Type is only available in the Designer OOP server-side.
-        ' So to use types, we would need to generate this also in the server-side.
-        ' We don 't think it's necessary though, and consider it is too much of an effort,
+        ' So, to use types, we would need to generate the whole code also server-side.
+        ' We don't think it's necessary though, and consider it is too much of an effort,
         ' so we decided to use a String for the type name client side.
         Private Shared Sub AddFieldAssignment(Method As CodeMemberMethod, FieldName As String, EnumType As String, EnumFieldName As String)
             Dim Statement As CodeAssignStatement
@@ -426,7 +426,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             '
             Debug.Assert(FieldName IsNot Nothing)
             If FormNameWithoutRootNamespace Is Nothing Then
-                FormNameWithoutRootNamespace = ""
+                FormNameWithoutRootNamespace = String.Empty
             End If
 
             If RootNamespace Is Nothing Then
@@ -443,7 +443,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Dim Hierarchy As IVsHierarchy = DirectCast(GetService(GetType(IVsHierarchy)), IVsHierarchy)
             Debug.Assert(Hierarchy IsNot Nothing, "Failed to get a Hierarchy item for item to generate code from")
             Dim data As MyApplicationData = Nothing
-            If InputString <> "" Then
+            If InputString <> String.Empty Then
                 ' We actually have some contents to deserialize.... 
                 Dim MyApplicationReader As New StringReader(InputString)
                 data = MyApplicationSerializer.Deserialize(MyApplicationReader)

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
@@ -1,4 +1,4 @@
-' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Namespace Microsoft.VisualStudio.Editors.MyApplication
 
@@ -23,6 +23,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _authenticationMode As Integer
         Private _splashScreenNoRootNS As String 'Splash screen to use (without the root namespace)
         Private _saveMySettingsOnExit As Boolean 'Whether to save My.Settings on shutdown
+        Private _highDpiMode As Integer
 
         Private _dirty As Boolean
 
@@ -111,6 +112,16 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Get
             Set
                 _saveMySettingsOnExit = value
+                IsDirty = True
+            End Set
+        End Property
+
+        Public Property HighDpiMode As Integer
+            Get
+                Return _highDpiMode
+            End Get
+            Set
+                _highDpiMode = Value
                 IsDirty = True
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
@@ -35,6 +35,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             WriteElementStringRaw("AuthenticationMode", "", Xml.XmlConvert.ToString(CType(o.AuthenticationMode, Integer)))
             WriteElementString("SplashScreen", "", o.SplashScreenNoRootNS)
             WriteElementStringRaw("SaveMySettingsOnExit", "", Xml.XmlConvert.ToString(CType(o.SaveMySettingsOnExit, Boolean)))
+            WriteElementStringRaw("HighDpiMpde", "", Xml.XmlConvert.ToString(CType(o.HighDpiMode, Boolean)))
             WriteEndElement(o)
         End Sub 'Write2_MyApplicationData
 
@@ -95,7 +96,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             Dim o As MyApplicationData
             o = New MyApplicationData()
-            Dim paramsRead(8) As Boolean
+            Dim paramsRead(9) As Boolean
 
             While Reader.MoveToNextAttribute()
                 If Not IsXmlnsAttribute(Reader.Name) Then
@@ -151,6 +152,10 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                         o.SaveMySettingsOnExit = Xml.XmlConvert.ToBoolean(Reader.ReadElementString())
                         paramsRead(8) = True
 
+                    ElseIf Not paramsRead(9) AndAlso Reader.LocalName = _id13_HighDpiMode AndAlso Reader.NamespaceURI = _id2_Item Then
+                        o.HighDpiMode = Xml.XmlConvert.ToInt32(Reader.ReadElementString())
+                        paramsRead(9) = True
+
                     Else
                         UnknownNode(CType(o, Object))
                     End If
@@ -199,6 +204,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _id7_EnableVisualStyles As String '
         Private _id8_AuthenticationMode As String
         Private _id12_SaveMySettingsOnExit As String
+        Private _id13_HighDpiMode As String
 
         Protected Overrides Sub InitIDs()
 
@@ -223,6 +229,8 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             _id8_AuthenticationMode = Reader.NameTable.Add("AuthenticationMode")
 
             _id12_SaveMySettingsOnExit = Reader.NameTable.Add("SaveMySettingsOnExit")
+
+            _id13_HighDpiMode = Reader.NameTable.Add("HighDpiMode")
         End Sub 'InitIDs 
 
         Private _publicMethods As Hashtable

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -602,13 +602,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Get
             Set
                 Select Case Value
-                    Case _
-                    0, ' There is no ApplicationService.HighDpiMode available to do it more clean.
-                    1,
-                    2,
-                    3,
-                    4
-                        ' Valid - continue
+                    Case 0 To 4 ' Valid - continue
                     Case Else
                         Throw New ArgumentOutOfRangeException(NameOf(Value))
                 End Select

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -86,6 +86,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         SplashScreen = 8
         ' ApplicationType = 9 ' OBSOLETE
         SaveMySettingsOnExit = 10
+        HigDpiMode = 11
     End Enum
 
     ''' <summary>
@@ -105,6 +106,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         <DispId(MyAppDISPIDs.SplashScreen)> Property SplashScreen As String
         ' <DispId(MyAppDISPIDs.ApplicationType)> Property ApplicationType() As Integer ' OBSOLETE
         <DispId(MyAppDISPIDs.SaveMySettingsOnExit)> Property SaveMySettingsOnExit As Boolean
+        <DispId(MyAppDISPIDs.HigDpiMode)> Property HighDpiMode As Integer
     End Interface
 
     Friend Interface IMyApplicationPropertiesInternal 'Not publicly exposed - for internal use only
@@ -192,6 +194,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Const PROPNAME_SaveMySettingsOnExit As String = "SaveMySettingsOnExit"
         Private Const PROPNAME_AuthenticationMode As String = "AuthenticationMode"
         Private Const PROPNAME_SplashScreen As String = "SplashScreen"
+        Private Const PROPNAME_HighDpiMode As String = "HighDpiMode"
 
         Private _projectHierarchy As IVsHierarchy
         Private WithEvents _myAppDocData As DocData 'The DocData which backs the MyApplication.myapp file
@@ -589,6 +592,34 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
                     'Notify users of property change
                     OnPropertyChanged(PROPNAME_SplashScreen)
+                End If
+            End Set
+        End Property
+
+        Friend Property HighDpiMode As Integer Implements IMyApplicationPropertiesInternal.HighDpiMode
+            Get
+                Return _myAppData.HighDpiMode
+            End Get
+            Set
+                Select Case Value
+                    Case _
+                    0, ' There is no ApplicationService.HighDpiMode available to do it more clean.
+                    1,
+                    2,
+                    3,
+                    4
+                        ' Valid - continue
+                    Case Else
+                        Throw New ArgumentOutOfRangeException(NameOf(Value))
+                End Select
+
+                If _myAppData.HighDpiMode <> Value Then
+                    CheckOutDocData()
+                    _myAppData.HighDpiMode = Value
+                    FlushToDocData()
+
+                    'Notify users of property change
+                    OnPropertyChanged(PROPNAME_highDpiMode)
                 End If
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode() -> Integer
+Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode(Value As Integer) -> Void

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -269,20 +269,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
                 };
             }
-            else if (propertyName == HighDpiModeProperty)
-            {
-                value = value switch
-                {
-                    "0" => "DpiUnaware",
-                    "1" => "SystemAware",
-                    "2" => "PerMonitor",
-                    "3" => "PerMonitorV2",
-                    "4" => "DpiUnawareGdiScaled",
-                    "" => "",
-
-                    _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
-                };
-            }
             else if (propertyName == ShutdownModeProperty)
             {
                 value = value switch
@@ -307,18 +293,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 {
                     "Windows" => "0",
                     "ApplicationDefined" => "1",
-                    _ => unevaluatedPropertyValue
-                };
-            }
-            else if (propertyName == HighDpiModeProperty)
-            {
-                unevaluatedPropertyValue = unevaluatedPropertyValue switch
-                {
-                    "DpiUnaware" => "0",
-                    "SystemAware" => "1",
-                    "PerMonitor" => "2",
-                    "PerMonitorV2" => "3",
-                    "DpiUnawareGdiScaled" => "4",
                     _ => unevaluatedPropertyValue
                 };
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -95,8 +95,7 @@
                 DisplayName="High DPI mode"
                 Description="Specifies the application-wide HighDpiMode for the application. This setting can be programaticaly overriden through the ApplyApplicationDefaults event."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195173"
-                Category="ApplicationFramework"
-                Visible="False">
+                Category="ApplicationFramework">
     <EnumProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
@@ -110,15 +109,15 @@
     </EnumProperty.Metadata>
 
     <!-- TODO: Validate DisplayName values. -->
-    <EnumValue Name="DpiUnaware"
+    <EnumValue Name="0"
                DisplayName="DPI unaware - No scaling and assuming 100% scaling." />
-    <EnumValue Name="DpiUnawareGdiScaled"
+    <EnumValue Name="4"
                DisplayName="DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content." />
-    <EnumValue Name="SystemAware"
+    <EnumValue Name="1"
                DisplayName="System aware - Primary monitor's DPI is scale lead." />
-    <EnumValue Name="PerMonitor"
+    <EnumValue Name="2"
                DisplayName="Per monitor - DPI detected on-launch and on-change." />
-    <EnumValue Name="PerMonitorV2"
+    <EnumValue Name="3"
                DisplayName="Per monitor V2 - DPI detected on-launch and on-change including child windows" />
   </EnumProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Režim ověřování</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">Nepodporuje DPI, GDI se škáluje – Stejně jako rozlišení DPI bez rozlišení, ale je optimalizované pro grafický obsah, který není ve vyrovnávací paměti.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">Nepodporuje DPI – Bez měřítka a předpokládá se 100% škálování.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Na monitor V2 – Rozpoznáno DPI při spuštění a při změně včetně podřízených oken</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Na monitor – Rozpoznáno DPI při spuštění a při změně.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Informace o systému – DPI primárního monitoru je potenciální měřítko.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Authentifizierungsmodus</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">Nicht DPI-fähig, GDI-skaliert – Wie nicht DPI-fähig, aber für nicht doppelt gepufferte Grafikinhalte optimiert.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">Nicht DPI-fähig – Keine Skalierung und Annahme einer 100%igen Skalierung.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Pro Monitor V2 – DPI beim Start und bei Änderung erkannt, einschließlich untergeordneter Fenster</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Pro Monitor – DPI beim Start und bei Änderung erkannt.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Systemfähig – Der DPI des primären Monitors ist ein Skalierungslead.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Modo de autenticación</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">Sin reconocimiento de PPP, GDI escalado: como con reconocimiento de PPP, pero optimizado para contenido gráfico sin búfer doble.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">Con reconocimiento de PPP: sin escala y se supone un 100 % de ajuste de escala.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Por monitor V2: PPP detectado al iniciar y al cambiar, incluidas las ventanas secundarias</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Por monitor: PPP detectado al iniciar y al cambiar.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Con reconocimiento de sistema: el PPP del monitor principal es el cliente potencial de la escala.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Mode d'authentification</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">Sans prise en charge PPP, GDI mis à l’échelle : similaire à Sans prise en charge PPP, mais optimisé pour le contenu graphique non mis en mémoire tampon double.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">Sans prise en charge PPP : aucune mise à l’échelle et mise à l’échelle de 100 %.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Par moniteur V2 : PPP détecté lors du lancement et de la modification, y compris les fenêtres enfants</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Par moniteur : PPP détecté lors du lancement et de la modification.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Prise en charge du système : la résolution PPP du moniteur principal dépend de la mise à l’échelle.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Modalità di autenticazione</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI non disponibile, GDI ridimensionato- Come DPI non disponibile ma ottimizzato per i contenuti grafici non a doppio buffer.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI non disponibile: nessun ridimensionamento e presupponendo un ridimensionamento del100%.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Per monitor V2: rilevato DPI all'avvio e alla modifica, incluse le finestre figlio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Per monitor: rilevato DPI all'avvio e alla modifica.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Compatibile con il sistema: il DPI del monitor principale è un lead di scalabilità.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -122,29 +122,29 @@
         <target state="translated">認証モード</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI 非対応、GDI スケーリング済み - DPI 非対応と同様ですが、ダブル バッファリングを使用しないグラフィックス コンテンツ向けに最適化されます。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI 非対応 - スケーリングなし。スケーリングは 100%であると仮定します。</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">モニターごと V2 - 子ウィンドウを含め、起動時と変更時に DPI が検出されます</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">モニターごと - 起動時と変更時に DPI が検出されます。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">システム対応 - プライマリ モニターの DPI が最初にスケーリングされます。</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -122,29 +122,29 @@
         <target state="translated">인증 모드</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI를 인식하지 못함, GDI 크기 조정 - DPI와 마찬가지로 두 번 버퍼링되지 않은 그래픽 콘텐츠에 최적화되어 있습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI 인식 안 함 - 크기 조정이 없으며 100% 크기 조정을 가정합니다.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">모니터당 V2 - 자식 창을 포함하여 시작 시 및 변경 시 DPI가 검색됨</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">모니터당 - 시작 시 및 변경 시 DPI가 검색되었습니다.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">시스템 인식 - 기본 모니터의 DPI는 크기 조정 잠재 고객입니다.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Tryb uwierzytelniania</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">Nierozpoznawane wartości DPI, skalowane GDI — podobnie jak nierozpoznawane DPI, ale zoptymalizowane pod kątem zawartości grafiki niebuforowanej dwukrotnie.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">Nierozpoznawane wartość DPI — bez skalowania i przy założeniu skalowania na 100%.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Na monitor w wersji 2 — wykryto DPI podczas uruchamiania i zmiany, w tym okna podrzędne</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Na monitor — wykryto DPI podczas uruchamiania i zmiany.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Rozpoznawanie systemu — DPI monitora podstawowego to potencjalny klient skalowania.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Modo de autenticação</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI inconsciente, GDI dimensionado - Como DPI inconsciente, mas otimizado para conteúdo gráfico sem buffer duplo.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI inconsciente - Sem escala e assumindo 100% de escala.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Por monitor V2 - DPI detectado na inicialização e na alteração, incluindo janelas filhas</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Por monitor - DPI detectado na inicialização e na alteração.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Reconhecimento do sistema - O DPI do monitor primário é o cliente em potencial de escala.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Режим проверки подлинности</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">Без учета DPI, с масштабированием интерфейса графических устройств. Например, DPI не поддерживается, но оптимизирован для графического содержимого без двойной буферизации.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI не учитывается — без масштабирования и при условии 100% масштабирования.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">Для каждого монитора версии 2 — DPI определяется при запуске и изменении, включая дочерние окна</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">Для каждого монитора — DPI определяется при запуске и изменении.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Системная осведомленность — DPI основного монитора опережает шкалу.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -122,29 +122,29 @@
         <target state="translated">Kimlik doğrulaması modu</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI farkındalığı yok, GDI ölçeklendirildi: DPI farkındalığı yok gibi ancak çift arabelleğe alınmamış Grafik içeriği için iyileştirilmemiş.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI farkındalığı yok: Ölçeklendirme yok ve %100 ölçeklendirme varsayılıyor.</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">İzleyici başına V2: Alt pencereler de dahil olmak üzere başlatma ve değiştirme sırasında DPI algılandı</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">İzleyici başına: Başlatma ve değiştirme esnasında DPI algılandı.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">Sistem farkındalığı var: Birincil izleyicinin DPI'si ölçek lideridir.</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -122,29 +122,29 @@
         <target state="translated">身份验证模式</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI 不知情，GDI 已缩放 - 和 DPI 不知情相似，但针对非双缓冲图形内容进行了优化。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI 不知情 - 无缩放，并假定 100% 缩放。</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">按监视器 V2 - 在启动和更改时检测到 DPI，包括子窗口</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">按监视器 - 在启动和更改时检测到 DPI。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">系统感知 - 主监视器的 DPI 是缩放前导。</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -122,29 +122,29 @@
         <target state="translated">驗證模式</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnawareGdiScaled|DisplayName">
-        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
-        <target state="translated">DPI 非識別，GDI 縮放 - 像 DPI 非識別，但已針對非雙重緩衝圖形內容最佳化。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.DpiUnaware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.0|DisplayName">
         <source>DPI unaware - No scaling and assuming 100% scaling.</source>
-        <target state="translated">DPI 非識別 - 不調整規模並假設 100% 縮放。</target>
+        <target state="new">DPI unaware - No scaling and assuming 100% scaling.</target>
         <note />
       </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitorV2|DisplayName">
-        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
-        <target state="translated">每個監視器 V2 - DPI 在啟動時和變更時已偵測，包括子視窗</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.PerMonitor|DisplayName">
-        <source>Per monitor - DPI detected on-launch and on-change.</source>
-        <target state="translated">每個監視器 - DPI 在啟動時和變更時已偵測。</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="EnumValue|HighDpiMode.SystemAware|DisplayName">
+      <trans-unit id="EnumValue|HighDpiMode.1|DisplayName">
         <source>System aware - Primary monitor's DPI is scale lead.</source>
-        <target state="translated">系統感知 - 主要監視器的 DPI 是縮放潛在客戶。</target>
+        <target state="new">System aware - Primary monitor's DPI is scale lead.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.2|DisplayName">
+        <source>Per monitor - DPI detected on-launch and on-change.</source>
+        <target state="new">Per monitor - DPI detected on-launch and on-change.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.3|DisplayName">
+        <source>Per monitor V2 - DPI detected on-launch and on-change including child windows</source>
+        <target state="new">Per monitor V2 - DPI detected on-launch and on-change including child windows</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|HighDpiMode.4|DisplayName">
+        <source>DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</source>
+        <target state="new">DPI unaware, GDI scaled - Like DPI unaware but optimized for non-double-buffered Graphics content.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|ShutdownMode.AfterAllFormsClose|DisplayName">


### PR DESCRIPTION
Relates to #8283, where we hid this property as we were not ready with the code generation part.

This PR consists of two commits:
- In the first one, we make the property visible in the UI. Additionally, we simplify the way the enum values are stored: instead of translating from integer to string and back again, we only keep the integer that represents the value. Later in the code generation, we will translate to the proper string, as that's the point in time where we actually need it.
- In the second one, we make the proper changes to read/write from the xml file (App.myapp file), save it into a property and later use its value to generate the necessary code for the Application.Designer.vb file. Note that we had to implement an override function for the `AddFieldAssignment`: we are not in .NET Core, and thus we do not have access to the complete `ApplicationService` namespace ([see documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.visualbasic.applicationservices?view=windowsdesktop-6.0)); since we cannot access the `EnumType` for `HighDpiMode` property, we opted to override the function to accept a `String` instead of a `Type`, as the CodeDom already works with strings and it would be too much of an effort to support a request to the Designer OOP server-side.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8400)