### PR TITLE
Intercept StartupObject property for VB WinForms projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -28,6 +28,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
         string isWindowsFormsProject = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWinFormsProperty);
+        string rootNameSpace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
 
         if (bool.TryParse(isWindowsFormsProject, out bool b) && b)
         {
@@ -35,14 +36,17 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
 
             if (Equals(applicationFrameworkValue, EnabledValue))
             {
-                // TO-DO: Validate scenario where the selected value is a Form.
+                // Set the startup object in the myapp file.
                 await _myAppXmlFileAccessor.SetMainFormAsync(unevaluatedPropertyValue);
+
+                // And save namespace.My.MyApplication in the project file.
+                await defaultProperties.SetPropertyValueAsync("StartupObject", rootNameSpace + ".My.MyApplication");
             }
         }
 
         // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
         // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-        return unevaluatedPropertyValue;
+        return rootNameSpace + "." + unevaluatedPropertyValue;
     }
 
     public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -18,6 +18,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
 
     internal const string UseWinFormsProperty = "UseWindowsForms";
     internal const string StartupObjectProperty = "StartupObject";
+    internal const string RootNamespaceProperty = "RootNamespace";
 
     [ImportingConstructor]
     public StartupObjectValueProvider(IMyAppFileAccessor myAppXmlFileAccessor)
@@ -28,7 +29,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
         string isWindowsFormsProject = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWinFormsProperty);
-        string rootNameSpace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
+        string rootNameSpace = await defaultProperties.GetEvaluatedPropertyValueAsync(RootNamespaceProperty);
 
         if (bool.TryParse(isWindowsFormsProject, out bool b) && b)
         {
@@ -40,7 +41,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
                 await _myAppXmlFileAccessor.SetMainFormAsync(unevaluatedPropertyValue);
 
                 // And save namespace.My.MyApplication in the project file.
-                await defaultProperties.SetPropertyValueAsync("StartupObject", rootNameSpace + ".My.MyApplication");
+                await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, rootNameSpace + ".My.MyApplication");
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -37,14 +37,14 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
                 if (unevaluatedPropertyValue.Contains("Form")) // Is there a better way to identify a form?
                 {
                     // If the user selects a Form, the value should be serialized to the myapp file.
-                    await _myAppXmlFileAccessor.SetStartupObjectAsync(unevaluatedPropertyValue);
+                    await _myAppXmlFileAccessor.SetMainFormAsync(unevaluatedPropertyValue);
                     await defaultProperties.DeletePropertyAsync(StartupObjectProperty);
                     return null;
                 }
 
                 // If the ApplicationFramework is enabled, the value Sub Main should always be serialized to the project file.
                 await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, "Sub Main");
-                await _myAppXmlFileAccessor.SetStartupObjectAsync(string.Empty);
+                await _myAppXmlFileAccessor.SetMainFormAsync(string.Empty);
                 return null;
             }
         }
@@ -66,7 +66,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
         string valueInProjectFile = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
 
         if (string.IsNullOrEmpty(valueInProjectFile))
-            return await _myAppXmlFileAccessor.GetStartupObjectAsync() ?? string.Empty;
+            return await _myAppXmlFileAccessor.GetMainFormAsync() ?? string.Empty;
 
         return valueInProjectFile;
     }
@@ -82,7 +82,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
         string valueInProjectFile = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
 
         if (string.IsNullOrEmpty(valueInProjectFile))
-            return await _myAppXmlFileAccessor.GetStartupObjectAsync() ?? string.Empty;
+            return await _myAppXmlFileAccessor.GetMainFormAsync() ?? string.Empty;
 
         return valueInProjectFile;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -28,11 +28,11 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     {
         string isWindowsFormsProject = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWinFormsProperty);
 
-        if (isWindowsFormsProject == "true")
+        if (bool.TryParse(isWindowsFormsProject, out bool b) && b)
         {
             string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
 
-            if (applicationFrameworkValue == EnabledValue)
+            if (Equals(applicationFrameworkValue, EnabledValue))
             {
                 if (unevaluatedPropertyValue.Contains("Form")) // Is there a better way to identify a form?
                 {
@@ -59,11 +59,11 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     {
         // StartupObject can come from the project file or the myapp file.
         string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
-        
-        if (applicationFrameworkValue == DisabledValue)
-            return await base.OnGetUnevaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
 
         string valueInProjectFile = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
+        
+        if (Equals(applicationFrameworkValue, DisabledValue))
+            return valueInProjectFile;
 
         if (string.IsNullOrEmpty(valueInProjectFile))
             return await _myAppXmlFileAccessor.GetMainFormAsync() ?? string.Empty;
@@ -76,11 +76,10 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
         // StartupObject can come from the project file or the myapp file.
         string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
 
-        if (applicationFrameworkValue == DisabledValue)
-            return await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
-
         string valueInProjectFile = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
-
+        if (Equals(applicationFrameworkValue, DisabledValue))
+            return valueInProjectFile; 
+        
         if (string.IsNullOrEmpty(valueInProjectFile))
             return await _myAppXmlFileAccessor.GetMainFormAsync() ?? string.Empty;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+
+[ExportInterceptingPropertyValueProvider(StartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+[AppliesTo(ProjectCapability.VisualBasic)]
+internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBase
+{
+    private readonly IMyAppFileAccessor _myAppXmlFileAccessor;
+
+    internal const string ApplicationFrameworkProperty = "MyType";
+    private const string EnabledValue = "WindowsForms";
+    private const string DisabledValue = "WindowsFormsWithCustomSubMain";
+
+    internal const string UseWinFormsProperty = "UseWindowsForms";
+    internal const string StartupObjectProperty = "StartupObject";
+
+    [ImportingConstructor]
+    public StartupObjectValueProvider(IMyAppFileAccessor myAppXmlFileAccessor)
+    {
+        _myAppXmlFileAccessor = myAppXmlFileAccessor;
+    }
+
+    public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+    {
+        string isWindowsFormsProject = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWinFormsProperty);
+
+        if (isWindowsFormsProject == "true")
+        {
+            string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
+
+            if (applicationFrameworkValue == EnabledValue)
+            {
+                if (unevaluatedPropertyValue.Contains("Form")) // Is there a better way to identify a form?
+                {
+                    // If the user selects a Form, the value should be serialized to the myapp file.
+                    await _myAppXmlFileAccessor.SetStartupObjectAsync(unevaluatedPropertyValue);
+                    await defaultProperties.DeletePropertyAsync(StartupObjectProperty);
+                    return null;
+                }
+
+                // If the ApplicationFramework is enabled, the value Sub Main should always be serialized to the project file.
+                await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, "Sub Main");
+                await _myAppXmlFileAccessor.SetStartupObjectAsync(string.Empty);
+                return null;
+            }
+        }
+
+        // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
+        // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
+        await defaultProperties.SetPropertyValueAsync(propertyName, unevaluatedPropertyValue);
+        return null;
+    }
+
+    public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        // StartupObject can come from the project file or the myapp file.
+        string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
+        
+        if (applicationFrameworkValue == DisabledValue)
+            return await base.OnGetUnevaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
+
+        string valueInProjectFile = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, evaluatedPropertyValue, defaultProperties);
+
+        if (string.IsNullOrEmpty(valueInProjectFile))
+            return await _myAppXmlFileAccessor.GetStartupObjectAsync() ?? string.Empty;
+
+        return valueInProjectFile;
+    }
+
+    public override async Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+    {
+        // StartupObject can come from the project file or the myapp file.
+        string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
+
+        if (applicationFrameworkValue == DisabledValue)
+            return await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
+
+        string valueInProjectFile = await base.OnGetUnevaluatedPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
+
+        if (string.IsNullOrEmpty(valueInProjectFile))
+            return await _myAppXmlFileAccessor.GetStartupObjectAsync() ?? string.Empty;
+
+        return valueInProjectFile;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
         {
             bool searchForEntryPointsInFormsOnly = options?.Any(pair =>
-                pair.Name == "searchForEntryPointsInFormsOnly"
+                pair.Name == "SearchForEntryPointsInFormsOnly"
                 && bool.TryParse(pair.Value, out bool optionValue)
                 && optionValue) ?? false;
 
@@ -54,7 +54,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private readonly bool _includeEmptyValue;
         private readonly bool _searchForEntryPointsInFormsOnly;
 
-        [ImportingConstructor]
         public StartupObjectsEnumGenerator(Workspace workspace, UnconfiguredProject project, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly)
         {
             _workspace = workspace;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -26,18 +26,35 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
         {
-            // We only include a value representing the "not set" state if requested. This is
-            // because the old property pages explicitly add the "(Not set)" value at the UI
-            // layer; the new property pages do not have that option and so the value must come
-            // from the enum provider.
-            // When this project system no longer needs to support the old property pages we can
-            // remove this and always include the "(Not set)" value.
-            bool includeEmptyValue = options?.Any(pair =>
+            bool searchForEntryPointsInFormsOnly;
+            bool includeEmptyValue;
+
+            // The StartupObject property has a different set of appropriate values for VB and for C#.
+            // For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
+            // We specify this by setting the searchForEntryPointsInFormsOnly to true.
+            // We also want to ensure that the property always has a value.
+            if (_unconfiguredProject.Capabilities.Contains(ProjectCapability.VisualBasic))
+            {
+                searchForEntryPointsInFormsOnly = true;
+                includeEmptyValue = false;
+            }
+            else
+            {
+                searchForEntryPointsInFormsOnly = false;
+
+                // We only include a value representing the "not set" state if requested. This is
+                // because the old property pages explicitly add the "(Not set)" value at the UI
+                // layer; the new property pages do not have that option and so the value must come
+                // from the enum provider.
+                // When this project system no longer needs to support the old property pages we can
+                // remove this and always include the "(Not set)" value.
+                includeEmptyValue = options?.Any(pair =>
                 pair.Name == "IncludeEmptyValue"
                 && bool.TryParse(pair.Value, out bool optionValue)
                 && optionValue) ?? false;
+            }
 
-            return Task.FromResult<IDynamicEnumValuesGenerator>(new StartupObjectsEnumGenerator(_workspace, _unconfiguredProject, includeEmptyValue));
+            return Task.FromResult<IDynamicEnumValuesGenerator>(new StartupObjectsEnumGenerator(_workspace, _unconfiguredProject, includeEmptyValue, searchForEntryPointsInFormsOnly));
         }
     }
 
@@ -47,18 +64,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private readonly Workspace _workspace;
         private readonly UnconfiguredProject _unconfiguredProject;
         private readonly bool _includeEmptyValue;
-
-        /// <summary>
-        /// When we implement WinForms support, we need to set this for VB WinForms projects
-        /// </summary>
-        private static bool SearchForEntryPointsInFormsOnly => false;
+        private readonly bool _searchForEntryPointsInFormsOnly;
 
         [ImportingConstructor]
-        public StartupObjectsEnumGenerator(Workspace workspace, UnconfiguredProject project, bool includeEmptyValue)
+        public StartupObjectsEnumGenerator(Workspace workspace, UnconfiguredProject project, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly)
         {
             _workspace = workspace;
             _unconfiguredProject = project;
             _includeEmptyValue = includeEmptyValue;
+            _searchForEntryPointsInFormsOnly = searchForEntryPointsInFormsOnly;
         }
 
         public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
@@ -83,7 +97,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
 
             IEntryPointFinderService? entryPointFinderService = project.LanguageServices.GetService<IEntryPointFinderService>();
-            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, SearchForEntryPointsInFormsOnly);
+            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, _searchForEntryPointsInFormsOnly);
             if (entryPoints is not null)
             {
                 enumValues.AddRange(entryPoints.Select(ep =>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -26,33 +26,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
         {
-            bool searchForEntryPointsInFormsOnly;
-            bool includeEmptyValue;
+            bool searchForEntryPointsInFormsOnly = options?.Any(pair =>
+                pair.Name == "searchForEntryPointsInFormsOnly"
+                && bool.TryParse(pair.Value, out bool optionValue)
+                && optionValue) ?? false;
 
-            // The StartupObject property has a different set of appropriate values for VB and for C#.
-            // For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
-            // We specify this by setting the searchForEntryPointsInFormsOnly to true.
-            // We also want to ensure that the property always has a value.
-            if (_unconfiguredProject.Capabilities.Contains(ProjectCapability.VisualBasic))
-            {
-                searchForEntryPointsInFormsOnly = true;
-                includeEmptyValue = false;
-            }
-            else
-            {
-                searchForEntryPointsInFormsOnly = false;
-
-                // We only include a value representing the "not set" state if requested. This is
-                // because the old property pages explicitly add the "(Not set)" value at the UI
-                // layer; the new property pages do not have that option and so the value must come
-                // from the enum provider.
-                // When this project system no longer needs to support the old property pages we can
-                // remove this and always include the "(Not set)" value.
-                includeEmptyValue = options?.Any(pair =>
+            // We only include a value representing the "not set" state if requested. This is
+            // because the old property pages explicitly add the "(Not set)" value at the UI
+            // layer; the new property pages do not have that option and so the value must come
+            // from the enum provider.
+            // When this project system no longer needs to support the old property pages we can
+            // remove this and always include the "(Not set)" value.
+            bool includeEmptyValue = options?.Any(pair =>
                 pair.Name == "IncludeEmptyValue"
                 && bool.TryParse(pair.Value, out bool optionValue)
                 && optionValue) ?? false;
-            }
 
             return Task.FromResult<IDynamicEnumValuesGenerator>(new StartupObjectsEnumGenerator(_workspace, _unconfiguredProject, includeEmptyValue, searchForEntryPointsInFormsOnly));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -90,7 +90,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 enumValues.AddRange(entryPoints.Select(ep =>
                 {
                     string name = ep.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-                    return new PageEnumValue(new EnumValue { Name = name, DisplayName = name });
+                    string minimalName = ep.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                    return new PageEnumValue(new EnumValue { Name = minimalName, DisplayName = name });
                 }));
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -28,6 +28,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
     private const string HighDpiModeProperty = "HighDpiMode";
     private const string SplashScreenProperty = "SplashScreen";
     private const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
+    private const string StartupObjectProperty = "StartupObject";
 
     private const string DefaultMyappFileContents =
         """
@@ -176,4 +177,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
 
     public async Task SetMinimumSplashScreenDisplayTimeAsync(int value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value.ToString());
 
+    public async Task<string?> GetStartupObjectAsync() => await GetStringPropertyValueAsync(StartupObjectProperty);
+
+    public async Task SetStartupObjectAsync(string value) => await SetPropertyAsync(StartupObjectProperty, value);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -28,7 +28,6 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
     private const string HighDpiModeProperty = "HighDpiMode";
     private const string SplashScreenProperty = "SplashScreen";
     private const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
-    private const string StartupObjectProperty = "StartupObject";
 
     private const string DefaultMyappFileContents =
         """
@@ -176,8 +175,4 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
     public async Task<int?> GetMinimumSplashScreenDisplayTimeAsync() => await GetIntPropertyValueAsync(MinimumSplashScreenDisplayTimeProperty);
 
     public async Task SetMinimumSplashScreenDisplayTimeAsync(int value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value.ToString());
-
-    public async Task<string?> GetStartupObjectAsync() => await GetStringPropertyValueAsync(StartupObjectProperty);
-
-    public async Task SetStartupObjectAsync(string value) => await SetPropertyAsync(StartupObjectProperty, value);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -16,8 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         AuthenticationModeProperty,
         ShutdownModeProperty,
         SplashScreenProperty,
-        MinimumSplashScreenDisplayTimeProperty,
-        StartupObjectMSBuildProperty
+        MinimumSplashScreenDisplayTimeProperty
     },
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     [AppliesTo(ProjectCapability.VisualBasic)]
@@ -43,7 +42,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal const string ShutdownModeProperty = "ShutdownMode";
         internal const string SplashScreenProperty = "SplashScreen";
         internal const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
-        internal const string StartupObjectProperty = "StartupObject";
 
         private readonly UnconfiguredProject _project;
         private readonly IProjectItemProvider _sourceItemsProvider;
@@ -72,33 +70,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 {
                     return await SetPropertyValueForDefaultProjectTypesAsync(unevaluatedPropertyValue, defaultProperties);
                 }
-            }
-            else if (propertyName == StartupObjectProperty)
-            {
-                string isWindowsFormsProject = await defaultProperties.GetEvaluatedPropertyValueAsync("UseWinForms");
-
-                if (isWindowsFormsProject != null)
-                {
-                    string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
-
-                    if (applicationFrameworkValue == "true")
-                    {
-                        if (unevaluatedPropertyValue.Contains("form")) // Is there a better way to identify a form?
-                        {
-                            // If the user selects a Form, the value should be serialized to the myapp file.
-                            await _myAppXmlFileAccessor.SetStartupObjectAsync(unevaluatedPropertyValue);
-                            return null;
-                        }
-                        
-                        // If the ApplicationFramework is enabled, the value Sub Main should always be serialized to the project file.
-                        await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, "Sub Main");
-                        return null;
-                    }
-                }
-
-                // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
-                // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-                return await SetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
             }
             else
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string?> SetPropertyValueForDefaultProjectTypesAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            string rootNameSpace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
+            string rootNamespace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
             
             if (bool.TryParse(unevaluatedPropertyValue, out bool value))
             {
@@ -171,11 +171,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     // Set the StartupObject to namespace.My.MyApplication; we should save the actual value in the myapp file.
                     string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
 
-                    await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNameSpace + ".My.MyApplication");
+                    await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + ".My.MyApplication");
 
                     if (startupObjectValue is not null)
                     {
-                        startupObjectValue.Replace(rootNameSpace + ".", "");
+                        // Use StringComparison.OrdinalIgnoreCase because VB is _not_ case-sensitive
+                        if (startupObjectValue.StartsWith(rootNamespace + ".", StringComparison.OrdinalIgnoreCase))
+                        {
+                            startupObjectValue = startupObjectValue.Substring((rootNamespace + ".").Length);
+                        }
                         await _myAppXmlFileAccessor.SetMainFormAsync(startupObjectValue);
                     }
                 }
@@ -191,7 +195,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     string? startupObjectValue = await _myAppXmlFileAccessor.GetMainFormAsync();
 
                     if (startupObjectValue is not null)
-                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNameSpace + "." + startupObjectValue);
+                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + "." + startupObjectValue);
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -12,12 +12,40 @@
     <Category Name="WPF"
               DisplayName="WPF"
               Description="Settings specific to WPF applications." />
+
+    <Category Name="General"
+              DisplayName="General"
+              Description="General settings for the application." />
   </Rule.Categories>
 
   <!-- TODO: Add a hyperlink/button to open the app.manifest. Previously, we had a View Windows Settings button. -->
 
   <!-- TODO: Add a hyperlink/button to open the ApplicationEvents.vb. Previously, we had a View Application Events button. -->
-  
+
+  <!-- The StartupObject property has a different set of appropriate values for VB and for C#.
+       For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
+       We specify this by setting the searchForEntryPointsInFormsOnly to true.
+       We also want to ensure that the property always has a value. -->
+  <DynamicEnumProperty Name="StartupObject"
+                       DisplayName="Startup object"
+                       Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
+                       Category="General"
+                       EnumProvider="StartupObjectsEnumProvider">
+    <DynamicEnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </DynamicEnumProperty.DataSource>
+    <DynamicEnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>
+      </NameValuePair>
+    </DynamicEnumProperty.Metadata>
+    <DynamicEnumProperty.ProviderSettings>
+      <NameValuePair Name="IncludeEmptyValue" Value="false" />
+      <NameValuePair Name="searchForEntryPointsInFormsOnly" Value="true" />
+    </DynamicEnumProperty.ProviderSettings>
+  </DynamicEnumProperty>
+
   <!-- This property actually is saved as MyType. -->
   <BoolProperty Name="UseApplicationFramework"
                 DisplayName="Application Framework"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -5,10 +5,6 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.Categories>
-    <Category Name="General"
-              DisplayName="General"
-              Description="General settings for the application." />
-
     <Category Name="ApplicationFramework"
               DisplayName="Application Framework"
               Description="Application Framework settings." />
@@ -24,7 +20,7 @@
 
   <!-- The StartupObject property has a different set of appropriate values for VB and for C#.
        For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
-       We specify this by setting the searchForEntryPointsInFormsOnly to true.
+       We specify this by setting the SearchForEntryPointsInFormsOnly to true.
        We also want to ensure that the property always has a value. -->
   <DynamicEnumProperty Name="StartupObject"
                        DisplayName="Startup object"
@@ -42,7 +38,7 @@
     </DynamicEnumProperty.Metadata>
     <DynamicEnumProperty.ProviderSettings>
       <NameValuePair Name="IncludeEmptyValue" Value="false" />
-      <NameValuePair Name="searchForEntryPointsInFormsOnly" Value="true" />
+      <NameValuePair Name="SearchForEntryPointsInFormsOnly" Value="true" />
     </DynamicEnumProperty.ProviderSettings>
   </DynamicEnumProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -5,6 +5,10 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
 
   <Rule.Categories>
+    <Category Name="General"
+              DisplayName="General"
+              Description="General settings for the application." />
+
     <Category Name="ApplicationFramework"
               DisplayName="Application Framework"
               Description="Application Framework settings." />
@@ -12,10 +16,6 @@
     <Category Name="WPF"
               DisplayName="WPF"
               Description="Settings specific to WPF applications." />
-
-    <Category Name="General"
-              DisplayName="General"
-              Description="General settings for the application." />
   </Rule.Categories>
 
   <!-- TODO: Add a hyperlink/button to open the app.manifest. Previously, we had a View Windows Settings button. -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -223,10 +223,6 @@
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"
                        EnumProvider="StartupObjectsEnumProvider">
-    <DynamicEnumProperty.DataSource>
-      <DataSource Persistence="ProjectFileWithInterception"
-                  HasConfigurationCondition="False" />
-    </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -232,7 +232,7 @@
       <!-- We want an explicit item representing the empty value. We can remove this setting
            when the enum provider starts including it by default. -->
       <NameValuePair Name="IncludeEmptyValue" Value="true" />
-      <NameValuePair Name="searchForEntryPointsInFormsOnly" Value="false" />
+      <NameValuePair Name="SearchForEntryPointsInFormsOnly" Value="false" />
     </DynamicEnumProperty.ProviderSettings>
   </DynamicEnumProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -223,6 +223,10 @@
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"
                        EnumProvider="StartupObjectsEnumProvider">
+    <DynamicEnumProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="False" />
+    </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -236,6 +236,7 @@
       <!-- We want an explicit item representing the empty value. We can remove this setting
            when the enum provider starts including it by default. -->
       <NameValuePair Name="IncludeEmptyValue" Value="true" />
+      <NameValuePair Name="searchForEntryPointsInFormsOnly" Value="false" />
     </DynamicEnumProperty.ProviderSettings>
   </DynamicEnumProperty>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Architektura aplikace</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Nastavení specifická pro aplikace WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Úvodní obrazovka</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Architektura aplikace</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Nastavení specifická pro aplikace WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Anwendungsframework</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Spezifische Einstellungen für WPF-Anwendungen.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Anwendungsframework</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Spezifische Einstellungen für WPF-Anwendungen.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Begrüßungsbildschirm</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Marco de trabajo de la aplicación</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Configuración específica de las aplicaciones WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Marco de trabajo de la aplicación</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Configuración específica de las aplicaciones WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Pantalla de presentación</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Infrastructure d’application</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Paramètres spécifiques aux applications WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Écran de démarrage</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Infrastructure d’application</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Paramètres spécifiques aux applications WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Framework applicazione</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Impostazioni specifiche per le applicazioni WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Framework applicazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Impostazioni specifiche per le applicazioni WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Schermata iniziale</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -52,16 +52,6 @@
         <target state="translated">アプリケーション フレームワーク</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">WPF アプリケーションに固有の設定です。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -52,6 +52,16 @@
         <target state="translated">アプリケーション フレームワーク</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">WPF アプリケーションに固有の設定です。</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">スプラッシュ スクリーン</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -52,6 +52,16 @@
         <target state="translated">애플리케이션 프레임워크</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">WPF 애플리케이션과 관련된 설정입니다.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">시작 화면</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -52,16 +52,6 @@
         <target state="translated">애플리케이션 프레임워크</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">WPF 애플리케이션과 관련된 설정입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Struktura aplikacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Ustawienia specyficzne dla aplikacji WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Ekran powitalny</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Struktura aplikacji</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Ustawienia specyficzne dla aplikacji WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Estrutura do Aplicativo</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Configurações específicas para aplicativos WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Estrutura do Aplicativo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Configurações específicas para aplicativos WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Tela inicial</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Исполняющая среда</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Параметры, характерные для приложений WPF.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Экран-заставка</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Исполняющая среда</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">Параметры, характерные для приложений WPF.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -52,16 +52,6 @@
         <target state="translated">Uygulama Çerçevesi</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">WPF uygulamalarına özgü ayarlar.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Uygulama Çerçevesi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">WPF uygulamalarına özgü ayarlar.</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">Giriş ekranı</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="translated">应用程序框架</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">特定于 WPF 应用程序的设置。</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">初始屏幕</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -52,16 +52,6 @@
         <target state="translated">应用程序框架</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">特定于 WPF 应用程序的设置。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="translated">應用程式架構</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|General|Description">
+        <source>General settings for the application.</source>
+        <target state="new">General settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|General|DisplayName">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">特定於 WPF 應用程式的設定。</target>
@@ -70,6 +80,16 @@
       <trans-unit id="DynamicEnumProperty|SplashScreen|DisplayName">
         <source>Splash screen</source>
         <target state="translated">啟動顯示畫面</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+        <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+        <source>Startup object</source>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -52,16 +52,6 @@
         <target state="translated">應用程式架構</target>
         <note />
       </trans-unit>
-      <trans-unit id="Category|General|Description">
-        <source>General settings for the application.</source>
-        <target state="new">General settings for the application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="Category|General|DisplayName">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="Category|WPF|Description">
         <source>Settings specific to WPF applications.</source>
         <target state="translated">特定於 WPF 應用程式的設定。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
@@ -97,7 +97,7 @@ internal interface IMyAppFileAccessor
     /// Sets the current value of property in the myapp file.
     /// </summary>
     Task SetSplashScreenAsync(string splashScreen);
-    
+
     /// <summary>
     /// Returns the current value of property as stored in the myapp file.
     /// </summary>
@@ -107,14 +107,4 @@ internal interface IMyAppFileAccessor
     /// Sets the current value of property in the myapp file.
     /// </summary>
     Task SetMinimumSplashScreenDisplayTimeAsync(int minimumSplashScreenDisplayTime);
-
-    /// <summary>
-    /// Returns the current value of property in the myapp file.
-    /// </summary>
-    Task<string?> GetStartupObjectAsync();
-
-    /// <summary>
-    /// Sets the current value of property in the myapp file.
-    /// </summary>
-    Task SetStartupObjectAsync(string startupObject);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
@@ -107,4 +107,14 @@ internal interface IMyAppFileAccessor
     /// Sets the current value of property in the myapp file.
     /// </summary>
     Task SetMinimumSplashScreenDisplayTimeAsync(int minimumSplashScreenDisplayTime);
+
+    /// <summary>
+    /// Returns the current value of property in the myapp file.
+    /// </summary>
+    Task<string?> GetStartupObjectAsync();
+
+    /// <summary>
+    /// Sets the current value of property in the myapp file.
+    /// </summary>
+    Task SetStartupObjectAsync(string startupObject);
 }


### PR DESCRIPTION
Note: this PR has the same initial commits already reviewed as #8355. Please review the last commit.

The `StartupObject` property has a different behavior compared to the C# experience. This setting doesn't get serialized exclusively to the project file; in certain scenarios, it also needs to be serialized into the myapp file.

**Scenarios**
- If the `ApplicationFramework` is enabled, the value `Sub Main` should be serialized to the project file.
- If the user chooses a Form from the dropdown, this setting gets serialzed into the myapp file, which then generates the `Application.Designer.vb` code with the selected Form.
- If the `ApplicationFramework` is disabled, these settings get serialized into the project file.

We have been showing a correct set of values in the dropdown. The expected startup objects for VB WinForms projects should be:
- Every Form in the assembly directly or indirectly inherited from Form.
- Every Module which holds a Sub Main (Public, Friend, Protected).
- Every Class which holds a Shared Sub Main (Public, Friend, Protected).

For C#, this is being done by calling `FindEntryPoints`. We will use it for VB too; the flag `searchForEntryPointsInFormsOnly` in the rule file will help us differentiate the expected values. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8419)