### PR TITLE
Use newer Roslyn APIs in the language service

### DIFF
--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -50,6 +50,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CSharp" />
 
+    <!-- Needed to tie-break a potentially misspecified dependency somewhere -->
+    <PackageReference Include="Microsoft.ServiceHub.Framework" />
+
     <!-- Analyzers-->
     <!-- Set PrivateAssets="all" to prevent consumers of our packages from picking up these analyzers transitively. -->
     <PackageReference Include="CSharpIsNullAnalyzer"                           PrivateAssets="all" />
@@ -61,7 +64,7 @@
 
     <!-- Framework packages -->
     <PackageReference Include="Microsoft.IO.Redist" />
-    
+
     <!-- 3rd party -->
     <PackageReference Include="Newtonsoft.Json" />
 

--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -63,7 +63,7 @@
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="4.3.0-2.final" />
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.1.0-2.21558.8" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.4.0-3.22465.18" />
     <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.1.0-2.21558.8" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />

--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -6,9 +6,9 @@
     <PackageReference Update="MicroBuild.Core.Sentinel"                                               Version="1.0.0" />
     <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
     <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild"                 Version="1.1.286" />
-    <PackageReference Update="Nerdbank.Streams"                                                       Version="2.8.57" />
+    <PackageReference Update="Nerdbank.Streams"                                                       Version="2.9.87-alpha" />
     <PackageReference Update="Nerdbank.GitVersioning"                                                 Version="3.5.107" />
-    <PackageReference Update="System.IO.Pipelines"                                                    Version="6.0.1" />
+    <PackageReference Update="System.IO.Pipelines"                                                    Version="6.0.3" />
     <PackageReference Update="XliffTasks"                                                             Version="1.0.0-beta.20574.1" />
     <!-- This is used for publishing PDBs to the legacy symbol server. It converts portable PDBs to Windows PDBs (embedded). -->
     <!-- https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb?anchor=portable-pdbs -->
@@ -18,41 +18,42 @@
     <PackageReference Update="Microsoft.SourceLink.GitHub"                                            Version="1.1.1" />
 
     <!-- VS SDK -->
-    <PackageReference Update="EnvDTE"                                                                 Version="17.0.32112.339" />
-    <PackageReference Update="Microsoft.Internal.VisualStudio.Interop"                                Version="17.1.0-preview-2-32002-062" />
+    <PackageReference Update="EnvDTE"                                                                 Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.Internal.VisualStudio.Interop"                                Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.ServiceHub.Framework"                                         Version="4.0.2048" />
     <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.3.2093" />
-    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.1.224-preview" />
+    <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.3.198" />
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="17.0.46" />
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.2.0-beta.22219.1" />
-    <PackageReference Update="Microsoft.VisualStudio.Debugger.UI.Interfaces"                          Version="17.2.0-beta.22219.1" />
-    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.1.0-preview-2-32002-062" />
+    <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.4.0-beta.22470.1" />
+    <PackageReference Update="Microsoft.VisualStudio.Debugger.UI.Interfaces"                          Version="17.4.0-beta.22470.1" />
+    <PackageReference Update="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.3.13-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="16.8.30406.155-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.4.7-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.0.4492" />
     <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.4.13" />
-    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.3.22-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.3.22-alpha" />
-    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.1.0-preview-2-32002-062" />
-    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.58" />
-    <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.1.0-preview-2-32002-062" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.6.7" />
+    <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.3.44" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.3.44" />
+    <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.64" />
+    <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
     <PackageReference Update="System.Threading.Tasks.Dataflow"                                        Version="6.0.0" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219" />
 
     <!-- https://github.com/dotnet/roslyn/issues/53877 -->
-    <PackageReference Include="StreamJsonRpc"                                                         Version="2.11.35" />
+    <PackageReference Include="StreamJsonRpc"                                                         Version="2.13.21-alpha" />
 
     <!-- CPS -->
     <!-- Find versions at https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl -->
@@ -63,14 +64,14 @@
 
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="4.3.0-2.final" />
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.4.0-3.22465.18" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.1.0-2.21558.8" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.4.0-2.final" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.4.0-2.final" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 
     <!-- Analyzers -->
     <PackageReference Update="CSharpIsNullAnalyzer"                                                   Version="0.1.300" />
-    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.2" />
+    <PackageReference Update="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.3" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="3.11.0" />
     <PackageReference Update="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="3.11.0" />
     <PackageReference Update="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.2" />

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -11,6 +11,7 @@ Imports System.Text.RegularExpressions
 Imports System.Windows.Forms
 
 Imports Microsoft.VisualStudio.Shell
+Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VisualStudio.Telemetry
 
 Namespace Microsoft.VisualStudio.Editors.AppDesCommon
@@ -336,14 +337,14 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
         ''' <param name="hr">error code</param>
         ''' <param name="errorMessage">error message</param>
         Public Sub SetErrorInfo(sp As ServiceProvider, hr As Integer, errorMessage As String)
-            Dim vsUIShell As Interop.IVsUIShell = Nothing
+            Dim vsUIShell As IVsUIShell = Nothing
 
             If sp IsNot Nothing Then
-                vsUIShell = CType(sp.GetService(GetType(Interop.IVsUIShell)), Interop.IVsUIShell)
+                vsUIShell = CType(sp.GetService(GetType(IVsUIShell)), IVsUIShell)
             End If
 
             If vsUIShell Is Nothing AndAlso Not VBPackageInstance IsNot Nothing Then
-                vsUIShell = CType(VBPackageInstance.GetService(GetType(Interop.IVsUIShell)), Interop.IVsUIShell)
+                vsUIShell = CType(VBPackageInstance.GetService(GetType(IVsUIShell)), IVsUIShell)
             End If
 
             If vsUIShell IsNot Nothing Then
@@ -434,8 +435,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 Optional DefaultFileName As String = Nothing,
                 Optional NeedThrowError As Boolean = False) As ArrayList
 
-            Dim uishell As Interop.IVsUIShell =
-                CType(ServiceProvider.GetService(GetType(Interop.IVsUIShell)), Interop.IVsUIShell)
+            Dim uishell As IVsUIShell =
+                CType(ServiceProvider.GetService(GetType(IVsUIShell)), IVsUIShell)
 
             Dim fileNames As New ArrayList()
 
@@ -451,7 +452,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
                 MaxPathName = (AppDesInterop.Win32Constant.MAX_PATH + 1) * VSDPLMAXFILES
             End If
 
-            Dim vsOpenFileName As Interop.VSOPENFILENAMEW()
+            Dim vsOpenFileName As VSOPENFILENAMEW()
 
             Dim defaultName(MaxPathName) As Char
             If DefaultFileName IsNot Nothing Then
@@ -462,7 +463,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Marshal.Copy(defaultName, 0, stringMemPtr, defaultName.Length)
 
             Try
-                vsOpenFileName = New Interop.VSOPENFILENAMEW(0) {}
+                vsOpenFileName = New VSOPENFILENAMEW(0) {}
                 vsOpenFileName(0).lStructSize = CUInt(Marshal.SizeOf(vsOpenFileName(0)))
                 vsOpenFileName(0).hwndOwner = ParentWindow
                 vsOpenFileName(0).pwzDlgTitle = DialogTitle

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 enumValues.Add(new PageEnumValue(new EnumValue { Name = "", DisplayName = VSResources.StartupObjectNotSet }));
             }
 
-            IEntryPointFinderService? entryPointFinderService = project.LanguageServices.GetService<IEntryPointFinderService>();
+            IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();
             IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, _searchForEntryPointsInFormsOnly);
             if (entryPoints is not null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -137,7 +137,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
                     // This is a file item to another directory, it should only detect this a Update Namespace action.
                     // TODO Upgrade this api to get rid of the exclamation sign
+#pragma warning disable CS0618 // Type or member is obsolete https://github.com/dotnet/project-system/issues/8591
                     Renamer.RenameDocumentActionSet documentAction = await Renamer.RenameDocumentAsync(oldDocument, null!, documentFolders);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     if (documentAction.ApplicableActions.IsEmpty ||
                         documentAction.ApplicableActions.Any(a => !a.GetErrors().IsEmpty))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -166,7 +166,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             }
 
             // Get the list of possible actions to execute
+#pragma warning disable CS0618 // Type or member is obsolete https://github.com/dotnet/project-system/issues/8591
             Renamer.RenameDocumentActionSet documentRenameResult = await Renamer.RenameDocumentAsync(oldDocument, newFileWithExtension);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             // Check if there are any symbols that need to be renamed
             if (documentRenameResult.ApplicableActions.IsEmpty)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/RoslynServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/RoslynServices.cs
@@ -35,7 +35,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public Task<Solution> RenameSymbolAsync(Solution solution, ISymbol symbol, string newName, CancellationToken token = default)
         {
+#pragma warning disable CS0618 // Type or member is obsolete https://github.com/dotnet/project-system/issues/8591
             return RoslynRenamer.Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Workspace.Options, token);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         public bool ApplyChangesToSolution(Workspace ws, Solution renamedSolution)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -174,12 +174,24 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
                     _disposableBag.Add(_buildProgressRegistration);
                 }
 
-                await (update.Value switch
+                try
                 {
-                    { EvaluationUpdate: not null } => OnEvaluationUpdateAsync(update.Derive(u => u.EvaluationUpdate!)),
-                    { BuildUpdate: not null } => OnBuildUpdateAsync(update.Derive(u => u.BuildUpdate!)),
-                    _ => throw Assumes.NotReachable()
-                });
+                    await (update.Value switch
+                    {
+                        { EvaluationUpdate: not null } => OnEvaluationUpdateAsync(update.Derive(u => u.EvaluationUpdate!)),
+                        { BuildUpdate: not null } => OnBuildUpdateAsync(update.Derive(u => u.BuildUpdate!)),
+                        _ => throw Assumes.NotReachable()
+                    });
+                }
+                catch
+                {
+                    // Tear down on any exception
+                    await DisposeAsync();
+
+                    // Exceptions here are product errors, so let the exception escape in order
+                    // to produce an upstream NFE.
+                    throw;
+                }
             });
     }
 
@@ -217,24 +229,23 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
             IProjectRuleSnapshot snapshot = evaluationUpdate.Value.EvaluationRuleUpdate.CurrentState[ConfigurationGeneral.SchemaName];
 
             snapshot.Properties.TryGetValue(ConfigurationGeneral.LanguageServiceNameProperty, out string? languageName);
-            snapshot.Properties.TryGetValue(ConfigurationGeneral.TargetPathProperty, out string? binOutputPath);
             snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectFullPathProperty, out string? projectFilePath);
-            snapshot.Properties.TryGetValue(ConfigurationGeneral.AssemblyNameProperty, out string? assemblyName);
-            snapshot.Properties.TryGetValue(ConfigurationGeneral.CommandLineArgsForDesignTimeEvaluationProperty, out string? commandLineArgsForDesignTimeEvaluation);
 
-            if (string.IsNullOrEmpty(languageName) || string.IsNullOrEmpty(binOutputPath) || string.IsNullOrEmpty(projectFilePath))
+            if (string.IsNullOrEmpty(languageName) || string.IsNullOrEmpty(projectFilePath))
             {
                 // It's reasonable for a project to exist that doesn't contain enough data to initialize the language
                 // service. For example, the ".ilproj" project is not uncommon and hits this code path.
                 // In such cases, we don't want to throw here as that would fault the project. Instead, we
                 // dispose the workspace tears down the dataflow subscription and clean everything up gracefully.
-                Dispose();
+                await DisposeAsync();
 
                 return;
             }
 
             try
             {
+                EvaluationDataAdapter evaluationData = new(snapshot.Properties);
+
                 _contextId = GetWorkspaceProjectContextId(projectFilePath, _projectGuid, _slice);
 
                 _disposableBag.Add(_activeEditorContextTracker.RegisterContext(_contextId));
@@ -243,36 +254,16 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
                 // Call into Roslyn to initialize language service for this project
                 _context = await _workspaceProjectContextFactory.Value.CreateProjectContextAsync(
-                    languageName,
-                    _contextId,
-                    projectFilePath,
                     _projectGuid,
+                    _contextId,
+                    languageName,
+                    evaluationData,
                     hostObject,
-                    binOutputPath,
-                    assemblyName,
                     cancellationToken);
 
-                _disposableBag.Add(_context);
-
-                // Update additional properties within a batch to avoid thread pool starvation.
-                // https://github.com/dotnet/project-system/issues/8027
-                _context.StartBatch();
-
-                try
-                {
-                    _context.LastDesignTimeBuildSucceeded = false; // By default, turn off diagnostics until the first design time build succeeds for this project.
-
-                    // Pass along any early approximation we have of the command line options
-#pragma warning disable CS0618 // This was obsoleted in favor of the one that takes an array, but here just the string is easier; we'll un-Obsolete this API
-                    _context.SetOptions(commandLineArgsForDesignTimeEvaluation ?? "");
-#pragma warning restore CS0618 // Type or member is obsolete
-                }
-                finally
-                {
-                    await _context.EndBatchAsync();
-                }
-
                 _contextCreated.TrySetResult();
+
+                _disposableBag.Add(_context);
             }
             catch (Exception ex)
             {
@@ -285,9 +276,6 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
                 // We will never initialize now. Ensure anyone waiting on initialization sees the error.
                 _contextCreated.TrySetException(ex);
 
-                _disposableBag.Dispose();
-
-                // Let the exception escape, to unsubscribe data sources.
                 throw;
             }
         }
@@ -476,6 +464,8 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         Action<IProjectVersionedValue<T>, ContextState, CancellationToken> applyFunc,
         CancellationToken cancellationToken)
     {
+        Assumes.True(_contextCreated.Task.Status == TaskStatus.RanToCompletion);
+
         return ExecuteUnderLockAsync(ApplyProjectChangesUnderLockAsync, cancellationToken);
 
         Task ApplyProjectChangesUnderLockAsync(CancellationToken cancellationToken)
@@ -527,6 +517,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     public async Task WriteAsync(Func<IWorkspace, Task> action, CancellationToken cancellationToken)
     {
         Requires.NotNull(action, nameof(action));
+        Verify.NotDisposed(this);
 
         cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_unloadCancellationToken, cancellationToken).Token;
 
@@ -538,6 +529,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     public async Task<T> WriteAsync<T>(Func<IWorkspace, Task<T>> action, CancellationToken cancellationToken)
     {
         Requires.NotNull(action, nameof(action));
+        Verify.NotDisposed(this);
 
         cancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_unloadCancellationToken, cancellationToken).Token;
 
@@ -559,6 +551,30 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
             await _contextCreated.Task.WithCancellation(cancellationToken);
 
             Verify.NotDisposed(this);
+        }
+    }
+
+    /// <summary>
+    /// Maps from our property data snapshot to Roslyn's API for accessing the project's
+    /// evaluation data.
+    /// </summary>
+    private sealed class EvaluationDataAdapter : EvaluationData
+    {
+        private readonly IImmutableDictionary<string, string> _properties;
+
+        public EvaluationDataAdapter(IImmutableDictionary<string, string> properties)
+        {
+            _properties = properties;
+        }
+
+        public override string GetPropertyValue(string name)
+        {
+            _properties.TryGetValue(name, out string? value);
+
+            // Return the empty string rather than null.
+            value ??= "";
+
+            return value;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IWorkspaceProjectContextFactoryFactory.cs
@@ -1,17 +1,32 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Moq.Language.Flow;
+
 namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
 {
     internal static class IWorkspaceProjectContextFactoryFactory
     {
-        public static IWorkspaceProjectContextFactory ImplementCreateProjectContext(Func<string, string, string, Guid, object?, string?, string?, CancellationToken, IWorkspaceProjectContext> action)
+        public static IWorkspaceProjectContextFactory ImplementCreateProjectContext(Func<Guid, string, string, EvaluationData, object?, CancellationToken, IWorkspaceProjectContext> action)
         {
-            var mock = new Mock<IWorkspaceProjectContextFactory>();
+            var mock = new Mock<IWorkspaceProjectContextFactory>(MockBehavior.Strict);
 
-            mock.Setup(c => c.CreateProjectContextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<object?>(), It.IsAny<string?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(action);
+            mock.SetupCreateProjectContext().ReturnsAsync(action);
 
             return mock.Object;
+        }
+
+        public static IWorkspaceProjectContextFactory ImplementCreateProjectContextThrows(Exception exception)
+        {
+            var mock = new Mock<IWorkspaceProjectContextFactory>(MockBehavior.Strict);
+
+            mock.SetupCreateProjectContext().Throws(exception);
+
+            return mock.Object;
+        }
+
+        public static ISetup<IWorkspaceProjectContextFactory, Task<IWorkspaceProjectContext>> SetupCreateProjectContext(this Mock<IWorkspaceProjectContextFactory> mock)
+        {
+            return mock.Setup(c => c.CreateProjectContextAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<EvaluationData>(), It.IsAny<object?>(), It.IsAny<CancellationToken>()));
         }
     }
 }


### PR DESCRIPTION
@tmat and I designed a new API for the interaction between the .NET Project System and Roslyn when creating instances of `IWorkspaceProjectContext`.

This new API:

- Allows Roslyn to (generally) request additional properties from the project system, without requiring a corresponding change in the project system.

- Avoids having to create a wasteful batched update immediately after constructing the workspace.

This PR updates the API we use.

Bumping that package pulled the thread on a whole bunch of other package upgrades, including analyzer changes that lead to `.editorconfig` changes, some naming guideline changes, and some suppressions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8499)