### PR TITLE
Condition and notification table shouldn't shrink to zero height.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/compileproppage2.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/compileproppage2.resx
@@ -725,6 +725,9 @@
   </data>
   <data name="WarningsGridView.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 115</value>
+  <data name="WarningsGridView.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 200</value>
+  </data>
   </data>
   <data name="WarningsGridView.Size" type="System.Drawing.Size, System.Drawing">
     <value>437, 138</value>
@@ -998,6 +1001,9 @@
   </data>
   <data name="$this.Location" type="System.Drawing.Point, System.Drawing">
     <value>12, 13</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 865</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>455, 472</value>


### PR DESCRIPTION
Partially fixes the accessibility issue here: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1614439

If the screen resolution is low and/or window scaling is high, condition and notification table in "Compile" property page can get too small: enough to disappear completely.

This PR makes sure that the table is at least 200 pixels high.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8531)