### PR TITLE
Fix stack overflow in dependencies tree search

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeConfiguredProjectSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeConfiguredProjectSearchContext.cs
@@ -66,6 +66,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
                 var allParentItems = new List<object>();
 
+                childItem.ContainedByCollection = new AggregateContainedByRelationCollection(allParentItems);
+
                 foreach (IRelation relation in containedByRelations)
                 {
                     IEnumerable<IRelatableItem>? relationParentItems = relation.CreateContainedByItems(childItem);
@@ -91,8 +93,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                         }
                     }
                 }
-
-                childItem.ContainedByCollection = new AggregateContainedByRelationCollection(allParentItems);
             }
 
             IRelatableItem DeduplicateItem(IRelatableItem item)


### PR DESCRIPTION
Fixes [AB#1613079](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1613079)

That feedback ticket showed a stack overflow when populating the parent items of a given search hit. While I do not yet have a repro for the bug, it appears this would only have been possible if an item was its own parent. I do not know how this might occur in practice, but we should defend against it in theory.

The fix here is to ensure that the `ContainedByCollection` property is non-null earlier, as we test this property on the parent to see whether we need to recur. If the parent and the child were the same, previously we would have seen a null and invoked the recursion. With this change, we set the value to non-null before walking parents, which prevents this error.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8472)