### PR TITLE
Path exclusion removal for PRs

### DIFF
--- a/eng/pipelines/pull-request.yml
+++ b/eng/pipelines/pull-request.yml
@@ -19,10 +19,6 @@ pr:
     - dev*
     # Any other branches that contain major feature development.
     - feature/*
-  paths:
-    exclude:
-    - docs/*
-    - README.md
 
 # Disable CI builds for this pipeline.
 # See: https://docs.microsoft.com/azure/devops/pipelines/yaml-schema/trigger?view=azure-pipelines#examples


### PR DESCRIPTION
### Summary
Remove excluding certain paths that only contain changes in a PR. 

### Details
@tmeschter ran into [this situation](https://github.com/dotnet/project-system/pull/8440#issuecomment-1238817230) recently with some PRs where the only changes were document related. The issue is, the PR pipeline was filtering out running builds for that situation; but running the PR builds is a `required` check. Thus, the PR is never able to be 'green'. To merge, he had to override the checks and merge it manually. The situation looks similar to this:
![image](https://user-images.githubusercontent.com/17788297/189249701-010eb53f-4bb0-4e98-bb26-d1b3765a7e3d.png)

After some research, I found the recommended solution for this: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

This solution requires a couple things since we are using Azure Pipelines:
- An additional `.yml` pipeline file that includes only these paths (`docs/*` and `README.md`) and simply does a no-op task to succeed.
- An additional pipeline defined in Azure Pipelines that is associated with this dummy `.yml` pipeline.

Since that seems like a crazy amount of overhead, and that both of these pipelines need to keep parity on the file filters they include/exclude, I decided it is much, much easier to simply have no exclude paths. We still have these exclude paths for `official.yml`, which means we won't make new signed builds/insertions based on docs-only changes; but it does mean that every PR will run a build (which really isn't a bad thing). It is such a niche situation that this is the simplest resolution.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8474)