### PR TITLE
Update property page documentation

### DIFF
--- a/docs/repo/property-pages/back-end-architecture.md
+++ b/docs/repo/property-pages/back-end-architecture.md
@@ -69,4 +69,4 @@ At the very bottom of the implementation stack are XAML Rule files, so-called be
 
 These Rule files are where the declarative, metadata-driven aspect of the new property pages comes into play. These files declare page, the page's metadata, its properties, the storage mechanisms to use (i.e. which `IProjectPropertiesProvider` will handle a particular property), and a bunch of other property metadata: documentation links, search terms, descriptions, the property type, whether the value can vary across project configurations, etc.
 
-Adding a new property is largely a matter of defining it in the appropriate XAML file. Adding a new page is a matter of creating a new XAML file and including it in the project as a `PropertyPageSchema` item.
+Adding a new property is largely a matter of defining it in the appropriate XAML file. Adding a new page is a matter of creating a new XAML file and including it in the project as a `PropertyPageSchema` item with the appropriate `Context` metadata.

--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -60,6 +60,8 @@ Add the following item to your .props or .targets file:
 </PropertyPageSchema>
 ```
 
+Note that the `Context` metadata must be present, and must have the value "Project". Rule objects such as the one defined in these .xaml files are used for multiple purposes in the project system; failing to specify the correct context may prevent your property page from being shown and/or cause bugs elsewhere.
+
 ### Step 4: Describe the property page
 
 Replace the contents of MyLaunchProfile.xaml with the following:

--- a/docs/repo/property-pages/how-to-add-a-new-project-property-page.md
+++ b/docs/repo/property-pages/how-to-add-a-new-project-property-page.md
@@ -60,6 +60,8 @@ Add the following item to your .props or .targets file:
 </PropertyPageSchema>
 ```
 
+Note that the `Context` metadata must be present, and must have the value "Project". Rule objects such as the one defined in these .xaml files are used for multiple purposes in the project system; failing to specify the correct context may prevent your property page from being shown and/or cause bugs elsewhere.
+
 ### Step 4: Describe the property page
 
 Replace the contents of MyPropertyPage.xaml with the following:

--- a/docs/repo/property-pages/how-to-extend-a-project-property-page.md
+++ b/docs/repo/property-pages/how-to-extend-a-project-property-page.md
@@ -47,6 +47,8 @@ Add the following item to your .props or .targets file:
 
 Note that order of `PropertyPageSchema` items is important, as that is the order in which extensions are applied. For this reason, the `PropertyPageSchema` item for extension page must come _after_ the item for the base page in the MSBuild evaluation.
 
+Note also that the `Context` metadata must be present, and must have the value "Project". Rule objects such as the one defined in these .xaml files are used for multiple purposes in the project system; failing to specify the correct context may prevent your property page from being shown and/or cause bugs elsewhere.
+
 ### Step 4: Describe the property page
 
 Replace the contents of MyExtendedApplicationPage.xaml with the following:

--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -25,11 +25,16 @@ Any rule file to be included in the UI must be added to the project's evaluation
 
 ```xml
 <ItemGroup>
-  <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\$(LocaleFolder)MyProjectPropertiesPage.xaml" />
+  <PropertyPageSchema Include="$(MSBuildThisFileDirectory)\$(LocaleFolder)MyProjectPropertiesPage.xaml">
+    <Context>Project</Context>
+  </PropertyPageSchema>
 </ItemGroup>
 ```
 
-Note that rules files contain display strings which must be localised. Depending upon how you produce your package, you will want to make sure that the localised file is included.
+A couple of things to note:
+
+- Rule files contain display strings which must be localised. Depending upon how you produce your package, you will want to make sure that the localised file is included.
+- The "Context" metadata must be set to "Project". Rule files have other uses (unrelated to the property page UI) in other parts of the project system; correct "Context" metadata is important to ensure they are only used as intended.
 
 ### Structure of a XAML rule file
 


### PR DESCRIPTION
Fixes #8418.

Update our property page documentation to reflect that a `PropertyPageSchema` item must include the appropriate `Context` metadata. If the `Context` is not supplied the `Rule` may be pulled into _all_ contexts; if it is not set to "Project" the item will not be found by the property pages. Either will cause bugs.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8440)