### PR TITLE
Fix nuget restore perf regression

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -76,6 +76,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 
         private PackageRestoreUnconfiguredInput MergeRestoreInputs(RestoreValues restoreValues)
         {
+            System.Diagnostics.Debug.Assert(restoreValues.Item1.Count() == restoreValues.Item2.Count());
+
             IReadOnlyList<PackageRestoreConfiguredInput> inputs = restoreValues.Item2;
 
             // If there are no updates, we have no active configurations

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -59,20 +59,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
                 cancellationToken: CancellationToken.None
                 );
 
-            JoinUpstreamDataSources(_activeConfigurationGroupService.ActiveConfiguredProjectGroupSource);
+            JoinUpstreamDataSources(_activeConfigurationGroupService.ActiveConfiguredProjectGroupSource, _loadedActiveConfiguredProjectDataSource);
 
             // Set the link up so that we publish changes to target block
-            transformBlock.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+            var link = transformBlock.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
 
             return new DisposableBag
             {
                 joinBlock,
-
+                mergeBlock,
+                link,
                 // Link the active configured projects to our join block
                 _activeConfigurationGroupService.ActiveConfiguredProjectGroupSource.SourceBlock.LinkTo(joinBlock, DataflowOption.PropagateCompletion),
             };
         }
-
 
         private PackageRestoreUnconfiguredInput MergeRestoreInputs(RestoreValues restoreValues)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -8,9 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level
     ///     services, such as evaluation and build services, are started.
     /// </summary>
-    [Export(typeof(ActiveConfiguredProjectsLoader))]
-
-    internal class ActiveConfiguredProjectsLoader : ChainedProjectValueDataSourceBase<IEnumerable<ConfiguredProject>>
+    internal class ActiveConfiguredProjectsLoader : OnceInitializedOnceDisposed
     {
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
@@ -20,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         [ImportingConstructor]
         public ActiveConfiguredProjectsLoader(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService, IUnconfiguredProjectTasksService tasksService)
-            : base(containingProject: project, synchronousDisposal: false)
+            : base(synchronousDisposal: false)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
@@ -57,43 +55,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private async Task OnActiveConfigurationsChangedAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> e)
         {
-            await GetLoadedProjectsAsync(e);
-        }
-
-        protected override IDisposable? LinkExternalInput(ITargetBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> targetBlock)
-        {
-            IReceivableSourceBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> sourceBlock = _activeConfigurationGroupService.ActiveConfigurationGroupSource.SourceBlock;
-
-            DisposableValue<ISourceBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>>>? transformBlock = sourceBlock.TransformWithNoDelta(TransformAsync);
-
-            transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
-
-            return transformBlock;
-        }
-
-        private async Task<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> TransformAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
-        {
-            List<ConfiguredProject> generatedResult = await GetLoadedProjectsAsync(projectVersionedValue);
-
-            return new ProjectVersionedValue<IEnumerable<ConfiguredProject>>(generatedResult, projectVersionedValue.DataSourceVersions);
-        }
-
-        private async Task<List<ConfiguredProject>> GetLoadedProjectsAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
-        {
-            List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
-
-            foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
+            foreach (ProjectConfiguration configuration in e.Value)
             {
                 // Make sure we aren't currently unloading, or we don't unload while we load the configuration
-                var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() =>
+                await _tasksService.LoadedProjectAsync(() =>
                 {
                     return _project.LoadConfiguredProjectAsync(configuration);
                 });
-
-                generatedResult.Add(loadedConfiguredProject);
             }
-
-            return generatedResult;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedActiveConfiguredProjectDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedActiveConfiguredProjectDataSource.cs
@@ -2,6 +2,9 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem;
 
+/// <summary>
+/// This block publish data out loaded configuration when active configured project is changed. 
+/// </summary>
 [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = Composition.ImportCardinality.ExactlyOne)]
 internal interface ILoadedActiveConfiguredProjectDataSource : IProjectValueDataSource<IEnumerable<ConfiguredProject>>
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedActiveConfiguredProjectDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ILoadedActiveConfiguredProjectDataSource.cs
@@ -1,0 +1,8 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem;
+
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = Composition.ImportCardinality.ExactlyOne)]
+internal interface ILoadedActiveConfiguredProjectDataSource : IProjectValueDataSource<IEnumerable<ConfiguredProject>>
+{
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
@@ -32,6 +32,8 @@ internal class LoadedActiveConfiguredProjectsDataSource : ChainedProjectValueDat
 
         var link = transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
 
+        JoinUpstreamDataSources(_activeConfigurationGroupService.ActiveConfigurationGroupSource);
+
         return link;
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
@@ -46,19 +46,21 @@ internal class LoadedActiveConfiguredProjectsDataSource : ChainedProjectValueDat
 
     private async Task<List<ConfiguredProject>> GetLoadedProjectsAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
     {
-        return await JoinableFactory.RunAsync(async () =>
-        {
-            List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
+        return await JoinableFactory.RunAsync(() =>
+            _tasksService.LoadedProjectAsync(async() =>
+                {
+                    List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
 
-            foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
-            {
-                // Make sure we aren't currently unloading, or we don't unload while we load the configuration
-                var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() => _project.LoadConfiguredProjectAsync(configuration));
+                    foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
+                    {
+                        // Make sure we aren't currently unloading, or we don't unload while we load the configuration
+                        var loadedConfiguredProject = await _project.LoadConfiguredProjectAsync(configuration);
 
-                generatedResult.Add(loadedConfiguredProject);
-            }
+                        generatedResult.Add(loadedConfiguredProject);
+                    }
 
-            return generatedResult;
-        });
+                    return generatedResult;
+                })
+            );
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
@@ -30,9 +30,9 @@ internal class LoadedActiveConfiguredProjectsDataSource : ChainedProjectValueDat
 
         DisposableValue<ISourceBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>>>? transformBlock = sourceBlock.TransformWithNoDelta(TransformAsync);
 
-        transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+        var link = transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
 
-        return transformBlock;
+        return link;
     }
 
     private async Task<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> TransformAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Threading.Tasks.Dataflow;
+
+namespace Microsoft.VisualStudio.ProjectSystem;
+
+/// <summary>
+///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level
+///     services, such as evaluation and build services, are started.
+/// </summary>
+[Export(typeof(ILoadedActiveConfiguredProjectDataSource))]
+internal class LoadedActiveConfiguredProjectsDataSource : ChainedProjectValueDataSourceBase<IEnumerable<ConfiguredProject>>, ILoadedActiveConfiguredProjectDataSource
+{
+    private readonly UnconfiguredProject _project;
+    private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
+    private readonly IUnconfiguredProjectTasksService _tasksService;
+
+    [ImportingConstructor]
+    public LoadedActiveConfiguredProjectsDataSource(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService, IUnconfiguredProjectTasksService tasksService)
+        : base(containingProject: project, synchronousDisposal: false)
+    {
+        _project = project;
+        _activeConfigurationGroupService = activeConfigurationGroupService;
+        _tasksService = tasksService;
+    }
+
+    protected override IDisposable? LinkExternalInput(ITargetBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> targetBlock)
+    {
+        IReceivableSourceBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> sourceBlock = _activeConfigurationGroupService.ActiveConfigurationGroupSource.SourceBlock;
+
+        DisposableValue<ISourceBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>>>? transformBlock = sourceBlock.TransformWithNoDelta(TransformAsync);
+
+        transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+
+        return transformBlock;
+    }
+
+    private async Task<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> TransformAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
+    {
+        List<ConfiguredProject> generatedResult = await GetLoadedProjectsAsync(projectVersionedValue);
+
+        return new ProjectVersionedValue<IEnumerable<ConfiguredProject>>(generatedResult, projectVersionedValue.DataSourceVersions);
+    }
+
+    private async Task<List<ConfiguredProject>> GetLoadedProjectsAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
+    {
+        List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
+
+        foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
+        {
+            // Make sure we aren't currently unloading, or we don't unload while we load the configuration
+            var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() =>
+            {
+                return _project.LoadConfiguredProjectAsync(configuration);
+            });
+
+            generatedResult.Add(loadedConfiguredProject);
+        }
+
+        return generatedResult;
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
@@ -44,16 +44,19 @@ internal class LoadedActiveConfiguredProjectsDataSource : ChainedProjectValueDat
 
     private async Task<List<ConfiguredProject>> GetLoadedProjectsAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
     {
-        List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
-
-        foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
+        return await JoinableFactory.RunAsync(async () =>
         {
-            // Make sure we aren't currently unloading, or we don't unload while we load the configuration
-            var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() => _project.LoadConfiguredProjectAsync(configuration));
+            List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
 
-            generatedResult.Add(loadedConfiguredProject);
-        }
+            foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
+            {
+                // Make sure we aren't currently unloading, or we don't unload while we load the configuration
+                var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() => _project.LoadConfiguredProjectAsync(configuration));
 
-        return generatedResult;
+                generatedResult.Add(loadedConfiguredProject);
+            }
+
+            return generatedResult;
+        });
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LoadedActiveConfiguredProjectsDataSource.cs
@@ -49,10 +49,7 @@ internal class LoadedActiveConfiguredProjectsDataSource : ChainedProjectValueDat
         foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
         {
             // Make sure we aren't currently unloading, or we don't unload while we load the configuration
-            var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() =>
-            {
-                return _project.LoadConfiguredProjectAsync(configuration);
-            });
+            var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() => _project.LoadConfiguredProjectAsync(configuration));
 
             generatedResult.Add(loadedConfiguredProject);
         }


### PR DESCRIPTION
#7288

Avoid doing restore when receiving parts of the target frameworks. We can fix this by waiting for all target frameworks to get loaded and then publish.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8543)