### PR TITLE
Add missing public api to PublicAPI.Shipped.txt

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -1083,3 +1083,5 @@ Shared My.Resources.GeneralOptionPageResources.ResourceManager() -> System.Resou
 Shared My.Resources.GeneralOptionPageResources.General_PreferSingleTargetBuildsOnLaunch() -> String
 Shared My.Resources.GeneralOptionPageResources.General_MultiTargetingSettings_Title() -> String
 Shared My.Resources.GeneralOptionPageResources.General_PreferSingleTargetBuildsOnLaunchDescription() -> String
+Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode() -> Integer
+Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode(Value As Integer) -> Void

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode() -> Integer
-Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode(Value As Integer) -> Void


### PR DESCRIPTION
Code cleanup.

After I updated my local dotnet project system repo, and build it solution the file PublicAPI.Shipped.txt was modified to add some missing apis.

Perhaps this was part of a previous change.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8405)