### PR TITLE
Add APIScan retry mechanism

### DIFF
--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -3,7 +3,6 @@
 jobs:
 - job: AnalyzeAPI
   displayName: Analyze API
-  timeoutInMinutes: 90
   steps:
 
   ###################################################################################################################################################################
@@ -58,6 +57,9 @@ jobs:
     # This value is provided from the DotNet-Project-System variable group, defined in the stage variables.
     env:
       AzureServicesAuthConnectionString: $(ApiScanConnectionString)
+    # Add a timeout with a retry count in an attempt to workaround timeout failures that have been occurring with the task itself.
+    retryCountOnTaskFailure: 2
+    timeoutInMinutes: 120
 
   ###################################################################################################################################################################
   # PUBLISH RESULTS


### PR DESCRIPTION
Added a retry with timeout mechanism to APIScan task. This task has been timing out recently (going beyond 90 mins). Here, I remove the timeout for the job itself and instead, add a 2 hour timeout for the APIScan task, with the retry count of 2. This means it'll run 3 times total before failing.

### Test Run
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6660256&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8465)