### PR TITLE
Fix potential exception handling solution events

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
             if ((bool)isFullyLoaded)
             {
-                _loadedInHost.SetResult();
+                _loadedInHost.TrySetResult();
             }
         }
 
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public int OnAfterBackgroundSolutionLoadComplete()
         {
-            _loadedInHost.SetResult();
+            _loadedInHost.TrySetResult();
             return HResult.OK;
         }
 


### PR DESCRIPTION
There are currently two places we might attempt to set the results on our TaskCompletionSource. I've observed, in a debugger, an exception when we set this state twice.

This change uses `TrySetResult` rather than `SetResult`, as the former will not throw an exception if a result has already been set (or the result cancelled/faulted).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8481)