### PR TITLE
Dispose Roslyn workspaces when project unloads

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -129,7 +129,16 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                     _unconfiguredProject,
                     ProjectFaultSeverity.LimitedFunctionality),
                 linkOptions: DataflowOption.PropagateCompletion,
-                cancellationToken: cancellationToken)
+                cancellationToken: cancellationToken),
+
+            new DisposableDelegate(() =>
+            {
+                // Dispose all workspaces. Note that this happens within a lock, so we will not race with project updates.
+                foreach ((_, Workspace workspace) in workspaceBySlice)
+                {
+                    workspace.Dispose();
+                }
+            })
         };
 
         return;


### PR DESCRIPTION
Fixes [AB#1594395](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1594395)
Fixes [AB#1597595](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1597595)

This code path was missed during recent work on the language service. We must ensure that Roslyn's `IWorkspaceProjectContext` objects are disposed when the project is unloaded.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8455)