### PR TITLE
Revert "Remove unused template resource strings"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSPackage.resx
@@ -117,6 +117,36 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="10" xml:space="preserve">
+    <value>A project for creating a class library that targets .NET Core.</value>
+  </data>
+  <data name="11" xml:space="preserve">
+    <value>xUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="12" xml:space="preserve">
+    <value>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</value>
+  </data>
+  <data name="13" xml:space="preserve">
+    <value>NUnit Test Project (.NET Core)</value>
+  </data>
+  <data name="14" xml:space="preserve">
+    <value>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</value>
+  </data>
+  <data name="3" xml:space="preserve">
+    <value>Console App (.NET Core)</value>
+  </data>
+  <data name="4" xml:space="preserve">
+    <value>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</value>
+  </data>
+  <data name="5" xml:space="preserve">
+    <value>Class Library (.NET Standard)</value>
+  </data>
+  <data name="6" xml:space="preserve">
+    <value>A project for creating a class library that targets .NET Standard.</value>
+  </data>
+  <data name="9" xml:space="preserve">
+    <value>Class Library (.NET Core)</value>
+  </data>
   <data name="21" xml:space="preserve">
     <value>Visual Basic</value>
   </data>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.cs.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Konzolová aplikace (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projekt pro vytvoření aplikace příkazového řádku, která běží na platformě .NET Core v systémech Windows, Linux a MacOS</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Knihovna tříd (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Projekt pro vytvoření knihovny tříd určené pro .NET Standard</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Knihovna tříd (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Projekt pro vytvoření knihovny tříd určené pro .NET Core</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Projekt testů xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projekt obsahující testy xUnit.net, které je možné spustit na .NET Core ve Windows, Linuxu a MacOS</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Projekt testu NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projekt obsahující testy NUnit, který se dá spustit na platformě .NET Core v systémech Windows, Linux a MacOS</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.de.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Konsolen-App (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Ein Projekt zum Erstellen einer Befehlszeilenanwendung, die unter .NET Core unter Windows, Linux und MacOS ausgeführt werden kann.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Klassenbibliothek (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Ein Projekt zum Erstellen einer Klassenbibliothek für .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Klassenbibliothek (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Ein Projekt zum Erstellen einer Klassenbibliothek für .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">xUnit-Testprojekt (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Ein Projekt, das xUnit.net-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">NUnit-Testprojekt (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Ein Projekt, das NUnit-Tests enthält, die auf .NET Core unter Windows, Linux und MacOS ausgeführt werden können.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.es.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Aplicación de consola (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Proyecto para crear una aplicación de línea de comandos que se puede ejecutar en .NET Core en Windows, Linux y MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Biblioteca de clases (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Proyecto para crear una biblioteca de clases para .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Biblioteca de clases (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Proyecto para crear una biblioteca de clases para .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Proyecto de pruebas xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Proyecto que contiene pruebas xUnit que se pueden ejecutar en .NET Core en Windows, Linux y MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Proyecto de prueba NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Un proyecto que contiene tests de NUnit que pueden ejecutarse en .NET Core en Windows, Linux y MacOS.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.fr.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Application console (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projet de création d'une application en ligne de commande pouvant s'exécuter sur .NET Core sur Windows, Linux et MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Bibliothèque de classes (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Projet de création d'une bibliothèque de classes ciblant .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Bibliothèque de classes (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Projet de création d'une bibliothèque de classes ciblant .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Projet de test xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projet qui contient des tests xUnit.net pouvant s'exécuter sur .NET Core sur Windows, Linux et macOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Projet de test NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projet qui contient des tests NUnit qui peuvent s'exécuter sur .NET Core sur Windows, Linux et MacOS.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.it.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">App console (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Progetto per la creazione di un'applicazione da riga di comando eseguibile in .NET Core in Windows, Linux e MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Libreria di classi (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Progetto per la creazione di una libreria di classi destinata a .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Libreria di classi (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Progetto per la creazione di una libreria di classi destinata a .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Progetto di test xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Progetto che contiene i test xUnit.net eseguibili in .NET Core in Windows, Linux e MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Progetto di Test NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Progetto che contiene i test NUnit eseguibili in .NET Core in Windows, Linux e MacOS.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ja.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">コンソール アプリ (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows、Linux、MacOS 上の .NET Core で実行できるコマンドライン アプリケーションを作成するためのプロジェクト。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">クラス ライブラリ (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">.NET Standard を対象とするクラス ライブラリを作成するためのプロジェクト。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">クラス ライブラリ (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">.NET Core を対象とするクラス ライブラリを作成するためのプロジェクト。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">xUnit テスト プロジェクト (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows、Linux、および MacOS 上の .NET Core で実行できる xUnit.net テストを含むプロジェクト。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">NUnit テスト プロジェクト (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows、Linux および MacOS 上の .NET Core で実行できる NUnit テストを含むプロジェクト。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ko.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">콘솔 앱(.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 명령줄 애플리케이션을 만드는 프로젝트입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">클래스 라이브러리(.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">.NET Standard를 대상으로 하는 클래스 라이브러리를 만드는 프로젝트입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">클래스 라이브러리(.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">.NET Core를 대상으로 하는 클래스 라이브러리를 만드는 프로젝트입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">xUnit 테스트 프로젝트(.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 xUnit.net 테스트를 포함하는 프로젝트입니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">NUnit 테스트 프로젝트(.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows, Linux 및 MacOS의 .NET Core에서 실행할 수 있는 NUnit 테스트를 포함하는 프로젝트입니다.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pl.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Aplikacja konsoli (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projekt służący do tworzenia aplikacji wiersza polecenia, którą można uruchomić w środowisku .NET Core w systemach Windows, Linux i MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Biblioteka klas (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Projekt służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Biblioteka klas (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Projekt służący do tworzenia biblioteki klas przeznaczonej dla środowiska .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Projekt testów xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projekt zawierający testy xUnit.net, które mogą być uruchamiane w programie .NET Core w systemach Windows, Linux i MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Projekt testowy NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Projekt zawierający testy NUnit, które mogą być uruchamiane na platformie .NET Core w systemach Windows, Linux i MacOS.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.pt-BR.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Aplicativo do Console (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Um projeto para criar um aplicativo de linha de comando que pode ser executado no .NET Core no Windows, Linux e MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Biblioteca de Classes (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Um projeto para criar uma biblioteca de classes direcionada para o .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Biblioteca de Classes (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Um projeto para criar uma biblioteca de classes direcionada para o .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Projeto de Teste do xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Um projeto que contém testes xUnit.net que podem ser executados no .NET Core em Windows, Linux e MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Projeto de teste NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Um projeto que contém testes NUnit que podem ser executados no .NET Core no Windows, no Linux e no MacOS.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.ru.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Консольное приложение (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Проект для создания приложения командной строки, которое может выполняться в среде .NET Core в Windows, Linux и Mac OS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Библиотека классов (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">Проект для создания библиотеки классов, предназначенной для .NET Standard.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Библиотека классов (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">Проект для создания библиотеки классов, использующей .NET Core.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">Тестовый проект xUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Проект с тестами xUnit.net, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">Тестовый проект NUnit (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Проект с тестами NUnit, которые могут выполняться на базе .NET Core в Windows, Linux и MacOS.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.tr.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">Konsol Uygulaması (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows, Linux ve MacOS işletim sistemlerinde .NET Core üzerinde çalışabilen bir komut satırı uygulaması oluşturmaya yönelik proje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">Sınıf Kitaplığı (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">.NET Standard’ı hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">Sınıf Kitaplığı (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">.NET Core’u hedefleyen bir sınıf kitaplığı oluşturmaya yönelik proje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">xUnit Test Projesi (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows, Linux ve MacOS’ta .NET Core üzerinde çalıştırılabilen xUnit.net testlerini içeren bir proje.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">NUnit Test Projesi (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">Windows, Linux ve MacOS üzerinde .NET Core'da çalışabilen NUnit testleri içeren bir proje.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hans.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">控制台应用(.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">用于创建可在 Windows、Linux 和 MacOS 上的 .NET Core 上运行的命令行应用程序的项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">类库(.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">用于创建目标为 .NET Standard 的类库的项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">类库 (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">用于创建目标为 .NET Core 的类库的项目。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">xUnit 测试项目 (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">包含 xUnit.net 测试的项目，测试可在 Windows、Linux 和 MacOS 的 .NET Core 上运行</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">NUnit 测试项目(.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">包含 NUnit 测试的项目，可在 Windows、Linux 和 MacOS 中的 .NET Core 上运行。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSPackage.zh-Hant.xlf
@@ -2,6 +2,56 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VSPackage.resx">
     <body>
+      <trans-unit id="3">
+        <source>Console App (.NET Core)</source>
+        <target state="translated">主控台應用程式 (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="4">
+        <source>A project for creating a command-line application that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">專案，用於建立可在 Windows、Linux 及 MacOS 於 .NET Core 執行的命令列應用程式。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="5">
+        <source>Class Library (.NET Standard)</source>
+        <target state="translated">類別庫 (.NET Standard)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="6">
+        <source>A project for creating a class library that targets .NET Standard.</source>
+        <target state="translated">專案，用於建立以 .NET Standard 為目標的類別庫。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="9">
+        <source>Class Library (.NET Core)</source>
+        <target state="translated">類別庫 (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="10">
+        <source>A project for creating a class library that targets .NET Core.</source>
+        <target state="translated">專案，用於建立以 .NET Core 為目標的類別庫。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="11">
+        <source>xUnit Test Project (.NET Core)</source>
+        <target state="translated">xUnit 測試專案 (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="12">
+        <source>A project that contains xUnit.net tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">此專案包含 xUnit.net 測試，可以在 Windows、Linux 及 MacOS 的 .NET Core 上執行。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="13">
+        <source>NUnit Test Project (.NET Core)</source>
+        <target state="translated">NUnit 測試專案 (.NET Core)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="14">
+        <source>A project that contains NUnit tests that can run on .NET Core on Windows, Linux and MacOS.</source>
+        <target state="translated">包含可在 Windows、Linux 和 MacOS 上於 .NET Core 執行之 NUnit 測試的專案。</target>
+        <note />
+      </trans-unit>
       <trans-unit id="21">
         <source>Visual Basic</source>
         <target state="translated">Visual Basic</target>


### PR DESCRIPTION
Reverts dotnet/project-system#8484

An insertion containing this PR is associated with a DDRITs regression, blocking the insertion.

The image `Microsoft.VisualStudio.ProjectSystem.Managed.VS.ni.dll` is being loaded in _ManagedLangsVS64.AddNewProject.0100.Add New Project_ and _UWP64.ProjectManagement.0200.Xaml Designer Load_, where it was previously not loaded.

I'll create an insertion attempt with this reversion and monitor it. If the regression persists, we'll try reverting #8438 as well.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8497)