### PR TITLE
[17.4p2] Ensure the first workspace update is from evaluation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -43,9 +43,6 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     private readonly CancellationToken _unloadCancellationToken;
     private readonly string _baseDirectory;
 
-    /// <summary>Completes when the workspace has integrated evaluation data.</summary>
-    private readonly TaskCompletionSource _hasEvaluationData = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
     /// <summary>Completes when the workspace has integrated build data.</summary>
     private readonly TaskCompletionSource _hasBuildData = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -125,7 +122,6 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     {
         _state = WorkspaceState.Disposed;
 
-        _hasEvaluationData.TrySetCanceled();
         _hasBuildData.TrySetCanceled();
 
         _disposableBag.Dispose();
@@ -203,8 +199,6 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
             applyFunc: ApplyProjectEvaluation,
             _unloadCancellationToken);
 
-        _hasEvaluationData.TrySetResult();
-
         return;
 
         async Task ProcessInitialEvaluationDataAsync(CancellationToken cancellationToken)
@@ -224,10 +218,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
                 // Insufficient data to initialize the language service.
                 _state = WorkspaceState.Failed;
 
-                Exception ex = new("Insufficient project data to initialize the language service.");
-                _hasEvaluationData.TrySetException(ex);
-
-                throw ex;
+                throw new("Insufficient project data to initialize the language service.");
             }
 
             try
@@ -375,10 +366,9 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         Assumes.NotNull(_buildProgressRegistration);
 
         // The Roslyn workspace context is created when the first evaluation data arrives.
-        // It's possible that build data arrives before evaluation data, in which case
-        // the Roslyn context would be null. To prevent problems, we wait for evaluation
-        // data to have been processed at least once before continuing.
-        await _hasEvaluationData.Task;
+        // Upstream caller must ensure that build updates are delayed until the first
+        // evaluation update is processed.
+        Assumes.True(_seenEvaluation);
 
         await OnProjectChangedAsync(
             _buildProgressRegistration,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
@@ -88,6 +88,69 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 severity: ProjectFaultSeverity.LimitedFunctionality,
                 nameFormat: "Workspace update handler {0}");
 
+        #region Ordering evaluation before first build
+
+        // This dataflow block will ensure that the first output item is always evaluation data.
+        // We need that behaviour for the Workspace, which creates the Roslyn object in response
+        // to evaluation data, and needs that Roslyn object when build data is processed.
+        //
+        // This block works by buffering any build data that arrives ahead of the first evaluation
+        // data.
+
+        List<IProjectVersionedValue<WorkspaceUpdate>>? bufferedBuilds = new() { null! };
+
+        IPropagatorBlock<IProjectVersionedValue<WorkspaceUpdate>, IProjectVersionedValue<WorkspaceUpdate>> orderingBlock
+            = DataflowBlockSlim.CreateTransformManyBlock<IProjectVersionedValue<WorkspaceUpdate>, IProjectVersionedValue<WorkspaceUpdate>>(input =>
+                {
+                    if (input.Value.EvaluationUpdate is not null)
+                    {
+                        if (bufferedBuilds is null)
+                        {
+                            // Second or later evaluation update. Handle normally.
+                        }
+                        else if (bufferedBuilds is { Count: 1 })
+                        {
+                            // First evaluation data, and no build data was buffered. Handle normally.
+                            bufferedBuilds = null!;
+                        }
+                        else
+                        {
+                            // First evaluation data, and we have buffered build data.
+                            // Prepend the evaluation in the first slot (we reserved an empty position here).
+                            bufferedBuilds[0] = input;
+                            // Null out the reference for future callers, and return this collection of output
+                            // items for this input.
+                            IEnumerable<IProjectVersionedValue<WorkspaceUpdate>> result = bufferedBuilds;
+                            bufferedBuilds = null;
+                            return result;
+                        }
+                    }
+                    else if (input.Value.BuildUpdate is not null)
+                    {
+                        if (bufferedBuilds is not null)
+                        {
+                            // We are buffering build data until some later point at which evaluation
+                            // data arrives. Add it to the queue.
+                            bufferedBuilds.Add(input);
+
+                            // Return an empty enumerable. We don't yet want to produce any outputs.
+                            return Enumerable.Empty<IProjectVersionedValue<WorkspaceUpdate>>();
+                        }
+                    }
+                    else
+                    {
+                        throw Assumes.NotReachable();
+                    }
+
+                    // If we got here, we return the input item unchanged (just wrapped in an array).
+                    return new[] { input };
+                },
+                new ExecutionDataflowBlockOptions { NameFormat = "Workspace update ordering {0}" });
+
+        workspace.ChainDisposal(orderingBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion));
+
+        #endregion
+
         #region Evaluation data
 
         var evaluationTransformBlock
@@ -104,7 +167,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 linkOptions: DataflowOption.PropagateCompletion,
                 cancellationToken: cancellationToken),
 
-            evaluationTransformBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion),
+            evaluationTransformBlock.LinkTo(orderingBlock, DataflowOption.PropagateCompletion),
 
             ProjectDataSources.JoinUpstreamDataSources(joinableTaskFactory, _projectService.Services.FaultHandler, source.ProjectRuleSource, source.SourceItemsRuleSource)
         });
@@ -136,7 +199,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 target: buildTransformBlock,
                 linkOptions: DataflowOption.PropagateCompletion),
 
-            buildTransformBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion),
+            buildTransformBlock.LinkTo(orderingBlock, DataflowOption.PropagateCompletion),
 
             ProjectDataSources.JoinUpstreamDataSources(joinableTaskFactory, _projectService.Services.FaultHandler, source.ActiveConfiguredProjectSource, source.ProjectBuildRuleSource, commandLineArgumentsBlock)
         });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceFactoryTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
+
+using System.Threading.Tasks;
+using System.Threading.Tasks.Dataflow;
+using Microsoft.VisualStudio.Threading;
+
+public class WorkspaceFactoryTests
+{
+    [Fact]
+    public async Task WorkspaceUpdateOrderingBlock_UsualSequence()
+    {
+        var u1 = EvaluationUpdate();
+        var u2 = BuildUpdate();
+        var u3 = EvaluationUpdate();
+        var u4 = BuildUpdate();
+
+        await VerifyOrderAsync(
+            inputs:  new[] { u1, u2, u3, u4 },
+            outputs: new[] { u1, u2, u3, u4 }); // sequence is unchanged
+    }
+
+    [Fact]
+    public async Task WorkspaceUpdateOrderingBlock_BuildBeforeEvaluation()
+    {
+        var u1 = BuildUpdate();
+        var u2 = BuildUpdate();
+        var u3 = BuildUpdate();
+        var u4 = EvaluationUpdate();
+        var u5 = BuildUpdate();
+        var u6 = EvaluationUpdate();
+
+        await VerifyOrderAsync(
+            inputs:  new[] { u1, u2, u3, u4, u5, u6 },
+            outputs: new[] { u4, u1, u2, u3, u5, u6 });
+        //                   |<----------~~ evaluation moved forward
+    }
+
+    private static async Task VerifyOrderAsync(
+        IReadOnlyList<IProjectVersionedValue<WorkspaceUpdate>> inputs,
+        IReadOnlyList<IProjectVersionedValue<WorkspaceUpdate>> outputs)
+    {
+        var orderingBlock = WorkspaceFactory.CreateWorkspaceUpdateOrderingBlock();
+
+        var broadcastBlock = new BroadcastBlock<IProjectVersionedValue<WorkspaceUpdate>>(null);
+
+        broadcastBlock.LinkTo(orderingBlock, DataflowOption.PropagateCompletion);
+
+        List<IProjectVersionedValue<WorkspaceUpdate>> actualOutputs = new();
+
+        var actionBlock = new ActionBlock<IProjectVersionedValue<WorkspaceUpdate>>(actualOutputs.Add);
+
+        orderingBlock.LinkTo(actionBlock, DataflowOption.PropagateCompletion);
+
+        foreach (var input in inputs)
+        {
+            await broadcastBlock.SendAsync(input);
+        }
+
+        broadcastBlock.Complete();
+
+        await actionBlock.Completion.WithTimeout(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(outputs.Count, actualOutputs.Count);
+
+        for (int i = 0; i < outputs.Count; i++)
+        {
+            Assert.Same(outputs[i], actualOutputs[i]);
+        }
+    }
+
+    private static IProjectVersionedValue<WorkspaceUpdate> EvaluationUpdate()
+    {
+        ConfiguredProject configuredProject = ConfiguredProjectFactory.Create();
+        IProjectSubscriptionUpdate evaluationRuleUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
+        IProjectSubscriptionUpdate sourceItemsUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
+        var workspaceUpdate = WorkspaceUpdate.FromEvaluation((configuredProject, evaluationRuleUpdate, sourceItemsUpdate));
+
+        return new ProjectVersionedValue<WorkspaceUpdate>(
+            workspaceUpdate,
+            dataSourceVersions: ImmutableDictionary<NamedIdentity, IComparable>.Empty);
+    }
+
+    private static IProjectVersionedValue<WorkspaceUpdate> BuildUpdate()
+    {
+        ConfiguredProject configuredProject = ConfiguredProjectFactory.Create();
+        IProjectSubscriptionUpdate buildRuleUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
+        CommandLineArgumentsSnapshot commandLineArguments = new(ImmutableArray<string>.Empty, isChanged: false);
+        var workspaceUpdate = WorkspaceUpdate.FromBuild((configuredProject, buildRuleUpdate, commandLineArguments));
+
+        return new ProjectVersionedValue<WorkspaceUpdate>(
+            workspaceUpdate,
+            dataSourceVersions: ImmutableDictionary<NamedIdentity, IComparable>.Empty);
+    }
+}


### PR DESCRIPTION
This is the 17.4p2 version of #8475. See that PR for a description.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8476)