### PR TITLE
Prevent exception when language service not enabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceWriter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IWorkspaceWriter.cs
@@ -22,6 +22,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 internal interface IWorkspaceWriter
 {
     /// <summary>
+    ///    Gets a value indicating whether the language service is enabled for this project.
+    /// </summary>
+    /// <remarks>
+    ///    Users of this interface should use this method to validate that the language service
+    ///    is enabled for this project before attempting to use the other members of this interface.
+    ///    Attempting to use other members when the language service is disabled will result in
+    ///    an exception being thrown.
+    /// </remarks>
+    /// <param name="cancellationToken">
+    ///     Registers a loss of interest in the operation.
+    /// </param>
+    /// <returns>
+    ///     A task who's completed result indicates whether the language service is enabled or not
+    ///     for this project.
+    /// </returns>
+    Task<bool> IsEnabledAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Completes when a write lock can be requested for the active workspace.
     /// </summary>
     /// <remarks>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -100,7 +100,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
 
     protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
     {
-        if (await IsDisabledAsync(cancellationToken))
+        if (!await IsEnabledAsync(cancellationToken))
         {
             // We are not enabled, so don't perform any initialization.
             return;
@@ -251,6 +251,18 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
 
     #region IWorkspaceWriter
 
+    public Task<bool> IsEnabledAsync(CancellationToken cancellationToken)
+    {
+        if (_languageServiceHostEnvironment is null)
+        {
+            // Assume enabled when no host environment is available.
+            return TaskResult.True;
+        }
+
+        // Defer to the host environment to determine if we're enabled.
+        return _languageServiceHostEnvironment.IsEnabledAsync(cancellationToken);
+    }
+
     public async Task WhenInitialized(CancellationToken token)
     {
         await ValidateEnabledAsync(token);
@@ -307,7 +319,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
     public async Task AfterLoadInitialConfigurationAsync()
     {
-        if (await IsDisabledAsync(_tasksService.UnloadCancellationToken))
+        if (!await IsEnabledAsync(_tasksService.UnloadCancellationToken))
         {
             // We are not enabled, so don't block project load on our initialization.
             return;
@@ -336,15 +348,9 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
         return Task.CompletedTask;
     }
 
-    private async Task<bool> IsDisabledAsync(CancellationToken cancellationToken)
-    {
-        // Check whether our hosting environment is telling us we're enabled.
-        return _languageServiceHostEnvironment is not null && !await _languageServiceHostEnvironment.IsEnabledAsync(cancellationToken);
-    }
-
     private async Task ValidateEnabledAsync(CancellationToken cancellationToken)
     {
-        if (await IsDisabledAsync(cancellationToken))
+        if (!await IsEnabledAsync(cancellationToken))
         {
             Assumes.Fail("Invalid operation when language services are not enabled.");
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceWriterFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceWriterFactory.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.Threading;
+
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
     internal static class IWorkspaceWriterFactory
@@ -35,6 +37,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             public WorkspaceWriter(IWorkspace workspace)
             {
                 _workspace = workspace;
+            }
+
+            public Task<bool> IsEnabledAsync(CancellationToken cancellationToken = default)
+            {
+                return TaskResult.True;
             }
 
             public Task WhenInitialized(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Fixes #8500

In some cases the language service host environment may signal that language services should not be enabled. Command line mode /build is an example of this.

Users of the language service receive exceptions when attempting to use its APIs when it is disabled.

This change allows callers to validate that the language service is enabled in order to avoid such exceptions.

---

#8502 tracks using project capabilities instead of this manual check. As part of that work, we would revert this change, instead updating the project capabilities on `LanguageServiceErrorListProvider` itself (or just making the `LanguageServices` capability dynamic).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8503)