### PR TITLE
Enable CodeQL 3000

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -90,6 +90,9 @@ variables:
   # Allows CodeQL to run on our Build job.
   # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
   Codeql.Enabled: true
+  # Default to skipping auto-injection for CodeQL. It is not skipped in the Build job only.
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+  Codeql.SkipTaskAutoInjection: true
 
 parameters:
 - name: CreateInsertion
@@ -128,6 +131,9 @@ stages:
     # Only used for tracking purposes in MicroBuild tasks.
     # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
     TeamName: DotNet-Project-System
+    # Auto-injects the CodeQL task.
+    # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+    Codeql.SkipTaskAutoInjection: false
   jobs:
   - template: templates/build-official-release.yml
 
@@ -139,9 +145,6 @@ stages:
   # Variables used:
   # - SymbolsUncPath
   - group: DotNet-Project-System
-  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
-  - name: Codeql.SkipTaskAutoInjection
-    value: true
   jobs:
   - template: templates/publish-assets-and-packages.yml
   - template: templates/publish-symbols.yml
@@ -161,9 +164,6 @@ stages:
   # Variables used:
   # - ApiScanConnectionString
   - group: DotNet-Project-System
-  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
-  - name: Codeql.SkipTaskAutoInjection
-    value: true
   jobs:
   - template: templates/analyze-compliance.yml
   - template: templates/analyze-api.yml
@@ -183,9 +183,6 @@ stages:
   # - BotAccount-dotnet-bot-repo-PAT
   # - dn-bot-ceapex-package-r
   - group: OneLocBuildVariables
-  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
-  - name: Codeql.SkipTaskAutoInjection
-    value: true
   jobs:
   - template: templates/generate-localization.yml
 
@@ -213,9 +210,6 @@ stages:
         # - https://stackoverflow.com/a/57488169/294804
         # - https://github.com/microsoft/azure-pipelines-tasks/issues/4743
         value: $[ stageDependencies.Publish.PublishAssetsAndPackages.outputs['UpdateRunSettings.visualStudioBootstrapperURI'] ]
-      # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
-      - name: Codeql.SkipTaskAutoInjection
-        value: true
       runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/dotnet/project-system/$(Build.SourceBranchName)/$(Build.BuildId);OptProf.runsettings
       # This variable is set during the 'Update RunSettings' (UpdateRunSettings.ps1) step in the publish-assets-and-packages.yml.
       # This variable is expanded when it is used: https://docs.microsoft.com/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#macro-syntax-variables
@@ -262,7 +256,5 @@ stages:
       # Gets the PackageVersion variable produced by the Build pipeline.
       PackageVersion: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetPackageVersion.PackageVersion'] ]
       InsertionVSBranch: ${{ parameters.InsertionVSBranch }}
-      # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
-      Codeql.SkipTaskAutoInjection: true
     jobs:
     - template: templates/generate-insertion.yml

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -125,6 +125,8 @@ stages:
     # Only used for tracking purposes in MicroBuild tasks.
     # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
     TeamName: DotNet-Project-System
+    # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
+    Codeql.Enabled: true
   jobs:
   - template: templates/build-official-release.yml
 

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -87,6 +87,9 @@ variables:
   # - https://docs.opensource.microsoft.com/tools/cg/how-to/nuget-multifeed-configuration/
   # - https://onebranch.visualstudio.com/OneBranch/_wiki/wikis/OneBranch.wiki/5205/TSG-Build-Broken-Due-to-Using-Multiple-Feeds?anchor=setting-nugetsecurityanalysiswarninglevel-in-cdp
   NugetSecurityAnalysisWarningLevel: none
+  # Allows CodeQL to run on our Build job.
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
+  Codeql.Enabled: true
 
 parameters:
 - name: CreateInsertion
@@ -125,8 +128,6 @@ stages:
     # Only used for tracking purposes in MicroBuild tasks.
     # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
     TeamName: DotNet-Project-System
-    # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines
-    Codeql.Enabled: true
   jobs:
   - template: templates/build-official-release.yml
 
@@ -138,6 +139,9 @@ stages:
   # Variables used:
   # - SymbolsUncPath
   - group: DotNet-Project-System
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
   jobs:
   - template: templates/publish-assets-and-packages.yml
   - template: templates/publish-symbols.yml
@@ -157,6 +161,9 @@ stages:
   # Variables used:
   # - ApiScanConnectionString
   - group: DotNet-Project-System
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
   jobs:
   - template: templates/analyze-compliance.yml
   - template: templates/analyze-api.yml
@@ -176,6 +183,9 @@ stages:
   # - BotAccount-dotnet-bot-repo-PAT
   # - dn-bot-ceapex-package-r
   - group: OneLocBuildVariables
+  # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+  - name: Codeql.SkipTaskAutoInjection
+    value: true
   jobs:
   - template: templates/generate-localization.yml
 
@@ -203,6 +213,9 @@ stages:
         # - https://stackoverflow.com/a/57488169/294804
         # - https://github.com/microsoft/azure-pipelines-tasks/issues/4743
         value: $[ stageDependencies.Publish.PublishAssetsAndPackages.outputs['UpdateRunSettings.visualStudioBootstrapperURI'] ]
+      # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+      - name: Codeql.SkipTaskAutoInjection
+        value: true
       runSettingsURI: https://vsdrop.corp.microsoft.com/file/v1/RunSettings/$(System.TeamProject)/dotnet/project-system/$(Build.SourceBranchName)/$(Build.BuildId);OptProf.runsettings
       # This variable is set during the 'Update RunSettings' (UpdateRunSettings.ps1) step in the publish-assets-and-packages.yml.
       # This variable is expanded when it is used: https://docs.microsoft.com/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#macro-syntax-variables
@@ -249,5 +262,7 @@ stages:
       # Gets the PackageVersion variable produced by the Build pipeline.
       PackageVersion: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetPackageVersion.PackageVersion'] ]
       InsertionVSBranch: ${{ parameters.InsertionVSBranch }}
+      # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
+      Codeql.SkipTaskAutoInjection: true
     jobs:
     - template: templates/generate-insertion.yml

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -7,8 +7,6 @@ jobs:
   timeoutInMinutes: 90
   steps:
 
-  - task: CodeQL3000Init@0
-
   ###################################################################################################################################################################
   # SBOM GENERATION
   # This process occurs above plugin installation so that the Src build does not perform signing.
@@ -216,5 +214,3 @@ jobs:
     displayName: Publish Staging Artifacts
     artifact: Staging
     condition: succeededOrFailed()
-
-  - task: CodeQL3000Finalize@0

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -7,6 +7,8 @@ jobs:
   timeoutInMinutes: 90
   steps:
 
+  - task: CodeQL3000Init@0
+
   ###################################################################################################################################################################
   # SBOM GENERATION
   # This process occurs above plugin installation so that the Src build does not perform signing.
@@ -214,3 +216,5 @@ jobs:
     displayName: Publish Staging Artifacts
     artifact: Staging
     condition: succeededOrFailed()
+
+  - task: CodeQL3000Finalize@0


### PR DESCRIPTION
Resolves: https://github.com/dotnet/project-system/issues/8421

[CodeQL](https://github.com/github/codeql) is an analysis tool for vulnerabilities. This PR is enabling a version of a CodeQL AzDO task called [CodeQL 3000](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines). There is another CodeQL task created by Guardian (same set of tools for the rest of our compliance checks), but this is not that task. This CodeQL task is auto-injected into the pipeline (a dynamic task that is not directly declared in the pipeline YML).

Unfortunately, I cannot directly test the auto-injected run of this task. [According to the documentation](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#how-does-this-extension-work), the auto-injected task only runs on the default branch for the repo (aka. `main` for us). I tested CodeQL 3000 using the manually added Init/Finalize tasks: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6722796&view=logs&j=3de96e8d-b8d1-5108-47b8-f6a54739db67&t=f9aea6eb-8f15-55f4-c13f-b9d7005edfde

This test run added *3 mins* to our Build job time, but that seems reasonable over the alternative. The alternative is using the [Guardian CodeQL task](https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/codeql-build-task) which requires a **rebuild of the code** to run the analysis. While this would run in parallel with other compliance jobs, it is extra work for the job agents that is not necessary. Also, there was an issue with that task where it seems to be running the wrong version of .NET, which causes it to not build properly. I feel that the CodeQL 3000 task is a fair compromise comparatively to the Guardian CodeQL task.

After this is merged and I see the actual auto-injected task runs, I'll make a follow-up PR that removes the current `analyze-vulnerabilities.yml` I added for using the Guardian CodeQL task (but doesn't run because of the build issue described).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8516)