### PR TITLE
Report a better exception message

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -332,7 +332,7 @@ public class WorkspaceTests
         {
             var ex = await Assert.ThrowsAsync<Exception>(() => task);
 
-            Assert.Equal("Insufficient project data to initialize the language service.", ex.Message);
+            Assert.StartsWith("Insufficient project data to initialize the language service: missing property", ex.Message);
         }
     }
 


### PR DESCRIPTION
Fixes #8518.

There are certain MSBuild properties that must be present in order for us to propertly initialize the language service: "LanguageServiceName", "TargetPath", and "MSBuildProjectFullPath". If one of these is missing we'll fail the initialization and throw an exception. However, the exception does not contain the name of the missing property which may make it harder to track down problems later.

Here we update the exception message to include the name of the missing property. A couple of helper methods have also been introduced to make it clear which properties are really required, and which ones could be null.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8519)