### PR TITLE
Fix perf regression in NuGet restore

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -4,7 +4,12 @@ using System.Globalization;
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using NuGet.SolutionRestoreManager;
+
 using RestoreInfo = Microsoft.VisualStudio.ProjectSystem.IProjectVersionedValue<Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.PackageRestoreUnconfiguredInput>;
+
+using RestoreValues = System.ValueTuple<
+    System.Collections.Generic.IEnumerable<Microsoft.VisualStudio.ProjectSystem.ConfiguredProject>,
+    System.Collections.Generic.IReadOnlyList<Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.PackageRestoreConfiguredInput>>;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 {
@@ -14,13 +19,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
     {
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
+        private readonly IActiveConfiguredProjectsLoadedDataSource _loadedActiveConfiguredProjectsDataSource;
 
         [ImportingConstructor]
-        public PackageRestoreUnconfiguredInputDataSource(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
+        public PackageRestoreUnconfiguredInputDataSource(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService, IActiveConfiguredProjectsLoadedDataSource loadedActiveConfiguredProjectsDataSource)
             : base(project, synchronousDisposal: false, registerDataSource: false)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
+            _loadedActiveConfiguredProjectsDataSource = loadedActiveConfiguredProjectsDataSource;
         }
 
         protected override UnconfiguredProject ContainingProject
@@ -40,13 +47,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                 JoinableFactory,
                 _project);
 
-            // Transform all restore data -> combined restore data
-            DisposableValue<ISourceBlock<RestoreInfo>> mergeBlock = joinBlock.TransformWithNoDelta(update => update.Derive(MergeRestoreInputs));
+            IPropagatorBlock<IProjectVersionedValue<RestoreValues>, RestoreInfo> transformBlock
+                = DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<RestoreValues>, RestoreInfo>(update => update.Derive(MergeRestoreInputs));
+
+            // Publish when all target frameworks get loaded
+            var mergeBlock = ProjectDataSources.SyncLinkTo(
+                _loadedActiveConfiguredProjectsDataSource.SourceBlock.SyncLinkOptions(),
+                joinBlock.SyncLinkOptions(),
+                target: transformBlock, 
+                linkOptions: DataflowOption.PropagateCompletion,
+                cancellationToken: CancellationToken.None
+                );
 
             JoinUpstreamDataSources(_activeConfigurationGroupService.ActiveConfiguredProjectGroupSource);
 
             // Set the link up so that we publish changes to target block
-            mergeBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+            transformBlock.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
 
             return new DisposableBag
             {
@@ -57,8 +73,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             };
         }
 
-        private PackageRestoreUnconfiguredInput MergeRestoreInputs(IReadOnlyCollection<PackageRestoreConfiguredInput> inputs)
+        private PackageRestoreUnconfiguredInput MergeRestoreInputs(RestoreValues restoreValues)
         {
+            IReadOnlyList<PackageRestoreConfiguredInput> inputs = restoreValues.Item2;
+
             // If there are no updates, we have no active configurations
             ProjectRestoreInfo? restoreInfo = null;
             if (inputs.Count != 0)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsLoadedDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsLoadedDataSource.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem;
+
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = Composition.ImportCardinality.ExactlyOne)]
+internal interface IActiveConfiguredProjectsLoadedDataSource : IProjectValueDataSource<IEnumerable<ConfiguredProject>>
+{
+}


### PR DESCRIPTION
Avoid doing restore when receiving parts of the target frameworks. We can fix this by waiting for all target frameworks to get loaded and then publish.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8542)