### PR TITLE
APIScan with retries and ignoring failure

### DIFF
--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -57,9 +57,11 @@ jobs:
     # This value is provided from the DotNet-Project-System variable group, defined in the stage variables.
     env:
       AzureServicesAuthConnectionString: $(ApiScanConnectionString)
-    # Add a timeout with a retry count in an attempt to workaround timeout failures that have been occurring with the task itself.
+    # Add a retry count in an attempt to workaround timeout failures that have been occurring with the task itself.
+    # You cannot have both a retry count and a timeout. See: https://stackoverflow.com/questions/71582213/how-can-you-handle-retrycountontaskfailure-and-timeoutinminutes-together
     retryCountOnTaskFailure: 2
-    timeoutInMinutes: 120
+    # This task is causing problems because of timeouts. Make it still succeed, even if it times out.
+    continueOnError: true
 
   ###################################################################################################################################################################
   # PUBLISH RESULTS


### PR DESCRIPTION
Made it so ApiScan will actually retry now. Also made it so that if it fails, the failures are ignored.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8468)