### PR TITLE
Mark AbstractFindByNameUnderAppDesignerSpecialFileProvider as an 'abstract' class.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AbstractFindByNameUnderAppDesignerSpecialFileProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
     ///     that find their special file by file name under the AppDesigner folder, falling back
     ///     to the root folder if it doesn't exist.
     /// </summary>
-    internal class AbstractFindByNameUnderAppDesignerSpecialFileProvider : AbstractFindByNameSpecialFileProvider
+    internal abstract class AbstractFindByNameUnderAppDesignerSpecialFileProvider : AbstractFindByNameSpecialFileProvider
     {
         private readonly ISpecialFilesManager _specialFilesManager;
 


### PR DESCRIPTION
It is confusing this is not an abstract class

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8416)