### PR TITLE
Remove unnecessary PackageReferences

### DIFF
--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -108,10 +108,4 @@
     <PackageReference Update="Microsoft.DotNet.Common.ProjectTemplates.1.x"                           Version="1.0.0-beta2-20170629-269" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IncludeVSSDKPackages)' != 'false'">
-    <!-- Avoid double-writes, can remove when https://github.com/NuGet/Home/issues/8343 is fixed -->
-    <PackageReference Include="VSSDK.DTE"                                                             Version="7.0.4"                           ExcludeAssets="All" />
-    <PackageReference Include="VSSDK.TemplateWizardInterface"                                         Version="12.0.4"                          ExcludeAssets="All" />
-  </ItemGroup>
-
 </Project>

--- a/eng/tools/OneLocBuildSetup/OneLocBuildSetup.csproj
+++ b/eng/tools/OneLocBuildSetup/OneLocBuildSetup.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <IncludeVSSDKPackages>false</IncludeVSSDKPackages>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove some PackageReferences items added in c71988886996789cd3b3b8c6d1f781110da559f6. Older versions of the NuGet.VisualStudio package depended on these, but they duplicated assemblies that we pulled in from other (more official) packages. This led to double-writes during build, where two files from different locations (but the same name and ostensibly the same content) would get copied to the same destination. This is undesirable as--at best--all but one of the copies are pointless. At worst you get an unstable build where which one "wins" is non-deterministic. By declaring our own PackageReferences to these with `ExcludeAssets="All"` we can prevent the build from copying files out of these packages.

The downside is that this adds package dependencies we don't actually need, and is particularly weird for Microsoft.VisualStudio.ProjectSystem.Managed.csproj as it shouldn't depend at all on VS APIs (like DTE and the template wizard).

The 6.x.x (and later) versions of Nuget.VisualStudio no longer depend on these non-standard packages; the double-write is no longer a problem and so we no longer need these PackageReferences.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8513)