### PR TITLE
Ensure the first workspace update is from evaluation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
@@ -88,6 +88,69 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 severity: ProjectFaultSeverity.LimitedFunctionality,
                 nameFormat: "Workspace update handler {0}");
 
+        #region Ordering evaluation before first build
+
+        // This dataflow block will ensure that the first output item is always evaluation data.
+        // We need that behaviour for the Workspace, which creates the Roslyn object in response
+        // to evaluation data, and needs that Roslyn object when build data is processed.
+        //
+        // This block works by buffering any build data that arrives ahead of the first evaluation
+        // data.
+
+        List<IProjectVersionedValue<WorkspaceUpdate>>? bufferedBuilds = new() { null! };
+
+        IPropagatorBlock<IProjectVersionedValue<WorkspaceUpdate>, IProjectVersionedValue<WorkspaceUpdate>> orderingBlock
+            = DataflowBlockSlim.CreateTransformManyBlock<IProjectVersionedValue<WorkspaceUpdate>, IProjectVersionedValue<WorkspaceUpdate>>(input =>
+                {
+                    if (input.Value.EvaluationUpdate is not null)
+                    {
+                        if (bufferedBuilds is null)
+                        {
+                            // Second or later evaluation update. Handle normally.
+                        }
+                        else if (bufferedBuilds is { Count: 1 })
+                        {
+                            // First evaluation data, and no build data was buffered. Handle normally.
+                            bufferedBuilds = null!;
+                        }
+                        else
+                        {
+                            // First evaluation data, and we have buffered build data.
+                            // Prepend the evaluation in the first slot (we reserved an empty position here).
+                            bufferedBuilds[0] = input;
+                            // Null out the reference for future callers, and return this collection of output
+                            // items for this input.
+                            IEnumerable<IProjectVersionedValue<WorkspaceUpdate>> result = bufferedBuilds;
+                            bufferedBuilds = null;
+                            return result;
+                        }
+                    }
+                    else if (input.Value.BuildUpdate is not null)
+                    {
+                        if (bufferedBuilds is not null)
+                        {
+                            // We are buffering build data until some later point at which evaluation
+                            // data arrives. Add it to the queue.
+                            bufferedBuilds.Add(input);
+
+                            // Return an empty enumerable. We don't yet want to produce any outputs.
+                            return Enumerable.Empty<IProjectVersionedValue<WorkspaceUpdate>>();
+                        }
+                    }
+                    else
+                    {
+                        throw Assumes.NotReachable();
+                    }
+
+                    // If we got here, we return the input item unchanged (just wrapped in an array).
+                    return new[] { input };
+                },
+                new ExecutionDataflowBlockOptions { NameFormat = "Workspace update ordering {0}" });
+
+        workspace.ChainDisposal(orderingBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion));
+
+        #endregion
+
         #region Evaluation data
 
         var evaluationTransformBlock
@@ -104,7 +167,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 linkOptions: DataflowOption.PropagateCompletion,
                 cancellationToken: cancellationToken),
 
-            evaluationTransformBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion),
+            evaluationTransformBlock.LinkTo(orderingBlock, DataflowOption.PropagateCompletion),
 
             ProjectDataSources.JoinUpstreamDataSources(joinableTaskFactory, _projectService.Services.FaultHandler, source.ProjectRuleSource, source.SourceItemsRuleSource)
         });
@@ -136,7 +199,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 target: buildTransformBlock,
                 linkOptions: DataflowOption.PropagateCompletion),
 
-            buildTransformBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion),
+            buildTransformBlock.LinkTo(orderingBlock, DataflowOption.PropagateCompletion),
 
             ProjectDataSources.JoinUpstreamDataSources(joinableTaskFactory, _projectService.Services.FaultHandler, source.ActiveConfiguredProjectSource, source.ProjectBuildRuleSource, commandLineArgumentsBlock)
         });


### PR DESCRIPTION
Fixes [AB#1586247](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1586247)

In the language service host, we need to process evaluation data before design-time build data. We need an evaluation to create the Roslyn workspace object, and we need that workspace to apply build data.

In practice, build data can arrive first. This may be due to caching, for example. We see this unexpected ordering more on perf lab machines too, interestingly.

The previous code didn't handle the out-of-order case correctly. If build data arrived first, it would block waiting for evaluation data. However the upstream TPL action block serialises callbacks, so any future update that might unblock the build data handler cannot run, leading to deadlock.

The fix here uses a `TransformManyBlock` to allow any initial build updates to be queued until evaluation data arrives. The downstream handler (`Workspace.OnWorkspaceUpdateAsync`) will therefore always receive an evaluation update first.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8475)