### PR TITLE
Re-enable APIScan and allow timeouts (for certain jobs) to not cause build failures

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -157,8 +157,7 @@ stages:
   - group: DotNet-Project-System
   jobs:
   - template: templates/analyze-compliance.yml
-  - ${{ if false }}:
-    - template: templates/analyze-api.yml
+  - template: templates/analyze-api.yml
   # TODO: Disabled since the build for CodeQL does not seem to recognize global namespaces. Thus, it fails to build.
   # Issue: https://github.com/dotnet/project-system/issues/8421
   - ${{ if false }}:

--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -3,7 +3,7 @@
 jobs:
 - job: AnalyzeAPI
   displayName: Analyze API
-  timeoutInMinutes: 5
+  timeoutInMinutes: 180
   # This is a non-critical job, so don't fail the build if it fails.
   continueOnError: true
   steps:

--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -3,7 +3,9 @@
 jobs:
 - job: AnalyzeAPI
   displayName: Analyze API
-  timeoutInMinutes: 360
+  timeoutInMinutes: 5
+  # This is a non-critical job, so don't fail the build if it fails.
+  continueOnError: true
   steps:
 
   ###################################################################################################################################################################

--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -53,6 +53,7 @@ jobs:
       noDecompress: true
       isLargeApp: true
       verbosityLevel: minimal
+      preserveTempFiles: true
     # APIScan requires an Azure Identity to run. That is provided via an Azure service principal.
     # - https://microsoft.sharepoint.com/teams/apiscan/APIScan%20User%20Wiki/authentication_using_AAD_identities.aspx
     # - https://microsoft.sharepoint.com/teams/apiscan/Lists/Contacts%20%20System%20Account%20and%20Wrappers/AllItems.aspx?skipSignal=true

--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -52,6 +52,7 @@ jobs:
       noCopyBinaries: true
       noDecompress: true
       isLargeApp: true
+      verbosityLevel: minimal
     # APIScan requires an Azure Identity to run. That is provided via an Azure service principal.
     # - https://microsoft.sharepoint.com/teams/apiscan/APIScan%20User%20Wiki/authentication_using_AAD_identities.aspx
     # - https://microsoft.sharepoint.com/teams/apiscan/Lists/Contacts%20%20System%20Account%20and%20Wrappers/AllItems.aspx?skipSignal=true

--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -3,6 +3,7 @@
 jobs:
 - job: AnalyzeAPI
   displayName: Analyze API
+  timeoutInMinutes: 360
   steps:
 
   ###################################################################################################################################################################
@@ -57,11 +58,6 @@ jobs:
     # This value is provided from the DotNet-Project-System variable group, defined in the stage variables.
     env:
       AzureServicesAuthConnectionString: $(ApiScanConnectionString)
-    # Add a retry count in an attempt to workaround timeout failures that have been occurring with the task itself.
-    # You cannot have both a retry count and a timeout. See: https://stackoverflow.com/questions/71582213/how-can-you-handle-retrycountontaskfailure-and-timeoutinminutes-together
-    retryCountOnTaskFailure: 2
-    # This task is causing problems because of timeouts. Make it still succeed, even if it times out.
-    continueOnError: true
 
   ###################################################################################################################################################################
   # PUBLISH RESULTS

--- a/eng/pipelines/templates/analyze-vulnerabilities.yml
+++ b/eng/pipelines/templates/analyze-vulnerabilities.yml
@@ -4,6 +4,8 @@ jobs:
 - job: AnalyzeVulnerabilities
   displayName: Analyze Vulnerabilities
   timeoutInMinutes: 60
+  # This is a non-critical job, so don't fail the build if it fails.
+  continueOnError: true
   steps:
 
   ###################################################################################################################################################################

--- a/eng/pipelines/templates/publish-assets-and-packages.yml
+++ b/eng/pipelines/templates/publish-assets-and-packages.yml
@@ -143,7 +143,7 @@ jobs:
       allowPackageConflicts: true
 
   # Publishes the NuGet packages to DevDiv/VS (https://dev.azure.com/DevDiv/DevDiv/_artifacts/feed/VS)
-  # The RoslynInsertionTool will republish these packages to DevDiv/VS-CoreXtFeeds (https://dev.azure.com/DevDiv/DevDiv/_artifacts/feed/VS-CoreXtFeeds)
+  # A separate process will republish these packages to DevDiv/VS-CoreXtFeeds (https://dev.azure.com/DevDiv/DevDiv/_artifacts/feed/VS-CoreXtFeeds)
   - task: NuGetCommand@2
     displayName: Publish Packages to DevDiv
     inputs:

--- a/eng/pipelines/templates/publish-richnav.yml
+++ b/eng/pipelines/templates/publish-richnav.yml
@@ -4,6 +4,8 @@ jobs:
 - job: PublishRichNav
   displayName: Publish RichNav
   timeoutInMinutes: 30
+  # This is a non-critical job, so don't fail the build if it fails.
+  continueOnError: true
   steps:
 
   ###################################################################################################################################################################


### PR DESCRIPTION
This PR turns APIScan back on. It sets the timeout to 3 hours. So far, I've seen APIScan go above 2 hours, and we're working with a dev to investigate why it is taking so long.

We also had RichNav fail recently because of timing out, but that seems to be a separate issue. To avoid non-critical jobs from causing the entire build to fail, I've marked the following jobs with `continueOnError: true` which allows the build pipeline to continue, even when these jobs time out:
- `analyze-api.yml` (APIScan)
- `analyze-vulnerabilities.yml` (CodeQL, but we don't run this yet)
- `publish-richnav.yml` (RichNav)

I tested that this works by setting APIScan temporarily for a 5 minute timeout. You can see here that APIScan stopped at 5 mins but the next stage (VS Insertion) that requires the Compliance stage to pass ran successfully.
![image](https://user-images.githubusercontent.com/17788297/190049696-873535e2-0b43-4e1e-834d-2b8a91ce166a.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8487)