### PR TITLE
Language service runs when populating solution cache

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
@@ -37,7 +37,7 @@ internal partial class VsInfoBarService : IInfoBarService
         Requires.NotNullOrEmpty(message, nameof(message));
         Requires.NotNull(items, nameof(items));
 
-        if (!_vsShellServices.IsInServerMode)
+        if (!await _vsShellServices.IsInServerModeAsync(cancellationToken))
         {
             await _threadingService.SwitchToUIThread(cancellationToken);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
@@ -37,7 +37,7 @@ internal partial class VsInfoBarService : IInfoBarService
         Requires.NotNullOrEmpty(message, nameof(message));
         Requires.NotNull(items, nameof(items));
 
-        if (!await _vsShellServices.IsInServerModeAsync(cancellationToken))
+        if (!await _vsShellServices.IsCommandLineModeAsync(cancellationToken))
         {
             await _threadingService.SwitchToUIThread(cancellationToken);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/IVsShellServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/IVsShellServices.cs
@@ -19,17 +19,6 @@ namespace Microsoft.VisualStudio.Shell
         Task<bool> IsCommandLineModeAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Gets a value indicating whether VS is running in server mode.
-        /// </summary>
-        /// <remarks>
-        /// Implies <see cref="IsCommandLineModeAsync"/> is also <see langword="true"/>.
-        /// </remarks>
-        /// <remarks>
-        /// This has a free-threaded implementation.
-        /// </remarks>
-        Task<bool> IsInServerModeAsync(CancellationToken cancellationToken = default);
-
-        /// <summary>
         /// Gets a value indicating whether VS is populating the solution cache during a command line operation.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/IVsShellServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/IVsShellServices.cs
@@ -7,20 +7,37 @@ namespace Microsoft.VisualStudio.Shell
     /// <summary>
     /// Provides common shell services in an agnostic manner
     /// </summary>
-    /// <remarks>
-    /// This contract defines the boundary between the VS shell system
-    /// and the consumer to help avoid taking unnecessary assembly dependencies
-    /// in the client.
-    /// </remarks>
-    [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Host)]
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Host)]
     internal interface IVsShellServices
     {
         /// <summary>
-        /// Gets a value indicating whether VS is running in the server mode.
+        /// Gets a value indicating whether VS is running in command line mode.
         /// </summary>
         /// <remarks>
         /// This has a free-threaded implementation.
         /// </remarks>
-        bool IsInServerMode { get; }
+        Task<bool> IsCommandLineModeAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a value indicating whether VS is running in server mode.
+        /// </summary>
+        /// <remarks>
+        /// Implies <see cref="IsCommandLineModeAsync"/> is also <see langword="true"/>.
+        /// </remarks>
+        /// <remarks>
+        /// This has a free-threaded implementation.
+        /// </remarks>
+        Task<bool> IsInServerModeAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Gets a value indicating whether VS is populating the solution cache during a command line operation.
+        /// </summary>
+        /// <remarks>
+        /// Implies <see cref="IsCommandLineModeAsync"/> is also <see langword="true"/>.
+        /// </remarks>
+        /// <remarks>
+        /// This has a free-threaded implementation.
+        /// </remarks>
+        Task<bool> IsPopulateSolutionCacheModeAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/VSShellServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/VSShellServices.cs
@@ -1,64 +1,89 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Runtime.CompilerServices;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.Shell.Interop;
-
-#nullable disable
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Shell;
 
-/// <summary>
-/// See IVSShellServices.
-/// </summary>
 [Export(typeof(IVsShellServices))]
 [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
-internal class VSShellServices : OnceInitializedOnceDisposed, IVsShellServices
+internal class VSShellServices : IVsShellServices
 {
-    /// <summary>
-    /// The service provider providing access to the VS services.
-    /// </summary>
-    [Import]
-    private IVsUIService<SVsShell, IVsShell> ServiceProvider { get; set; }
 
-    public bool IsInServerMode { get; private set; }
+    private readonly AsyncLazy<(bool IsCommandLineMode, bool IsServerMode, bool IsPopulateSolutionCacheMode)> _initialization;
 
-    /// <summary>
-    /// The SVsShell service.
-    /// </summary>
-    private IVsShell vsShell;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="VSShellServices"/> class.
-    /// </summary>
-    public VSShellServices()
-        : base(synchronousDisposal: true) // disposal requires UI thread unadvise, so async defeats that.
+    [ImportingConstructor]
+    public VSShellServices(
+        IVsUIService<SVsShell, IVsShell> vsShellService,
+        IVsUIService<SVsAppCommandLine, IVsAppCommandLine> commandLineService,
+        JoinableTaskContext joinableTaskContext)
     {
+        _initialization = new(
+            async () =>
+            {
+                // Initialisation must occur on the main thread.
+                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
+
+                IVsShell? vsShell = vsShellService.Value;
+                IVsAppCommandLine? commandLine = commandLineService.Value;
+
+                Assumes.Present(vsShell);
+
+                bool isCommandLineMode = IsCommandLineMode();
+
+                if (isCommandLineMode)
+                {
+                    return (IsCommandLineMode: true, IsInServerMode(), IsPopulateSolutionCacheMode());
+                }
+
+                return (false, false, false);
+
+                bool IsCommandLineMode()
+                {
+                    int hr = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object result);
+
+                    return ErrorHandler.Succeeded(hr)
+                        && result is bool isCommandLineMode
+                        && isCommandLineMode;
+                }
+
+                bool IsInServerMode()
+                {
+                    int hr = vsShell.GetProperty((int)__VSSPROPID11.VSSPROPID_ShellMode, out object value);
+
+                    return ErrorHandler.Succeeded(hr)
+                        && value is int shellMode
+                        && shellMode == (int)__VSShellMode.VSSM_Server;
+                }
+
+                bool IsPopulateSolutionCacheMode()
+                {
+                    if (commandLine is null)
+                        return false;
+
+                    int hr = commandLine.GetOption("populateSolutionCache", out int populateSolutionCache, out string commandValue);
+
+                    return ErrorHandler.Succeeded(hr)
+                        && Convert.ToBoolean(populateSolutionCache);
+                }
+            },
+            joinableTaskContext.Factory);
     }
 
-    protected override void Initialize()
+    public async Task<bool> IsCommandLineModeAsync(CancellationToken cancellationToken)
     {
-        vsShell = ServiceProvider.Value;
-
-        if (ErrorHandler.Succeeded(vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object result)) && (bool)result)
-        {
-            IsInServerMode = CheckIsInServerMode();
-        }
+        return (await _initialization.GetValueAsync(cancellationToken)).IsCommandLineMode;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private bool CheckIsInServerMode()
+    public async Task<bool> IsInServerModeAsync(CancellationToken cancellationToken)
     {
-        if (ErrorHandler.Succeeded(vsShell.GetProperty((int)__VSSPROPID11.VSSPROPID_ShellMode, out object value))
-            && value is int shellMode
-            && shellMode == (int)__VSShellMode.VSSM_Server)
-            return true;
-
-        return false;
+        return (await _initialization.GetValueAsync(cancellationToken)).IsServerMode;
     }
 
-    protected override void Dispose(bool disposing)
+    public async Task<bool> IsPopulateSolutionCacheModeAsync(CancellationToken cancellationToken)
     {
+        return (await _initialization.GetValueAsync(cancellationToken)).IsPopulateSolutionCacheMode;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -303,7 +303,9 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
 
     #endregion
 
-    [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.AfterLoadInitialConfiguration, completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
+    [ProjectAutoLoad(
+        startAfter: ProjectLoadCheckpoint.AfterLoadInitialConfiguration,
+        completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
     public async Task AfterLoadInitialConfigurationAsync()
     {


### PR DESCRIPTION
Fixes #8504
Fixes #8505

Main parts to this PR:

1. _Fix `IVsShellServices`_. This interface and its implementation (`VSShellServices`) was copied from CPS in #8239, but nothing ever initialised the implementation. This change changes the API so that these values can be lazily implemented and efficiently queried.
2. _Initialise language service when populating the solution cache_. Requires extending `IVsShellServices`.
3. _Remove outdated use of server mode_. This feature is no longer supported.