### PR TITLE
Add a solution filter for editors only

### DIFF
--- a/Editors.slnf
+++ b/Editors.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "ProjectSystem.sln",
+    "projects": [
+      "setup\\VisualStudioEditorsSetup\\VisualStudioEditorsSetup.csproj",
+      "src\\Microsoft.VisualStudio.AppDesigner\\Microsoft.VisualStudio.AppDesigner.vbproj",
+      "src\\Microsoft.VisualStudio.Editors\\Microsoft.VisualStudio.Editors.vbproj"
+    ]
+  }
+}


### PR DESCRIPTION
Editors are kind of independent project from dotnet project system, and we can treat them independently.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8429)