### PR TITLE
Fix unit test

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -127,15 +127,14 @@ public class WorkspaceTests
                 },
                 CancellationToken.None);
 
+        // Wait a little while to increase the chance a bug would surface in this test.
+        await Task.Delay(10);
+
         Assert.Equal(0, callCount);
         Assert.Equal(TaskStatus.WaitingForActivation, initializedTask.Status);
 
+        // Only once we have evaluation data should a write operation be scheduled.
         await ApplyEvaluationAsync(workspace);
-
-        Assert.Equal(0, callCount);
-        Assert.Equal(TaskStatus.WaitingForActivation, initializedTask.Status);
-
-        await ApplyBuildAsync(workspace);
 
         await Task.WhenAny(initializedTask, Task.Delay(TimeSpan.FromSeconds(30)));
 


### PR DESCRIPTION
In #8498 we changed the required conditions for initialisation of a language service workspace. This unit test should have been updated at the same time. For some reason, the CI build for that PR passed.

This change updates the test to reflect the new behaviour.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8523)