### PR TITLE
Avoid deadlock between CodeModel API and build data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceFactory.cs
@@ -17,6 +17,7 @@ internal interface IWorkspaceFactory
     /// </summary>
     /// <param name="source">A special project subscription source for data from a single slice.</param>
     /// <param name="slice">The slice this workspace represents.</param>
+    /// <param name="joinableTaskCollection">A collection for joinable tasks.</param>
     /// <param name="joinableTaskFactory">A factory for joinable tasks.</param>
     /// <param name="projectGuid">The project's GUID.</param>
     /// <param name="cancellationToken">Signals a loss of interest in the result of this operation.</param>
@@ -24,6 +25,7 @@ internal interface IWorkspaceFactory
     Workspace Create(
         IActiveConfigurationSubscriptionSource source,
         ProjectConfigurationSlice slice,
+        JoinableTaskCollection joinableTaskCollection,
         JoinableTaskFactory joinableTaskFactory,
         Guid projectGuid,
         CancellationToken cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -162,7 +162,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                     Guid projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
 
                     // New slice. Create a workspace for it.
-                    workspace = _workspaceFactory.Create(source, slice, _joinableTaskFactory, projectGuid, cancellationToken);
+                    workspace = _workspaceFactory.Create(source, slice, _joinableTaskCollection, _joinableTaskFactory, projectGuid, cancellationToken);
 
                     if (workspace is null)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
@@ -60,6 +60,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
     public Workspace Create(
         IActiveConfigurationSubscriptionSource source,
         ProjectConfigurationSlice slice,
+        JoinableTaskCollection joinableTaskCollection,
         JoinableTaskFactory joinableTaskFactory,
         Guid projectGuid,
         CancellationToken cancellationToken)
@@ -77,6 +78,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
             _dataProgressTrackerService,
             _workspaceProjectContextFactory,
             _faultHandlerService,
+            joinableTaskCollection,
             joinableTaskFactory,
             _threadingService.JoinableTaskContext,
             unloadCancellationToken: cancellationToken);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -748,7 +748,8 @@ public class WorkspaceTests
         workspaceProjectContext ??= Mock.Of<IWorkspaceProjectContext>(MockBehavior.Loose);
         workspaceProjectContextFactory ??= IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext(delegate { return workspaceProjectContext; });
         faultHandlerService ??= IProjectFaultHandlerServiceFactory.Create();
-        joinableTaskFactory ??= new(new JoinableTaskCollection(new JoinableTaskContext()));
+        JoinableTaskCollection joinableTaskCollection = new(new JoinableTaskContext());
+        joinableTaskFactory ??= new(joinableTaskCollection);
         joinableTaskContextNode ??= JoinableTaskContextNodeFactory.Create();
 
         var workspace = new Workspace(
@@ -762,6 +763,7 @@ public class WorkspaceTests
             dataProgressTrackerService,
             new(() => workspaceProjectContextFactory),
             faultHandlerService,
+            joinableTaskCollection,
             joinableTaskFactory,
             joinableTaskContextNode,
             unloadCancellationToken)


### PR DESCRIPTION
Fixes [AB#1600170](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1600170)

When project system components outside the language service host want to write to the Roslyn project context, we block those operations until the `Workspace` object is initialised with both evaluation and build data.

This state is signalled via a `TaskCompletionSource`, unblocked by the arrival of the first build data for that project slice.

Previously we used `JTF.RunAsync` in an attempt to join work between components that acquire a lock over the `Workspace`. That does not correctly join the two operations. What we need to do is temporarily join the `JoinableTaskCollection` used within the dataflow handling logic. This allows dataflow to keep pumping on the main thread, even if other code is waiting for a write lock.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8492)