### PR TITLE
Fix wrong behavior in Symbolic Renaming prompt

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -17,9 +17,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
     internal class FileMoveNotificationListener : IFileMoveNotificationListener
     {
-        private const string PromptNamespaceUpdate = "SolutionNavigator.PromptNamespaceUpdate";
-        private const string EnableNamespaceUpdate = "SolutionNavigator.EnableNamespaceUpdate";
-
         private readonly UnconfiguredProject _unconfiguredProject;
         private readonly IUserNotificationServices _userNotificationServices;
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
@@ -147,8 +144,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             {
                 ISettingsManager settings = await _settingsManagerService.GetValueAsync();
 
-                bool promptNamespaceUpdate = settings.GetValueOrDefault(PromptNamespaceUpdate, true);
-                bool enabledNamespaceUpdate = settings.GetValueOrDefault(EnableNamespaceUpdate, true);
+                bool promptNamespaceUpdate = settings.GetValueOrDefault(VsToolsOptions.OptionPromptNamespaceUpdate, true);
+                bool enabledNamespaceUpdate = settings.GetValueOrDefault(VsToolsOptions.OptionEnableNamespaceUpdate, true);
 
                 if (!enabledNamespaceUpdate || !promptNamespaceUpdate)
                 {
@@ -159,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
                 bool confirmation = _userNotificationServices.Confirm(VSResources.UpdateNamespacePromptMessage, out promptNamespaceUpdate);
 
-                await settings.SetValueAsync(PromptNamespaceUpdate, !promptNamespaceUpdate, true);
+                await settings.SetValueAsync(VsToolsOptions.OptionPromptNamespaceUpdate, !promptNamespaceUpdate, true);
 
                 return confirmation;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsToolsOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsToolsOptions.cs
@@ -1,0 +1,39 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS;
+
+/// <summary>
+///     Provides Pages, Categories, and Options related to VS menu Tools | Options.
+/// </summary>
+internal static class VsToolsOptions
+{
+    /// <summary>
+    /// Category Environment in Projects and Solutions
+    /// </summary>
+    public const string CategoryEnvironment = "Environment";
+
+    /// <summary>
+    /// Page Projects and Solutions in Tools | Options
+    /// </summary>
+    public const string PageProjectsAndSolution = "ProjectsAndSolution";
+
+    /// <summary>
+    /// "Enable symbolic renaming when renaming files" in Tools | Options | Projects and Solutions
+    /// </summary>
+    public const string OptionEnableSymbolicRename = "SolutionNavigator.EnableSymbolicRename";
+
+    /// <summary>
+    /// "Prompt for symbolic renaming when renaming files" in Tools | Options | Projects and Solutions
+    /// </summary>
+    public const string OptionPromptRenameSymbol = "PromptForRenameSymbol";
+
+    /// <summary>
+    /// "Prompt to update namespace when moving files" in Tools | Options | Projects and Solutions
+    /// </summary>
+    public const string OptionPromptNamespaceUpdate = "SolutionNavigator.PromptNamespaceUpdate";
+
+    /// <summary>
+    /// "Enable namespace update when moving files" in Tools | Options | Projects and Solutions
+    /// </summary>
+    public const string OptionEnableNamespaceUpdate = "SolutionNavigator.EnableNamespaceUpdate";
+}


### PR DESCRIPTION
Fixes #8441 

Fix wrong behavior in Enable symbolic renaming

if "Don't show again" is checked,
--  then persist UNcheck "prompt for symbolic renaming when renaming files"
-----   if "Yes", then persist check "enable symbolic renaming when renaming files"
-----   if "No", then persist UNcheck "enable symbolic renaming when renaming files"

If "Don't show again" is UNchecked, don't make changes to persisted values.

![fixGithubBug8453](https://user-images.githubusercontent.com/510598/187871443-b2d4197d-ad47-47d8-bb30-e5b7a4177e25.gif)
