### PR TITLE
Fix launchSettings parser to read date as string in environment variables

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -356,10 +356,20 @@ internal static class LaunchSettingsJsonEncoding
             ReadObject(property =>
             {
                 builder ??= ImmutableArray.CreateBuilder<(string Name, string Value)>();
-                builder.Add((property, ReadString()));
+                builder.Add((property, ReadEnvironmentVariableString()));
             });
 
             return builder?.ToImmutable() ?? ImmutableArray<(string Name, string Value)>.Empty;
+        }
+
+        string ReadEnvironmentVariableString()
+        {
+            if (!reader.Read())
+            {
+                throw new JsonReaderException($"Cannot read string at {reader.LineNumber}.");
+            }
+
+            return reader.Value!.ToString();
         }
 
         string ReadString()


### PR DESCRIPTION
Fixes [AB#1599326](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1599326)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8530)