### PR TITLE
Add SourceLink to NuGet packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -55,6 +55,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
+    <!-- Sets deterministic compilation (/deterministic compiler flag) -->
+    <Deterministic>true</Deterministic>
 
     <!-- SourceLink properties -->
     <!-- https://github.com/dotnet/sourcelink#using-source-link-in-net-projects -->
@@ -66,9 +68,13 @@
     <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <!-- Marks the assembly be built in a determinstic way. -->
-    <!-- See: https://github.com/dotnet/sdk/issues/16325#issuecomment-981818164 -->
-    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    <!-- Controls both the compiler determinism (same as Deterministic) and turns on normalized PDB paths, which may break local debugging scenarios. -->
+    <!-- We only want this on for CIBuild, so PDB files point to the local source locations on disk, making finding local files easy during debugging. -->
+    <!-- See:
+      - https://github.com/dotnet/sdk/issues/16325#issuecomment-981818164 
+      - https://github.com/dotnet/project-system/pull/8464#discussion_r965499524
+    -->
+    <ContinuousIntegrationBuild Condition="'$(CIBuild)' == 'true'">true</ContinuousIntegrationBuild>
 
     <!-- Test project properties -->
     <IsUnitTestProject Condition="'$(IsUnitTestProject)' == ''">false</IsUnitTestProject>
@@ -114,6 +120,7 @@
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=529443</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/dotnet/project-system</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
+    <RepositoryType>git</RepositoryType>
     <!-- By default, do not build a NuGet package for a project. -->
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,9 +54,21 @@
     <ForceGenerationOfBindingRedirects>true</ForceGenerationOfBindingRedirects>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
-    <!-- TODO: Might be related to: https://github.com/dotnet/project-system/issues/5619 -->
-    <EnableSourceLink Condition="'$(CIBuild)' == 'true'">true</EnableSourceLink>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
+
+    <!-- SourceLink properties -->
+    <!-- https://github.com/dotnet/sourcelink#using-source-link-in-net-projects -->
+    <EnableSourceLink>true</EnableSourceLink>
+    <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!-- Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Marks the assembly be built in a determinstic way. -->
+    <!-- See: https://github.com/dotnet/sdk/issues/16325#issuecomment-981818164 -->
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
 
     <!-- Test project properties -->
     <IsUnitTestProject Condition="'$(IsUnitTestProject)' == ''">false</IsUnitTestProject>

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb"      ExcludeAssets="all" GeneratePathProperty="true" />
     <!-- Path Property: PkgCodecov -->
     <PackageReference Include="Codecov"                             ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub"         PrivateAssets="all" />
 
     <!-- CPS -->
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" />

--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -15,6 +15,7 @@
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="1.1.0-beta2-22320-02" />
     <!-- This package is deprecated. CodecovUploader is now the recommended package. -->
     <PackageReference Update="Codecov"                                                                Version="1.13.0" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub"                                            Version="1.1.1" />
 
     <!-- VS SDK -->
     <PackageReference Update="EnvDTE"                                                                 Version="17.0.32112.339" />

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -627,4 +627,11 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
 
+  <!-- This is required for SourceLink to find these .xaml files within the generated .g.cs files. -->
+  <!-- Note that the filepath for the file MUST be nested within itself in the destination, as the .g.cs files include the relative nested path. -->
+  <!-- See: https://github.com/dotnet/sourcelink/issues/492 -->
+  <Target Name="CopyDependentUponXamlFiles" BeforeTargets="CoreCompile">
+    <Copy SourceFiles="OptionPages\GeneralOptionPageControl.xaml" DestinationFiles="$(IntermediateOutputPath)\OptionPages\OptionPages\GeneralOptionPageControl.xaml" SkipUnchangedFiles="true" />
+  </Target>
+
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj
@@ -77,8 +77,8 @@
 
   <ItemGroup>
     <Page Include="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml">
       <Generator>MSBuild:Compile</Generator>
@@ -116,5 +116,13 @@
     <AdditionalFiles Include="PublicAPI.Shipped.txt" />
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
+
+  <!-- This is required for SourceLink to find these .xaml files within the generated .g.cs files. -->
+  <!-- Note that the filepath for the file MUST be nested within itself in the destination, as the .g.cs files include the relative nested path. -->
+  <!-- See: https://github.com/dotnet/sourcelink/issues/492 -->
+  <Target Name="CopyDependentUponXamlFiles" BeforeTargets="CoreCompile">
+    <Copy SourceFiles="ProjectSystem\VS\PropertyPages\DebugPageControl.xaml" DestinationFiles="$(IntermediateOutputPath)\ProjectSystem\VS\PropertyPages\ProjectSystem\VS\PropertyPages\DebugPageControl.xaml" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml" DestinationFiles="$(IntermediateOutputPath)\ProjectSystem\VS\PropertyPages\ProjectSystem\VS\PropertyPages\GetProfileNameDialog.xaml" SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/5619

Adds the SourceLink functionality to our NuGet packages. It also makes our build marked with the deterministic flag.

### Verification
I used the [NuGet Package Explorer](https://github.com/NuGetPackageExplorer/NuGetPackageExplorer) to verify the packages. When they started, they looked like this:
![image](https://user-images.githubusercontent.com/17788297/189013093-803ad547-09b8-4571-99a4-6ac26874e69f.png)

I enabled SourceLink but it was still showing issues. Seems I needed the `EmbedUntrackedSources` setting.
![image](https://user-images.githubusercontent.com/17788297/189013202-67858826-adb3-4556-b585-2604102c34b6.png)

After adding `EmbedUntrackedSources`, the build was broken. After some investigation, I found an issue that was reported for the problem, but no workaround: https://github.com/dotnet/sourcelink/issues/492 \
I looked into how the generated `.g.cs` files wanted to reference the `.xaml`. Then, I determined how to output them to that path. I added those targets to the affected projects. After that, we had SourceLink working.
![image](https://user-images.githubusercontent.com/17788297/189013412-63c771f0-2271-447b-9f86-6b085e692b73.png)

I noticed the *Deterministic* flag was still red. Found that I needed to add `ContinuousIntegrationBuild` for it to add the `/deterministic` compiler flag. After that, everything was green.
![image](https://user-images.githubusercontent.com/17788297/189013605-bfb3edf2-61f1-4db0-8c79-8ccdfc557b19.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8464)