### PR TITLE
Workaround incorrect active configured project data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -48,6 +48,11 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
     private readonly ILanguageServiceHostEnvironment? _languageServiceHostEnvironment;
 
     private DisposableBag? _disposables;
+
+    /// <summary>
+    /// Gets the "primary" workspace. Each slice represents a single implicitly active configuration.
+    /// This workspace is from the slice that VS considers "active".
+    /// </summary>
     private Workspace? _primaryWorkspace;
 
     [ImportingConstructor]
@@ -146,12 +151,15 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
         async Task OnSlicesChanged(IProjectVersionedValue<(ConfiguredProject ActiveConfiguredProject, ConfigurationSubscriptionSources Sources)> update, CancellationToken cancellationToken)
         {
             ProjectConfiguration activeProjectConfiguration = update.Value.ActiveConfiguredProject.ProjectConfiguration;
-            IReadOnlyDictionary<ProjectConfigurationSlice, IActiveConfigurationSubscriptionSource> sources = update.Value.Sources;
+            ConfigurationSubscriptionSources sources = update.Value.Sources;
 
             // Check off existing slices. An unseen at the end must be disposed.
             var checklist = new Dictionary<ProjectConfigurationSlice, Workspace>(workspaceBySlice);
 
             // TODO currently this loops through each slice, initializing them serially. can we do this in parallel, or can we do the active slice first?
+
+            // Remember the first slice's workspace. We may use it later, if the active workspace is removed.
+            Workspace? firstWorkspace = null;
 
             foreach ((ProjectConfigurationSlice slice, IActiveConfigurationSubscriptionSource source) in sources)
             {
@@ -178,6 +186,8 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                     Assumes.True(checklist.Remove(slice));
                 }
 
+                firstWorkspace ??= workspace;
+
                 workspace.IsPrimary = IsPrimaryActiveSlice(slice, activeProjectConfiguration);
 
                 if (workspace.IsPrimary)
@@ -187,18 +197,34 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                 }
             }
 
+            bool removedPrimary = false;
+
             // Dispose workspaces for unseen slices
             foreach ((_, Workspace workspace) in checklist)
             {
                 if (ReferenceEquals(_primaryWorkspace, workspace))
                 {
-                    _primaryWorkspace = null;
+                    removedPrimary = true;
                 }
 
                 workspace.IsPrimary = false;
 
                 // Disposes asynchronously on the thread pool, without awaiting completion.
                 workspace.Dispose();
+            }
+
+            if (removedPrimary)
+            {
+                // We removed the primary workspace
+
+                // If we have a new primary workspace, use it.
+                if (firstWorkspace is not null)
+                {
+                    firstWorkspace.IsPrimary = true;
+                }
+
+                // Set the new primary workspace (or theoretically null if no slices exist).
+                _primaryWorkspace = firstWorkspace;
             }
         }
 


### PR DESCRIPTION
Fixes [AB#1597866](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1597866)

When slices change, we receive updates to both the slices and the active configured project, from two separate data sources that we sync link. That sync link does not actually ensure the active configured project has a corresponding slice in the linked data.

Fixing that in CPS will likely be expensive. This commit introduces a workaround. When the active workspace is removed from the project, we set the workspace associated with the first slice provided as primary instead. This way, we will not have a null primary workspace, and therefore not encounter the bug in the linked issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8493)