### PR TITLE
Update public pool names

### DIFF
--- a/eng/pipelines/pull-request.yml
+++ b/eng/pipelines/pull-request.yml
@@ -31,7 +31,7 @@ trigger: none
 pool:
   # The max number of concurrent jobs that can be run in the pool is 820.
   # https://dnceng.visualstudio.com/public/_settings/agentqueues?queueId=396&view=jobs
-  name: NetCore1ESPool-Public
+  name: NetCore-Public
   # Demands Docs: https://docs.microsoft.com/azure/devops/pipelines/process/demands?view=azure-devops&tabs=yaml#manually-entered-demands
   # ImageOverride is used to select the image. See:
   # - https://dev.azure.com/dnceng/internal/_wiki/wikis/DNCEng%20Services%20Wiki/510/1ES-Hosted-Pools-Migration


### PR DESCRIPTION
This change is required for builds to continue working in the new org, dev.azure.com/dnceng-public.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8448)