### PR TITLE
Fix potential hang in language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -255,7 +255,10 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
     {
         await ValidateEnabledAsync(token);
 
-        await _firstPrimaryWorkspaceSet.Task.WithCancellation(token);
+        using (_joinableTaskCollection.Join())
+        {
+            await _firstPrimaryWorkspaceSet.Task.WithCancellation(token);
+        }
     }
 
     public async Task WriteAsync(Func<IWorkspace, Task> action, CancellationToken token)


### PR DESCRIPTION
Any caller of `IWorkspaceWriter.WhenInitialized` from the main thread could conceivably hit a hang with the prior code. We are not aware of any instances of this occurring, however.

This fix ensures that any JTF work scope of the caller is joined with the language service's own dataflow JTF work, such that the main thread may be shared between both work streams, allowing forward progress.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8501)