### PR TITLE
Publish loaded configured projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -8,7 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level
     ///     services, such as evaluation and build services, are started.
     /// </summary>
-    internal class ActiveConfiguredProjectsLoader : OnceInitializedOnceDisposed
+    [Export(typeof(ActiveConfiguredProjectsLoader))]
+
+    internal class ActiveConfiguredProjectsLoader : ChainedProjectValueDataSourceBase<IEnumerable<ConfiguredProject>>
     {
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
@@ -18,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         [ImportingConstructor]
         public ActiveConfiguredProjectsLoader(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService, IUnconfiguredProjectTasksService tasksService)
-            : base(synchronousDisposal: false)
+            : base(containingProject: project, synchronousDisposal: false)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
@@ -54,14 +56,43 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private async Task OnActiveConfigurationsChangedAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> e)
         {
-            foreach (ProjectConfiguration configuration in e.Value)
+            await GetLoadedProjectsAsync(e);
+        }
+
+        protected override IDisposable? LinkExternalInput(ITargetBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> targetBlock)
+        {
+            IReceivableSourceBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> sourceBlock = _activeConfigurationGroupService.ActiveConfigurationGroupSource.SourceBlock;
+
+            DisposableValue<ISourceBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>>>? transformBlock = sourceBlock.TransformWithNoDelta(TransformAsync);
+
+            transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+
+            return transformBlock;
+        }
+
+        private async Task<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> TransformAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
+        {
+            List<ConfiguredProject> generatedResult = await GetLoadedProjectsAsync(projectVersionedValue);
+
+            return new ProjectVersionedValue<IEnumerable<ConfiguredProject>>(generatedResult, projectVersionedValue.DataSourceVersions);
+        }
+
+        private async Task<List<ConfiguredProject>> GetLoadedProjectsAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
+        {
+            List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
+
+            foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
             {
                 // Make sure we aren't currently unloading, or we don't unload while we load the configuration
-                await _tasksService.LoadedProjectAsync(() =>
+                var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() =>
                 {
                     return _project.LoadConfiguredProjectAsync(configuration);
                 });
+
+                generatedResult.Add(loadedConfiguredProject);
             }
+
+            return generatedResult;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [Fact]
         public async Task Dispose_WhenNotInitialized_DoesNotThrow()
         {
-            var project = UnconfiguredProjectFactory.Create();
+            var project = UnconfiguredProjectFactory.CreateWithActiveConfiguredProjectProvider(IProjectThreadingServiceFactory.Create());
 
             var loader = CreateInstance(project, out _);
 


### PR DESCRIPTION
Components like the NuGet restore (only do restore when all target frameworks are available) can benefit from this data.

This is one part of the fix for #7288. 
###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8524)