### PR TITLE
Myapp and Settings file generator fixes

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Const HighDpiMode_PerMonitor = "PerMonitor"
         Private Const HighDpiMode_PerMonitorV2 = "PerMonitorV2"
         Private Const HighDpiMode_DpiUnawareGdiScaled = "DpiUnawareGdiScaled"
-        
+
         Friend Const SingleFileGeneratorName As String = "MyApplicationCodeGenerator"
 
         ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -10,6 +10,7 @@ Imports System.Runtime.InteropServices
 Imports EnvDTE
 
 Imports Microsoft.VisualStudio.Designer.Interfaces
+Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.OLE.Interop
 Imports Microsoft.VisualStudio.Shell
@@ -39,6 +40,14 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Const EnableVisualStylesFieldName As String = "EnableVisualStyles"
         Private Const SaveMySettingsOnExitFieldName As String = "SaveMySettingsOnExit"
         Private Const SplashScreenFieldName As String = "SplashScreen"
+        Private Const HighDpiModeFieldName As String = "HighDpiMode"
+
+        Private Const HighDpiMode_DpiUnaware = "DpiUnaware"
+        Private Const HighDpiMode_SystemAware = "SystemAware"
+        Private Const HighDpiMode_PerMonitor = "PerMonitor"
+        Private Const HighDpiMode_PerMonitorV2 = "PerMonitorV2"
+        Private Const HighDpiMode_DpiUnawareGdiScaled = "DpiUnawareGdiScaled"
+        
         Friend Const SingleFileGeneratorName As String = "MyApplicationCodeGenerator"
 
         ''' <summary>
@@ -220,6 +229,26 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     Debug.Fail("Unexpected MyApplication.ShutdownMode")
                 End If
                 
+                If IsTargetingDotNetCore(DirectCast(GetService(GetType(IVsHierarchy)), IVsHierarchy))
+                    '    Me.HighDpiMode = HighDpiMode.xxx
+                    Dim HighDpiValue As String
+                    Select Case MyApplication.HighDpiMode
+                        Case 0
+                            HighDpiValue = HighDpiMode_DpiUnaware
+                        Case 1
+                            HighDpiValue = HighDpiMode_SystemAware
+                        Case 2
+                            HighDpiValue = HighDpiMode_PerMonitor
+                        Case 3
+                            HighDpiValue = HighDpiMode_PerMonitorV2
+                        Case 4
+                            HighDpiValue = HighDpiMode_DpiUnawareGdiScaled
+                        Case Else
+                            HighDpiValue = String.Empty
+                    End Select
+                    AddFieldAssignment(Constructor, HighDpiModeFieldName, HighDpiModeFieldName, HighDpiValue)
+                End If
+                    
                 GeneratedType.Members.Add(Constructor)
 
                 If MyApplication.MainFormNoRootNS <> String.Empty Then

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -39,14 +39,6 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Const EnableVisualStylesFieldName As String = "EnableVisualStyles"
         Private Const SaveMySettingsOnExitFieldName As String = "SaveMySettingsOnExit"
         Private Const SplashScreenFieldName As String = "SplashScreen"
-        Private Const HighDpiModeFieldName As String = "HighDpiMode"
-
-        Private Const HighDpiMode_DpiUnaware = "DpiUnaware"
-        Private Const HighDpiMode_SystemAware = "SystemAware"
-        Private Const HighDpiMode_PerMonitor = "PerMonitor"
-        Private Const HighDpiMode_PerMonitorV2 = "PerMonitorV2"
-        Private Const HighDpiMode_DpiUnawareGdiScaled = "DpiUnawareGdiScaled"
-
         Friend Const SingleFileGeneratorName As String = "MyApplicationCodeGenerator"
 
         ''' <summary>
@@ -227,25 +219,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 Else
                     Debug.Fail("Unexpected MyApplication.ShutdownMode")
                 End If
-
-                '    Me.HighDpiMode = HighDpiMode.xxx
-                Dim HighDpiValue As String
-                Select Case MyApplication.HighDpiMode
-                    Case 0
-                        HighDpiValue = HighDpiMode_DpiUnaware
-                    Case 1
-                        HighDpiValue = HighDpiMode_SystemAware
-                    Case 2
-                        HighDpiValue = HighDpiMode_PerMonitor
-                    Case 3
-                        HighDpiValue = HighDpiMode_PerMonitorV2
-                    Case 4
-                        HighDpiValue = HighDpiMode_DpiUnawareGdiScaled
-                    Case Else
-                        HighDpiValue = String.Empty
-                End Select
-                AddFieldAssignment(Constructor, HighDpiModeFieldName, HighDpiModeFieldName, HighDpiValue)
-
+                
                 GeneratedType.Members.Add(Constructor)
 
                 If MyApplication.MainFormNoRootNS <> String.Empty Then

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -172,7 +172,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                     ' If this is the "default" settings file, we add the "My" module as well...
                     '
                     If shouldGenerateMyStuff Then
-                        AddMyModule(CompileUnit, projectRootNamespace, DesignUtil.GenerateValidLanguageIndependentNamespace(wszDefaultNamespace))
+                        AddMyModule(CompileUnit, projectRootNamespace, DesignUtil.GenerateValidLanguageIndependentNamespace(wszDefaultNamespace), isVB)
                     End If
                 End If
 
@@ -581,7 +581,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' </summary>
         ''' <param name="defaultNamespace">namespace into which we are generating (may be String.Empty)</param>
         ''' <param name="typeName">the type of the settings-class we are generating</param>
-        Private Shared Function GetFullTypeName(projectRootNamespace As String, defaultNamespace As String, typeName As String) As String
+        Private Shared Function GetFullTypeName(projectRootNamespace As String, defaultNamespace As String, typeName As String, isVb as Boolean) As String
 
             Dim fullTypeName As String = String.Empty
 
@@ -593,6 +593,10 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 fullTypeName &= defaultNamespace & "."
             End If
 
+            If isVb Then
+                fullTypeName &= MyNamespaceName + "."
+            End If
+            
             Debug.Assert(typeName <> "", "we shouldn't have an empty type-name when generating a Settings class")
             fullTypeName &= typeName
 
@@ -625,7 +629,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' My.Settings for easy access to typed-settings.
         ''' </summary>
         ''' <param name="Unit"></param>
-        Private Shared Sub AddMyModule(Unit As CodeCompileUnit, projectRootNamespace As String, defaultNamespace As String)
+        Private Shared Sub AddMyModule(Unit As CodeCompileUnit, projectRootNamespace As String, defaultNamespace As String, isVb as Boolean)
 
             Debug.Assert(Unit IsNot Nothing AndAlso Unit.Namespaces.Count = 1 AndAlso Unit.Namespaces(0).Types.Count = 1, "Expected a compile unit with a single namespace containing a single type!")
 
@@ -672,7 +676,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 .HasSet = False
             }
 
-            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name)) With {
+            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name, isVb)) With {
                 .Options = CodeTypeReferenceOptions.GlobalReference
             }
             SettingProperty.Type = fullTypeReference

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -593,7 +593,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 fullTypeName &= defaultNamespace & "."
             End If
 
-            If isVb Then
+            If isVb And Not fullTypeName.EndsWith("." + MyNamespaceName + ".") Then
                 fullTypeName &= MyNamespaceName + "."
             End If
             

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -129,7 +129,7 @@
         <NameValuePair.Value>
           (and 
             (has-evaluated-value "Application" "UseApplicationFramework" true)
-            (has-net-core-app-version-or-greater "3.0")
+            (has-net-core-app-version-or-greater "6.0")
           )
         </NameValuePair.Value>
       </NameValuePair>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -127,7 +127,10 @@
     <EnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
-          (has-evaluated-value "Application" "UseApplicationFramework" true)
+          (and 
+            (has-evaluated-value "Application" "UseApplicationFramework" true)
+            (has-net-core-app-version-or-greater "3.0")
+          )
         </NameValuePair.Value>
       </NameValuePair>
     </EnumProperty.Metadata>


### PR DESCRIPTION
This includes two fixes, as noted in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1591002/

1: HighDpiMode is not a valid property name for some netframework versions. It needs to be removed.
2: The generated My.Settings() property (shown below) was missing the "My" identifier if generated in a VB project. This has now been added
![image](https://user-images.githubusercontent.com/20359921/187965306-6afd0ae3-7154-4849-8154-5fbec7193d82.png)


This has been tested for:
WPF netframework VB: yes
WinForms netframework VB:
WPF netcore VB: yes
WinForms netcore VB: yes

WPF netframework C#: yes
WinForms netframework C#: yes
WPF netcore C#: yes
WinForms netcore C#: yes
