### PR TITLE
Use full-form literals for telemetry const strings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
@@ -55,8 +55,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
             // with the click-through rate for more information.
             var telemetryEvent = new TelemetryEvent(TelemetryEventName.IncrementalBuildValidationFailureDisplayed);
 
-            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildFailureReason, failureReason);
-            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildValidationDurationMillis, checkDuration);
+            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildValidation.FailureReason, failureReason);
+            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildValidation.DurationMillis, checkDuration);
 
             TelemetryService.DefaultSession.PostEvent(telemetryEvent);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureTelemetryReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureTelemetryReporter.cs
@@ -48,8 +48,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
 
             var telemetryEvent = new TelemetryEvent(TelemetryEventName.IncrementalBuildValidationFailure);
 
-            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildFailureReason, failureReason);
-            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildValidationDurationMillis, checkDuration);
+            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildValidation.FailureReason, failureReason);
+            telemetryEvent.Properties.Add(TelemetryPropertyName.IncrementalBuildValidation.DurationMillis, checkDuration);
 
             TelemetryService.DefaultSession.PostEvent(telemetryEvent);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -224,9 +224,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             {
                 _telemetryService.PostProperties(TelemetryEventName.NuGetRestoreCycleDetected, new[]
                 {
-                    (TelemetryPropertyName.NuGetRestoreCycleDetectedRestoreDurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
-                    (TelemetryPropertyName.NuGetRestoreCycleDetectedRestoreSuccesses, _nuGetRestoreSuccesses),
-                    (TelemetryPropertyName.NuGetRestoreCycleDetectedRestoreCyclesDetected, _nuGetRestoreCyclesDetected)
+                    (TelemetryPropertyName.NuGetRestoreCycleDetected.RestoreDurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
+                    (TelemetryPropertyName.NuGetRestoreCycleDetected.RestoreSuccesses, _nuGetRestoreSuccesses),
+                    (TelemetryPropertyName.NuGetRestoreCycleDetected.RestoreCyclesDetected, _nuGetRestoreCyclesDetected)
                 });
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PropertyPages/DebugPageControl.xaml.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
                         cell?.Focus();
                         dataGridEnvironmentVariables.BeginEdit();
                     }
-                }).FileAndForget(TelemetryEventName.Prefix);
+                }).FileAndForget(TelemetryEventName.Fault);
 #pragma warning restore RS0030 // Do not used banned APIs
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.cs
@@ -164,10 +164,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 compileStopWatch!.Stop();
                 _telemetryService.PostProperties(TelemetryEventName.TempPEProcessQueue, new[]
                 {
-                    ( TelemetryPropertyName.TempPECompileCount,        (object)compileCount),
-                    ( TelemetryPropertyName.TempPEInitialQueueLength,  initialQueueLength),
-                    ( TelemetryPropertyName.TempPECompileWasCancelled, cancelled),
-                    ( TelemetryPropertyName.TempPECompileDuration,     compileStopWatch.ElapsedMilliseconds)
+                    ( TelemetryPropertyName.TempPE.CompileCount,        (object)compileCount),
+                    ( TelemetryPropertyName.TempPE.InitialQueueLength,  initialQueueLength),
+                    ( TelemetryPropertyName.TempPE.CompileWasCancelled, cancelled),
+                    ( TelemetryPropertyName.TempPE.CompileDuration,     compileStopWatch.ElapsedMilliseconds)
                 });
             }
         }
@@ -204,7 +204,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             {
                 _telemetryService.PostProperties(TelemetryEventName.TempPECompileOnDemand, new[]
                 {
-                    ( TelemetryPropertyName.TempPEInitialQueueLength, (object)initialQueueLength)
+                    ( TelemetryPropertyName.TempPE.InitialQueueLength, (object)initialQueueLength)
                 });
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/DesignTimeTelemetryLogger.cs
@@ -65,8 +65,8 @@ namespace Microsoft.VisualStudio.Telemetry
 
             _telemetryService.PostProperties(TelemetryEventName.DesignTimeBuildComplete, new[]
             {
-                (TelemetryPropertyName.DesignTimeBuildCompleteSucceeded, (object)_succeeded),
-                (TelemetryPropertyName.DesignTimeBuildCompleteTargets, targetResults)
+                (TelemetryPropertyName.DesignTimeBuildComplete.Succeeded, (object)_succeeded),
+                (TelemetryPropertyName.DesignTimeBuildComplete.Targets, targetResults)
             });
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Telemetry/VsTelemetryService.cs
@@ -51,11 +51,11 @@ namespace Microsoft.VisualStudio.Telemetry
         private void PostTelemetryEvent(TelemetryEvent telemetryEvent)
         {
 #if DEBUG
-            Assumes.True(telemetryEvent.Name.StartsWith(TelemetryEventName.Prefix, StringComparisons.TelemetryEventNames));
+            Assumes.True(telemetryEvent.Name.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
 
             foreach (string propertyName in telemetryEvent.Properties.Keys)
             {
-                Assumes.True(propertyName.StartsWith(TelemetryPropertyName.Prefix, StringComparisons.TelemetryEventNames));
+                Assumes.True(propertyName.StartsWith("vs.projectsystem.managed.", StringComparisons.TelemetryEventNames));
             }
 #endif
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyTreeTelemetryService.cs
@@ -130,16 +130,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
             {
                 _telemetryService.PostProperties(TelemetryEventName.TreeUpdatedUnresolved, new[]
                 {
-                    (TelemetryPropertyName.TreeUpdatedUnresolvedProject, (object)_projectId),
-                    (TelemetryPropertyName.TreeUpdatedUnresolvedObservedAllRules, observedAllRules)
+                    (TelemetryPropertyName.TreeUpdated.UnresolvedProject, (object)_projectId),
+                    (TelemetryPropertyName.TreeUpdated.UnresolvedObservedAllRules, observedAllRules)
                 });
             }
             else
             {
                 _telemetryService.PostProperties(TelemetryEventName.TreeUpdatedResolved, new[]
                 {
-                    (TelemetryPropertyName.TreeUpdatedResolvedProject, (object)_projectId),
-                    (TelemetryPropertyName.TreeUpdatedResolvedObservedAllRules, observedAllRules)
+                    (TelemetryPropertyName.TreeUpdated.ResolvedProject, (object)_projectId),
+                    (TelemetryPropertyName.TreeUpdated.ResolvedObservedAllRules, observedAllRules)
                 });
             }
 
@@ -201,13 +201,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
                 _telemetryService.PostProperties(TelemetryEventName.ProjectUnloadDependencies, new (string, object)[]
                 {
-                    (TelemetryPropertyName.ProjectUnloadDependenciesVersion, 2),
-                    (TelemetryPropertyName.ProjectUnloadDependenciesProject, _projectId),
-                    (TelemetryPropertyName.ProjectUnloadProjectAgeMillis, _projectLoadTime.ElapsedMilliseconds),
-                    (TelemetryPropertyName.ProjectUnloadTotalDependencyCount, totalDependencyCount),
-                    (TelemetryPropertyName.ProjectUnloadUnresolvedDependencyCount, unresolvedDependencyCount),
-                    (TelemetryPropertyName.ProjectUnloadTargetFrameworkCount, _dependenciesSnapshot.DependenciesByTargetFramework.Count),
-                    (TelemetryPropertyName.ProjectUnloadDependencyBreakdown, new ComplexPropertyValue(data.ToArray()))
+                    (TelemetryPropertyName.ProjectUnload.DependenciesVersion, 2),
+                    (TelemetryPropertyName.ProjectUnload.DependenciesProject, _projectId),
+                    (TelemetryPropertyName.ProjectUnload.ProjectAgeMillis, _projectLoadTime.ElapsedMilliseconds),
+                    (TelemetryPropertyName.ProjectUnload.TotalDependencyCount, totalDependencyCount),
+                    (TelemetryPropertyName.ProjectUnload.UnresolvedDependencyCount, unresolvedDependencyCount),
+                    (TelemetryPropertyName.ProjectUnload.TargetFrameworkCount, _dependenciesSnapshot.DependenciesByTargetFramework.Count),
+                    (TelemetryPropertyName.ProjectUnload.DependencyBreakdown, new ComplexPropertyValue(data.ToArray()))
                 });
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/SDKVersionTelemetryServiceComponent.SDKVersionTelemetryServiceInstance.cs
@@ -47,8 +47,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
                     _telemetryService.PostProperties(TelemetryEventName.SDKVersion, new[]
                     {
-                        (TelemetryPropertyName.SDKVersionProject, (object)projectId),
-                        (TelemetryPropertyName.SDKVersionNETCoreSdkVersion, version)
+                        (TelemetryPropertyName.SDKVersion.Project, (object)projectId),
+                        (TelemetryPropertyName.SDKVersion.NETCoreSDKVersion, version)
                     });
                 },
                 unconfiguredProject: _projectVsServices.Project);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -159,14 +159,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 // Send telemetry.
                 _telemetryService?.PostProperties(TelemetryEventName.UpToDateCheckFail, new[]
                 {
-                    (TelemetryPropertyName.UpToDateCheckFailReason, (object)reason),
-                    (TelemetryPropertyName.UpToDateCheckDurationMillis, _stopwatch.Elapsed.TotalMilliseconds),
-                    (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),
-                    (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
-                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level),
-                    (TelemetryPropertyName.UpToDateCheckProject, _projectGuid),
-                    (TelemetryPropertyName.UpToDateCheckNumber, _checkNumber),
-                    (TelemetryPropertyName.UpToDateCheckIgnoreKinds, _ignoreKinds ?? "")
+                    (TelemetryPropertyName.UpToDateCheck.FailReason, (object)reason),
+                    (TelemetryPropertyName.UpToDateCheck.DurationMillis, _stopwatch.Elapsed.TotalMilliseconds),
+                    (TelemetryPropertyName.UpToDateCheck.FileCount, _timestampCache.Count),
+                    (TelemetryPropertyName.UpToDateCheck.ConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
+                    (TelemetryPropertyName.UpToDateCheck.LogLevel, Level),
+                    (TelemetryPropertyName.UpToDateCheck.Project, _projectGuid),
+                    (TelemetryPropertyName.UpToDateCheck.CheckNumber, _checkNumber),
+                    (TelemetryPropertyName.UpToDateCheck.IgnoreKinds, _ignoreKinds ?? "")
                 });
 
                 // Remember the failure reason and description for use in IncrementalBuildFailureDetector.
@@ -186,13 +186,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 // Send telemetry.
                 _telemetryService?.PostProperties(TelemetryEventName.UpToDateCheckSuccess, new[]
                 {
-                    (TelemetryPropertyName.UpToDateCheckDurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
-                    (TelemetryPropertyName.UpToDateCheckFileCount, _timestampCache.Count),
-                    (TelemetryPropertyName.UpToDateCheckConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
-                    (TelemetryPropertyName.UpToDateCheckLogLevel, Level),
-                    (TelemetryPropertyName.UpToDateCheckProject, _projectGuid),
-                    (TelemetryPropertyName.UpToDateCheckNumber, _checkNumber),
-                    (TelemetryPropertyName.UpToDateCheckIgnoreKinds, _ignoreKinds ?? "")
+                    (TelemetryPropertyName.UpToDateCheck.DurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
+                    (TelemetryPropertyName.UpToDateCheck.FileCount, _timestampCache.Count),
+                    (TelemetryPropertyName.UpToDateCheck.ConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
+                    (TelemetryPropertyName.UpToDateCheck.LogLevel, Level),
+                    (TelemetryPropertyName.UpToDateCheck.Project, _projectGuid),
+                    (TelemetryPropertyName.UpToDateCheck.CheckNumber, _checkNumber),
+                    (TelemetryPropertyName.UpToDateCheck.IgnoreKinds, _ignoreKinds ?? "")
                 });
 
                 Info(nameof(Resources.FUTD_UpToDate));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -7,55 +7,59 @@ namespace Microsoft.VisualStudio.Telemetry
     /// </summary>
     internal static class TelemetryEventName
     {
+        // NOTE we don't extract the prefix (vs/projectsystem/managed) into a variable here, to make
+        // it easier to search for the full event name across repositories and find this code as
+        // a match.
+
         /// <summary>
-        ///     Indicates the prefix (vs/projectsystem/managed/) of all event names throughout this project.
+        ///     Indicates the a fault in the managed project system.
         /// </summary>
-        public const string Prefix = "vs/projectsystem/managed";
+        public const string Fault = "vs/projectsystem/managed/fault";
 
         /// <summary>
         ///     Indicates that a project's last build is considered up-to-date.
         /// </summary>
-        public const string UpToDateCheckSuccess = Prefix + "/uptodatecheck/success";
+        public const string UpToDateCheckSuccess = "vs/projectsystem/managed/uptodatecheck/success";
 
         /// <summary>
         ///     Indicates that a project's last build is considered out-of-date.
         /// </summary>
-        public const string UpToDateCheckFail = Prefix + "/uptodatecheck/fail";
+        public const string UpToDateCheckFail = "vs/projectsystem/managed/uptodatecheck/fail";
 
         /// <summary>
         ///     Indicates that the dependency tree was updated with unresolved dependencies.
         /// </summary>
-        public const string TreeUpdatedUnresolved = Prefix + "/treeupdated/unresolved";
+        public const string TreeUpdatedUnresolved = "vs/projectsystem/managed/treeupdated/unresolved";
 
         /// <summary>
         ///     Indicates that the dependency tree was updated with all resolved dependencies.
         /// </summary>
-        public const string TreeUpdatedResolved = Prefix + "/treeupdated/resolved";
+        public const string TreeUpdatedResolved = "vs/projectsystem/managed/treeupdated/resolved";
 
         /// <summary>
         ///     Indicates that a design-time build has completed.
         /// </summary>
-        public const string DesignTimeBuildComplete = Prefix + "/designtimebuildcomplete";
+        public const string DesignTimeBuildComplete = "vs/projectsystem/managed/designtimebuildcomplete";
 
         /// <summary>
         ///     Indicates the .NET Core SDK version.
         /// </summary>
-        public const string SDKVersion = Prefix + "/sdkversion";
+        public const string SDKVersion = "vs/projectsystem/managed/sdkversion";
 
         /// <summary>
         ///     Indicates that the TempPE compilation queue has been processed.
         /// </summary>
-        public const string TempPEProcessQueue = Prefix + "/temppe/processcompilequeue";
+        public const string TempPEProcessQueue = "vs/projectsystem/managed/temppe/processcompilequeue";
 
         /// <summary>
         ///     Indicates that the TempPE compilation has occurred on demand from a designer.
         /// </summary>
-        public const string TempPECompileOnDemand = Prefix + "/temppe/compileondemand";
+        public const string TempPECompileOnDemand = "vs/projectsystem/managed/temppe/compileondemand";
 
         /// <summary>
         ///     Indicates that the summary of a project's dependencies is being reported during project unload.
         /// </summary>
-        public const string ProjectUnloadDependencies = Prefix + "/projectunload/dependencies";
+        public const string ProjectUnloadDependencies = "vs/projectsystem/managed/projectunload/dependencies";
 
         /// <summary>
         ///    Indicates that project was not up-to-date after build, meaning that incremental build is not
@@ -65,16 +69,16 @@ namespace Microsoft.VisualStudio.Telemetry
         ///    In some cases, we run the up-to-date check <i>after</i> a build completes, to determine whether
         ///    the project's incremental build is working correctly. When a build completes, it should be up-to-date.
         /// </remarks>
-        public const string IncrementalBuildValidationFailure = Prefix + "/incrementalbuild/validationfailure";
-        
+        public const string IncrementalBuildValidationFailure = "vs/projectsystem/managed/incrementalbuild/validationfailure";
+
         /// <summary>
         ///     Indicates that the user was notified of the suspected incremental build failure.
         /// </summary>
-        public const string IncrementalBuildValidationFailureDisplayed = Prefix + "/incrementalbuild/validationfailure/displayed";
+        public const string IncrementalBuildValidationFailureDisplayed = "vs/projectsystem/managed/incrementalbuild/validationfailure/displayed";
 
         /// <summary>
         ///     Indicates that the NuGet restore detected a cycle.
         /// </summary>
-        public const string NuGetRestoreCycleDetected = Prefix + "/nugetrestore/cycledetected";
+        public const string NuGetRestoreCycleDetected = "vs/projectsystem/managed/nugetrestore/cycledetected";
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.ProjectSystem;
-
 namespace Microsoft.VisualStudio.Telemetry
 {
     /// <summary>
@@ -9,193 +7,205 @@ namespace Microsoft.VisualStudio.Telemetry
     /// </summary>
     internal static class TelemetryPropertyName
     {
-        /// <summary>
-        ///     Indicates the prefix (vs.projectsystem.managed) of all property names throughout this project.
-        /// </summary>
-        public const string Prefix = "vs.projectsystem.managed";
+        // NOTE we don't extract the prefix (vs.projectsystem.managed) into a variable here, to make
+        // it easier to search for the full property name across repositories and find this code as
+        // a match.
 
-        /// <summary>
-        ///     Indicates the reason that a project's last build is considered out-of-date.
-        /// </summary>
-        public static readonly string UpToDateCheckFailReason = BuildPropertyName(TelemetryEventName.UpToDateCheckFail, "Reason2");
-
-        /// <summary>
-        ///     Indicates the duration of the up-to-date check, in milliseconds.
-        /// </summary>
-        public const string UpToDateCheckDurationMillis = Prefix + ".uptodatecheck.durationmillis";
-
-        /// <summary>
-        ///     Indicates the number of file system timestamps that were queried during the up-to-date check.
-        /// </summary>
-        public const string UpToDateCheckFileCount = Prefix + ".uptodatecheck.filecount";
-
-        /// <summary>
-        ///     Indicates the number of (implicitly active) configurations that were included in the the up-to-date check.
-        /// </summary>
-        /// <remarks>
-        ///     The up-to-date check runs for the active configuration only, but will consider state from all
-        ///     implicitly active configurations. Generally, for a single targeting project this will equal one,
-        ///     and for multi-targeting projects this will equal the number of target frameworks being targeted.
-        /// </remarks>
-        public const string UpToDateCheckConfigurationCount = Prefix + ".uptodatecheck.configurationcount";
-
-        /// <summary>
-        ///     Indicates the user's chosen logging level. Values from the <see cref="LogLevel"/> enum.
-        /// </summary>
-        public const string UpToDateCheckLogLevel = Prefix + ".uptodatecheck.loglevel";
-
-        /// <summary>
-        ///     Indicates any ignore kinds provided to the fast up-to-date check.
-        ///     Used to skip analyzers during indirect builds (for debug or unit tests).
-        /// </summary>
-        public const string UpToDateCheckIgnoreKinds = Prefix + ".uptodatecheck.ignorekinds";
-
-        /// <summary>
-        ///     Identifies the project to which data in the telemetry event applies.
-        /// </summary>
-        public const string UpToDateCheckProject = Prefix + ".uptodatecheck.projectid";
-
-        /// <summary>
-        ///     Indicates the number of checks performed for this project so far in the current session, starting at one.
-        ///     This number resets when the project is reloaded.
-        /// </summary>
-        public const string UpToDateCheckNumber = Prefix + ".uptodatecheck.checknumber";
-
-        /// <summary>
-        ///     Indicates the project when the dependency tree is updated with all resolved dependencies.
-        /// </summary>
-        public static readonly string TreeUpdatedResolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "Project");
-
-        /// <summary>
-        ///     Indicates the project when the dependency tree is updated with unresolved dependencies.
-        /// </summary>
-        public static readonly string TreeUpdatedUnresolvedProject = BuildPropertyName(TelemetryEventName.TreeUpdatedUnresolved, "Project");
-
-        /// <summary>
-        ///     Identifies the project to which data in the telemetry event applies.
-        /// </summary>
-        public static readonly string ProjectUnloadDependenciesProject = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Project");
-
-        /// <summary>
-        ///     Identifies the version of project unload dependencies telemetry being sent.
-        /// </summary>
-        public static readonly string ProjectUnloadDependenciesVersion = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "Version");
-
-        /// <summary>
-        ///     Identifies the time between project load and unload, in milliseconds.
-        /// </summary>
-        public static readonly string ProjectUnloadProjectAgeMillis = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "ProjectAgeMillis");
-
-        /// <summary>
-        ///     Identifies the total number of visible dependencies in the project.
-        ///     If a project multi-targets (i.e. <see cref="ProjectUnloadTargetFrameworkCount"/> is greater than one) then the count of dependencies
-        ///     in each target is summed together to produce this single value. If a breakdown is required, <see cref="ProjectUnloadDependencyBreakdown"/>
-        ///     may be used.
-        /// </summary>
-        public static readonly string ProjectUnloadTotalDependencyCount = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "TotalDependencyCount");
-
-        /// <summary>
-        ///     Identifies the total number of visible unresolved dependencies in the project.
-        ///     If a project multi-targets (i.e. <see cref="ProjectUnloadTargetFrameworkCount"/> is greater than one) then the count of unresolved dependencies
-        ///     in each target is summed together to produce this single value. If a breakdown is required, <see cref="ProjectUnloadDependencyBreakdown"/>
-        ///     may be used.
-        /// </summary>
-        public static readonly string ProjectUnloadUnresolvedDependencyCount = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "UnresolvedDependencyCount");
-
-        /// <summary>
-        ///     Identifies the number of frameworks this project targets.
-        /// </summary>
-        public static readonly string ProjectUnloadTargetFrameworkCount = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "TargetFrameworkCount");
-
-        /// <summary>
-        ///     Contains structured data describing the number of total/unresolved dependencies broken down by target framework and dependency type.
-        /// </summary>
-        public static readonly string ProjectUnloadDependencyBreakdown = BuildPropertyName(TelemetryEventName.ProjectUnloadDependencies, "DependencyBreakdown");
-
-        /// <summary>
-        ///     Indicates whether seen all rules initialized when the dependency tree is updated with all resolved dependencies.
-        /// </summary>
-        public static readonly string TreeUpdatedResolvedObservedAllRules = BuildPropertyName(TelemetryEventName.TreeUpdatedResolved, "ObservedAllRules");
-
-        /// <summary>
-        ///      Indicates whether seen all rules initialized when the dependency tree is updated with unresolved dependencies.
-        /// </summary>
-        public static readonly string TreeUpdatedUnresolvedObservedAllRules = BuildPropertyName(TelemetryEventName.TreeUpdatedUnresolved, "ObservedAllRules");
-
-        /// <summary>
-        ///     Indicates whether a design-time build has completed without errors.
-        /// </summary>
-        public static readonly string DesignTimeBuildCompleteSucceeded = BuildPropertyName(TelemetryEventName.DesignTimeBuildComplete, "Succeeded");
-
-        /// <summary>
-        ///     Indicates the targets and their times during a design-time build.
-        /// </summary>
-        public static readonly string DesignTimeBuildCompleteTargets = BuildPropertyName(TelemetryEventName.DesignTimeBuildComplete, "Targets");
-
-        /// <summary>
-        ///     Indicates the project that contains the SDK version.
-        /// </summary>
-        public static readonly string SDKVersionProject = BuildPropertyName(TelemetryEventName.SDKVersion, "Project");
-
-        /// <summary>
-        ///     Indicates the actual underlying version of .NET Core SDK.
-        /// </summary>
-        public static readonly string SDKVersionNETCoreSdkVersion = BuildPropertyName(TelemetryEventName.SDKVersion, "NETCoreSdkVersion");
-
-        /// <summary>
-        ///     Indicates the number of TempPE DLLs compiled
-        /// </summary>
-        public static readonly string TempPECompileCount = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "CompileCount");
-
-        /// <summary>
-        ///     Indicates the starting length of the TempPE compilation queue
-        /// </summary>
-        public static readonly string TempPEInitialQueueLength = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "QueueLength");
-
-        /// <summary>
-        ///     Indicates whether the TempPE compilation was cancelled
-        /// </summary>
-        public static readonly string TempPECompileWasCancelled = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "Cancelled");
-
-        /// <summary>
-        ///     Indicates the duration of the TempPE compilation
-        /// </summary>
-        public static readonly string TempPECompileDuration = BuildPropertyName(TelemetryEventName.TempPEProcessQueue, "Duration");
-
-        /// <summary>
-        ///     Indicates the reason the project was not up-to-date immediately after build.
-        /// </summary>
-        public static readonly string IncrementalBuildFailureReason = BuildPropertyName(TelemetryEventName.IncrementalBuildValidationFailure, "Reason");
-
-        /// <summary>
-        ///     Indicates the duration of the up-to-date check performed immediately after build to find incremental build breaks.
-        /// </summary>
-        public static readonly string IncrementalBuildValidationDurationMillis = BuildPropertyName(TelemetryEventName.IncrementalBuildValidationFailure, "DurationMillis");
-
-        /// <summary>
-        ///     Indicates the duration of the NuGet restore to detect a cycle
-        /// </summary>
-        public static readonly string NuGetRestoreCycleDetectedRestoreDurationMillis = BuildPropertyName(TelemetryEventName.NuGetRestoreCycleDetected, "DurationMillis");
-
-        /// <summary>
-        ///     Indicates the number of time NuGet restore have succeeded until now.
-        /// </summary>
-        public static readonly string NuGetRestoreCycleDetectedRestoreSuccesses = BuildPropertyName(TelemetryEventName.NuGetRestoreCycleDetected, "RestoreSuccesses");
-
-        /// <summary>
-        ///     Indicates the number of times NuGet restore have detected cycles until now.
-        /// </summary>
-        public static readonly string NuGetRestoreCycleDetectedRestoreCyclesDetected = BuildPropertyName(TelemetryEventName.NuGetRestoreCycleDetected, "CyclesDetected");
-
-        private static string BuildPropertyName(string eventName, string propertyName)
+        public static class UpToDateCheck
         {
-            // Property names use the event names, but with slashes replaced by periods.
-            // For example, vs/myevent would translate to vs.myevent.myproperty.
-            string prefix = eventName.Replace('/', '.');
+            /// <summary>
+            ///     Indicates the reason that a project's last build is considered out-of-date.
+            /// </summary>
+            public const string FailReason = "vs.projectsystem.managed.uptodatecheck.fail.reason2";
 
-            Assumes.False(prefix.EndsWith("."));
+            /// <summary>
+            ///     Indicates the duration of the up-to-date check, in milliseconds.
+            /// </summary>
+            public const string DurationMillis = "vs.projectsystem.managed.uptodatecheck.durationmillis";
 
-            return prefix + "." + propertyName.ToLowerInvariant();
+            /// <summary>
+            ///     Indicates the number of file system timestamps that were queried during the up-to-date check.
+            /// </summary>
+            public const string FileCount = "vs.projectsystem.managed.uptodatecheck.filecount";
+
+            /// <summary>
+            ///     Indicates the number of (implicitly active) configurations that were included in the the up-to-date check.
+            /// </summary>
+            /// <remarks>
+            ///     The up-to-date check runs for the active configuration only, but will consider state from all
+            ///     implicitly active configurations. Generally, for a single targeting project this will equal one,
+            ///     and for multi-targeting projects this will equal the number of target frameworks being targeted.
+            /// </remarks>
+            public const string ConfigurationCount = "vs.projectsystem.managed.uptodatecheck.configurationcount";
+
+            /// <summary>
+            ///     Indicates the user's chosen logging level. Values from the <see cref="LogLevel"/> enum.
+            /// </summary>
+            public const string LogLevel = "vs.projectsystem.managed.uptodatecheck.loglevel";
+
+            /// <summary>
+            ///     Indicates any ignore kinds provided to the fast up-to-date check.
+            ///     Used to skip analyzers during indirect builds (for debug or unit tests).
+            /// </summary>
+            public const string IgnoreKinds = "vs.projectsystem.managed.uptodatecheck.ignorekinds";
+
+            /// <summary>
+            ///     Identifies the project to which data in the telemetry event applies.
+            /// </summary>
+            public const string Project = "vs.projectsystem.managed.uptodatecheck.projectid";
+
+            /// <summary>
+            ///     Indicates the number of checks performed for this project so far in the current session, starting at one.
+            ///     This number resets when the project is reloaded.
+            /// </summary>
+            public const string CheckNumber = "vs.projectsystem.managed.uptodatecheck.checknumber";
+        }
+
+        public static class TreeUpdated
+        {
+            /// <summary>
+            ///     Indicates the project when the dependency tree is updated with all resolved dependencies.
+            /// </summary>
+            public const string ResolvedProject = "vs.projectsystem.managed.treeupdated.resolved.project";
+
+            /// <summary>
+            ///     Indicates the project when the dependency tree is updated with unresolved dependencies.
+            /// </summary>
+            public const string UnresolvedProject = "vs.projectsystem.managed.treeupdated.unresolved.project";
+
+            /// <summary>
+            ///     Indicates whether seen all rules initialized when the dependency tree is updated with all resolved dependencies.
+            /// </summary>
+            public const string ResolvedObservedAllRules = "vs.projectsystem.managed.treeupdated.resolved.observedallrules";
+
+            /// <summary>
+            ///      Indicates whether seen all rules initialized when the dependency tree is updated with unresolved dependencies.
+            /// </summary>
+            public const string UnresolvedObservedAllRules = "vs.projectsystem.managed.treeupdated.unresolved.observedallrules";
+        }
+
+        public static class ProjectUnload
+        {
+            /// <summary>
+            ///     Identifies the project to which data in the telemetry event applies.
+            /// </summary>
+            public const string DependenciesProject = "vs.projectsystem.managed.projectunload.dependencies.project";
+
+            /// <summary>
+            ///     Identifies the version of project unload dependencies telemetry being sent.
+            /// </summary>
+            public const string DependenciesVersion = "vs.projectsystem.managed.projectunload.dependencies.version";
+
+            /// <summary>
+            ///     Identifies the time between project load and unload, in milliseconds.
+            /// </summary>
+            public const string ProjectAgeMillis = "vs.projectsystem.managed.projectunload.dependencies.projectagemillis";
+
+            /// <summary>
+            ///     Identifies the total number of visible dependencies in the project.
+            ///     If a project multi-targets (i.e. <see cref="TargetFrameworkCount"/> is greater than one) then the count of dependencies
+            ///     in each target is summed together to produce this single value. If a breakdown is required, <see cref="DependencyBreakdown"/>
+            ///     may be used.
+            /// </summary>
+            public const string TotalDependencyCount = "vs.projectsystem.managed.projectunload.dependencies.totaldependencycount";
+
+            /// <summary>
+            ///     Identifies the total number of visible unresolved dependencies in the project.
+            ///     If a project multi-targets (i.e. <see cref="TargetFrameworkCount"/> is greater than one) then the count of unresolved dependencies
+            ///     in each target is summed together to produce this single value. If a breakdown is required, <see cref="DependencyBreakdown"/>
+            ///     may be used.
+            /// </summary>
+            public const string UnresolvedDependencyCount = "vs.projectsystem.managed.projectunload.dependencies.unresolveddependencycount";
+
+            /// <summary>
+            ///     Identifies the number of frameworks this project targets.
+            /// </summary>
+            public const string TargetFrameworkCount = "vs.projectsystem.managed.projectunload.dependencies.targetframeworkcount";
+
+            /// <summary>
+            ///     Contains structured data describing the number of total/unresolved dependencies broken down by target framework and dependency type.
+            /// </summary>
+            public const string DependencyBreakdown = "vs.projectsystem.managed.projectunload.dependencies.dependencybreakdown";
+        }
+
+        public static class DesignTimeBuildComplete
+        {
+            /// <summary>
+            ///     Indicates whether a design-time build has completed without errors.
+            /// </summary>
+            public const string Succeeded = "vs.projectsystem.managed.designtimebuildcomplete.succeeded";
+
+            /// <summary>
+            ///     Indicates the targets and their times during a design-time build.
+            /// </summary>
+            public const string Targets = "vs.projectsystem.managed.designtimebuildcomplete.targets";
+        }
+
+        public static class SDKVersion
+        {
+            /// <summary>
+            ///     Indicates the project that contains the SDK version.
+            /// </summary>
+            public const string Project = "vs.projectsystem.managed.sdkversion.project";
+
+            /// <summary>
+            ///     Indicates the actual underlying version of .NET Core SDK.
+            /// </summary>
+            public const string NETCoreSDKVersion = "vs.projectsystem.managed.sdkversion.netcoresdkversion";
+        }
+
+        public static class TempPE
+        {
+            /// <summary>
+            ///     Indicates the number of TempPE DLLs compiled
+            /// </summary>
+            public const string CompileCount = "vs.projectsystem.managed.temppe.processcompilequeue.compilecount";
+
+            /// <summary>
+            ///     Indicates the starting length of the TempPE compilation queue
+            /// </summary>
+            public const string InitialQueueLength = "vs.projectsystem.managed.temppe.processcompilequeue.queuelength";
+
+            /// <summary>
+            ///     Indicates whether the TempPE compilation was cancelled
+            /// </summary>
+            public const string CompileWasCancelled = "vs.projectsystem.managed.temppe.processcompilequeue.cancelled";
+
+            /// <summary>
+            ///     Indicates the duration of the TempPE compilation
+            /// </summary>
+            public const string CompileDuration = "vs.projectsystem.managed.temppe.processcompilequeue.duration";
+        }
+
+        public static class IncrementalBuildValidation
+        {
+            /// <summary>
+            ///     Indicates the reason the project was not up-to-date immediately after build.
+            /// </summary>
+            public const string FailureReason = "vs.projectsystem.managed.incrementalbuild.validationfailure.reason";
+
+            /// <summary>
+            ///     Indicates the duration of the up-to-date check performed immediately after build to find incremental build breaks.
+            /// </summary>
+            public const string DurationMillis = "vs.projectsystem.managed.incrementalbuild.validationfailure.durationmillis";
+        }
+
+        public static class NuGetRestoreCycleDetected
+        {
+            /// <summary>
+            ///     Indicates the duration of the NuGet restore to detect a cycle
+            /// </summary>
+            public const string RestoreDurationMillis = "vs.projectsystem.managed.nugetrestore.cycledetected.durationmillis";
+
+            /// <summary>
+            ///     Indicates the number of time NuGet restore have succeeded until now.
+            /// </summary>
+            public const string RestoreSuccesses = "vs.projectsystem.managed.nugetrestore.cycledetected.restoresuccesses";
+
+            /// <summary>
+            ///     Indicates the number of times NuGet restore have detected cycles until now.
+            /// </summary>
+            public const string RestoreCyclesDetected = "vs.projectsystem.managed.nugetrestore.cycledetected.cyclesdetected";
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -2053,31 +2053,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.NotNull(telemetryEvent.Properties);
             Assert.Equal(8, telemetryEvent.Properties.Count);
 
-            var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFailReason));
+            var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.FailReason));
             Assert.Equal(reason, reasonProp.propertyValue);
 
-            var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
+            var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.DurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
             Assert.True(duration > 0.0);
 
-            var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFileCount));
+            var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.FileCount));
             var fileCount = Assert.IsType<int>(fileCountProp.propertyValue);
             Assert.True(fileCount >= 0);
 
-            var configurationCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckConfigurationCount));
+            var configurationCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.ConfigurationCount));
             var configurationCount = Assert.IsType<int>(configurationCountProp.propertyValue);
             Assert.Equal(1, configurationCount);
 
-            var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckLogLevel));
+            var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.LogLevel));
             var logLevel = Assert.IsType<LogLevel>(logLevelProp.propertyValue);
             Assert.Equal(_logLevel, logLevel);
 
-            var ignoreKindsProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckIgnoreKinds));
+            var ignoreKindsProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.IgnoreKinds));
             var ignoreKindsStr = Assert.IsType<string>(ignoreKindsProp.propertyValue);
             Assert.Equal(ignoreKinds, ignoreKindsStr);
 
-            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckProject));
-            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckNumber));
+            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.Project));
+            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.CheckNumber));
 
             _telemetryEvents.Clear();
         }
@@ -2091,28 +2091,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.NotNull(telemetryEvent.Properties);
             Assert.Equal(7, telemetryEvent.Properties.Count);
 
-            var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckDurationMillis));
+            var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.DurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
             Assert.True(duration > 0.0);
 
-            var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckFileCount));
+            var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.FileCount));
             var fileCount = Assert.IsType<int>(fileCountProp.propertyValue);
             Assert.True(fileCount >= 0);
 
-            var configurationCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckConfigurationCount));
+            var configurationCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.ConfigurationCount));
             var configurationCount = Assert.IsType<int>(configurationCountProp.propertyValue);
             Assert.True(configurationCount == 1);
 
-            var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckLogLevel));
+            var logLevelProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.LogLevel));
             var logLevel = Assert.IsType<LogLevel>(logLevelProp.propertyValue);
             Assert.True(logLevel == _logLevel);
 
-            var ignoreKindsProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckIgnoreKinds));
+            var ignoreKindsProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.IgnoreKinds));
             var ignoreKindsStr = Assert.IsType<string>(ignoreKindsProp.propertyValue);
             Assert.Equal(ignoreKinds, ignoreKindsStr);
 
-            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckProject));
-            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheckNumber));
+            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.Project));
+            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.CheckNumber));
 
             _telemetryEvents.Clear();
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/VsTelemetryServiceTests.cs
@@ -145,11 +145,11 @@ namespace Microsoft.VisualStudio.Telemetry
             TelemetryEvent? result = null;
             var service = CreateInstance((e) => { result = e; });
 
-            service.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheckFailReason, "Reason");
+            service.PostProperty(TelemetryEventName.UpToDateCheckFail, TelemetryPropertyName.UpToDateCheck.FailReason, "Reason");
 
             Assert.NotNull(result);
             Assert.Equal(TelemetryEventName.UpToDateCheckFail, result.Name);
-            Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.UpToDateCheckFailReason, "Reason"), result.Properties);
+            Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.UpToDateCheck.FailReason, "Reason"), result.Properties);
         }
 
         [Fact]
@@ -160,14 +160,14 @@ namespace Microsoft.VisualStudio.Telemetry
 
             service.PostProperties(TelemetryEventName.DesignTimeBuildComplete, new[]
             {
-                (TelemetryPropertyName.DesignTimeBuildCompleteSucceeded, (object)true),
-                (TelemetryPropertyName.DesignTimeBuildCompleteTargets, "Compile")
+                (TelemetryPropertyName.DesignTimeBuildComplete.Succeeded, (object)true),
+                (TelemetryPropertyName.DesignTimeBuildComplete.Targets, "Compile")
             });
 
             Assert.NotNull(result);
             Assert.Equal(TelemetryEventName.DesignTimeBuildComplete, result.Name);
-            Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildCompleteSucceeded, true), result.Properties);
-            Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildCompleteTargets, "Compile"), result.Properties);
+            Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildComplete.Succeeded, true), result.Properties);
+            Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildComplete.Targets, "Compile"), result.Properties);
         }
 
         private static VsTelemetryService CreateInstance(Action<TelemetryEvent>? action = null)


### PR DESCRIPTION
Previous code used string concatenation and helper functions to create name strings for telemetry events and properties.

This meant that it wasn't possible to search for the full event name and find the source code that produced it.

With this change, telemetry event names and their property names appear as full string literals in the source code and are easily found during search.

This also removes the `BuildPropertyName` method, so that there's no runtime computation of these strings when the type loads during VS start.

I also broke the telemetry property names class up into smaller nested static classes to provide some kind of namespacing on these property names.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8480)