### PR TITLE
Disable date deserialisation in launchSettings.json

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -356,20 +356,10 @@ internal static class LaunchSettingsJsonEncoding
             ReadObject(property =>
             {
                 builder ??= ImmutableArray.CreateBuilder<(string Name, string Value)>();
-                builder.Add((property, ReadEnvironmentVariableString()));
+                builder.Add((property, ReadString()));
             });
 
             return builder?.ToImmutable() ?? ImmutableArray<(string Name, string Value)>.Empty;
-        }
-
-        string ReadEnvironmentVariableString()
-        {
-            if (!reader.Read())
-            {
-                throw new JsonReaderException($"Cannot read string at {reader.LineNumber}.");
-            }
-
-            return reader.Value!.ToString();
         }
 
         string ReadString()
@@ -414,6 +404,7 @@ internal static class LaunchSettingsJsonEncoding
     {
         public CommentSkippingJsonTextReader(TextReader reader) : base(reader)
         {
+            DateParseHandling = DateParseHandling.None;
         }
 
         public override bool Read()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsJsonEncodingTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsJsonEncodingTests.cs
@@ -60,6 +60,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                       "web1"
                     ]
                   }
+                },
+                "DateInEnvironmentVariableBugRepro": {
+                  "commandName": "Project",
+                  "environmentVariables": {
+                    "DATE": "2019-07-11T12:00:00"
+                  }
                 }
               },
               "string": "hello",
@@ -75,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var (profiles, globalSettings) = LaunchSettingsJsonEncoding.FromJson(new StringReader(json), _providers);
 
-            Assert.Equal(5, profiles.Length);
+            Assert.Equal(6, profiles.Length);
 
             var profile = profiles[0];
             Assert.Equal("IIS Express", profile.Name);
@@ -148,6 +154,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Assert.Equal(2, dicObj.Count);
             Assert.Equal("1", dicObj["A"]);
             Assert.Equal("2", dicObj["B"]);
+
+            profile = profiles[5];
+            Assert.Equal("DateInEnvironmentVariableBugRepro", profile.Name);
+            Assert.Equal("Project", profile.CommandName);
+            Assert.Null(profile.WorkingDirectory);
+            Assert.Null(profile.ExecutablePath);
+            Assert.False(profile.LaunchBrowser);
+            Assert.Null(profile.LaunchUrl);
+            Assert.Equal(("DATE", "2019-07-11T12:00:00"), Assert.Single(profile.EnvironmentVariables));
+            Assert.False(profile.IsInMemoryObject());
 
             var roundTrippedJson = LaunchSettingsJsonEncoding.ToJson(profiles, globalSettings);
 


### PR DESCRIPTION
This is an alternative to #8530 that modifies the default JSON.NET behaviour of deserialising a string containing an ISO format date as a `System.DateTime` rather than `System.String`.

Also adds a unit test.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8541)