### PR TITLE
Add names to broadcast blocks missing a name

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             ProjectThreadingService = threadingService;
         }
 
-        public override NamedIdentity DataSourceKey { get; } = new NamedIdentity();
+        public override NamedIdentity DataSourceKey { get; } = new NamedIdentity(nameof(DebugProfileDebugTargetGenerator));
 
         private int _dataSourceVersion;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/DebugProfileDebugTargetGenerator.cs
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                     return new ProjectVersionedValue<IReadOnlyList<IEnumValue>>(generatedResult, dataSources);
                 });
 
-            IBroadcastBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>> broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>>();
+            IBroadcastBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>> broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<IReadOnlyList<IEnumValue>>>(nameFormat: "Debug Profiles Broadcast: {1}");
 
             // The interface has two definitions of SourceBlock: one from
             // ILaunchSettingsProvider, and one from IProjectValueDataSource<T> (via

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             // Create an action block to process the design time inputs and configuration general changes
             ITargetBlock<IProjectVersionedValue<ValueTuple<DesignTimeInputs, IProjectSubscriptionUpdate>>> inputsAction = DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<ValueTuple<DesignTimeInputs, IProjectSubscriptionUpdate>>>(ProcessDataflowChanges, _project);
 
-            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<DesignTimeInputSnapshot>>(nameFormat: nameof(DesignTimeInputsChangeTracker) + "Broadcast {1}");
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<DesignTimeInputSnapshot>>(nameFormat: nameof(DesignTimeInputsChangeTracker) + " Broadcast: {1}");
             _publicBlock = AllowSourceBlockCompletion ? _broadcastBlock : _broadcastBlock.SafePublicize();
 
             Assumes.Present(_project.Services.ProjectAsynchronousTasks);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcher.cs
@@ -74,7 +74,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             base.Initialize();
 
-            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<string[]>>(nameFormat: nameof(DesignTimeInputsFileWatcher) + "Broadcast {1}");
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<string[]>>(nameFormat: nameof(DesignTimeInputsFileWatcher) + " Broadcast: {1}");
             _publicBlock = AllowSourceBlockCompletion ? _broadcastBlock : _broadcastBlock.SafePublicize();
 
             _actionBlock = DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<DesignTimeInputs>>(ProcessDesignTimeInputsAsync, _project);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -186,11 +186,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             base.Initialize();
 
             // Create our broadcast block for subscribers to ILaunchSettingsProvider to get new ILaunchSettings information
-            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<ILaunchSettings>();
+            _broadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<ILaunchSettings>(nameFormat: "Launch Settings Broadcast: {1}");
             _changedSourceBlock = _broadcastBlock.SafePublicize();
 
             // Create our broadcast block for subscribers to IVersionedLaunchSettingsProvider to get new ILaunchSettings information
-            _versionedBroadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<ILaunchSettings>>();
+            _versionedBroadcastBlock = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<ILaunchSettings>>(nameFormat: "Versioned Launch Settings Broadcast: {1}");
             _versionedChangedSourceBlock = _versionedBroadcastBlock.SafePublicize();
 
             // Subscribe to changes to the broadcast block using the idle scheduler. This should filter out a lot of the intermediate

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.SnapshotUpdater.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                 _currentSnapshot = DependenciesSnapshot.Empty;
 
                 // Updates will be published via Dataflow.
-                _source = DataflowBlockSlim.CreateBroadcastBlock<SnapshotChangedEventArgs>("DependenciesSnapshot {1}", skipIntermediateInputData: true);
+                _source = DataflowBlockSlim.CreateBroadcastBlock<SnapshotChangedEventArgs>(nameFormat: "DependenciesSnapshot Broadcast: {1}", skipIntermediateInputData: true);
 
                 // Updates are debounced to conflate rapid updates and reduce frequency of tree updates downstream.
                 _debounce = new TaskDelayScheduler(


### PR DESCRIPTION
Handles #8411, #8410 
This is useful when identifying root cause of problems from NFEs.

cc: @lifengl 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8414)