### PR TITLE
VS Build Tools 'removal' + no longer deploy to exp-hive in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,15 @@ There are many technologies that come together to make up the .NET Project Syste
 ## How do I build the repository?
 This repository is built on .NET Framework and requires the .NET Framework version of [MSBuild](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=vs-2022) to build successfully. Additionally, there is a dependency on the [Visual Studio SDK](https://docs.microsoft.com/en-us/visualstudio/extensibility/starting-to-develop-visual-studio-extensions?view=vs-2022) as the .NET Project System is bundled as a Visual Studio Extension for deployment into Visual Studio.
 
-Here are the two ways to acquire the necessary components:
+Here is how to acquire the necessary components:
 - Install the latest [Visual Studio](https://visualstudio.microsoft.com/downloads/)
-- Install [Build Tools for Visual Studio](https://visualstudio.microsoft.com/downloads/?q=build+tools#build-tools-for-visual-studio-2022)
-
-For either option, these workloads should be installed:
-- .NET desktop build tools
-- Visual Studio extension development
+  - Select these workloads during installation:
+    - .NET desktop build tools
+    - Visual Studio extension development
 
 ![image](docs/repo/images/workloads-for-building-the-repo.png)
 
 After the necessary components are installed, simply run the `build.cmd` batch file at the root of the repository. This will build, test, and bundle the repository appropriately.
-
-**NOTE:** When using the *Build Tools for Visual Studio*, the basic call to **build.cmd** will fail. It will attempt to deploy to the *Exp* hive (for debugging the .NET Project System) which it cannot do if full Visual Studio is not installed. Additionally, some tests will fail. To build without failures in this situation, run `build.cmd /p:DeployExtension=false /p:Test=false`.
 
 ### **build.cmd** flags
 All the command line arguments provided to **build.cmd** get forwarded to MSBuild. There are some special properties we've set up for building this repo.

--- a/eng/scripts/GetMSBuildPath.ps1
+++ b/eng/scripts/GetMSBuildPath.ps1
@@ -17,5 +17,6 @@ if(-Not $version)
   $version = "$(. "$PSScriptRoot\GetVisualStudioMinimumVersion.ps1").0"
 }
 
-# Note: Along with VS installations, this finds BuildTools' MSBuild.exe via '-products *'. However, the repo currently cannot deploy the VS Extensions via BuildTools.
-(& "$installerPath\vswhere.exe" -all -prerelease -latest -version $version -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe) | Select-Object -First 1
+# This only identifies Visual Studio installations since we do not use the '-products *' parameter. Otherwise, it would also include Visual Studio Build Tools.
+# See: https://github.com/microsoft/vswhere/wiki/FAQ#why-doesnt-vswhere-find-visual-studio-build-tools
+(& "$installerPath\vswhere.exe" -all -prerelease -latest -version $version -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe) | Select-Object -First 1

--- a/setup/Directory.Build.props
+++ b/setup/Directory.Build.props
@@ -32,7 +32,7 @@
     <IsPackable>false</IsPackable>
     <BuildForLiveUnitTesting>false</BuildForLiveUnitTesting>
     <!-- Runs the DeployVsixExtensionFiles from the VSSDK to enable the extension on the local machine. -->
-    <DeployExtension>true</DeployExtension>
+    <DeployExtension Condition="'$(CIBuild)' != 'true'">true</DeployExtension>
 
     <StartAction>Program</StartAction>
     <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>


### PR DESCRIPTION
Resolves: https://github.com/dotnet/project-system/issues/8319

### Changes
- Remove the recommendation and inclusion of [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/?q=build+tools#build-tools-for-visual-studio-2022) as an option for building the repo.
  - This was decided in the linked issue above to be our desired outcome, since users can install VS Community edition for free if they want to build our repo.
- Set DeployExtension to only happen locally.
  - This was pointed out by @wade0016 to save time on CI builds, since deploying the extensions we build (to the experimental hive) are not used by the CI machines in any way.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8473)