### PR TITLE
Update public pool names

### DIFF
--- a/eng/pipelines/integration-tests.yml
+++ b/eng/pipelines/integration-tests.yml
@@ -10,7 +10,7 @@ trigger: none
 jobs:
 - job: Visual_Studio
   pool:
-    name: NetCore1ESPool-Public
+    name: NetCore-Public
     # Image list: https://helix.dot.net/#1esPools
     demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   strategy:

--- a/eng/pipelines/one-loc-build.yml
+++ b/eng/pipelines/one-loc-build.yml
@@ -8,7 +8,7 @@ resources:
 - repo: self
   clean: true
 pool:
-  name: NetCore1ESPool-Public
+  name: NetCore-Public
   # Image list: https://helix.dot.net/#1esPools
   demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 15

--- a/eng/pipelines/richnav.yml
+++ b/eng/pipelines/richnav.yml
@@ -25,7 +25,7 @@ resources:
 - repo: self
   clean: true
 pool:
-  name: NetCore1ESPool-Public
+  name: NetCore-Public
   # Image list: https://helix.dot.net/#1esPools
   demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
   timeoutInMinutes: 15

--- a/eng/pipelines/unit-tests.yml
+++ b/eng/pipelines/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
     name: Windows_Debug
     configuration: Debug
     pool:
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       # Image list: https://helix.dot.net/#1esPools
       demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
 
@@ -39,7 +39,7 @@ jobs:
     name: Windows_Release
     configuration: Release
     pool:
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       # Image list: https://helix.dot.net/#1esPools
       demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
 
@@ -48,7 +48,7 @@ jobs:
     name: Spanish
     configuration: Debug
     pool: 
-      name: NetCore1ESPool-Public
+      name: NetCore-Public
       # Image list: https://helix.dot.net/#1esPools
       # NOTE: There currently is no Spanish VS 2022 image. Previous image was: Build.Windows.Amd64.VS2019.Pre.ES.Open
       # 'Scout' is the data-center image as to simply provide a different environment to test.


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8443)