### PR TITLE
Language service tidyup

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHostEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHostEnvironment.cs
@@ -19,8 +19,6 @@ internal sealed class LanguageServiceHostEnvironment : ILanguageServiceHostEnvir
         _isEnabled = new(
             async () =>
             {
-                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
-
                 // If VS is running in command line mode (e.g. "devenv.exe /build my.sln"),
                 // the language service host is not enabled. The one exception to this is
                 // when we're populating a solution cache via "/populateSolutionCache".

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -132,7 +132,8 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                 target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<(ConfiguredProject ActiveConfiguredProject, ConfigurationSubscriptionSources Sources)>>(
                     async update => await ExecuteUnderLockAsync(cancellationToken => OnSlicesChanged(update, cancellationToken)),
                     _unconfiguredProject,
-                    ProjectFaultSeverity.LimitedFunctionality),
+                    ProjectFaultSeverity.LimitedFunctionality,
+                    "LanguageServiceHostSlices {0}"),
                 linkOptions: DataflowOption.PropagateCompletion,
                 cancellationToken: cancellationToken),
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -298,22 +298,22 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
         {
             await ValidateEnabledAsync(cancellationToken);
 
-            await WhenProjectLoaded(cancellationToken);
+            await WhenProjectLoaded();
         }
 
         return _primaryWorkspace ?? throw Assumes.Fail("Primary workspace unknown.");
-    }
 
-    private async Task WhenProjectLoaded(CancellationToken cancellationToken)
-    {
-        // The active configuration can change multiple times during initialization in cases where we've incorrectly
-        // guessed the configuration via our IProjectConfigurationDimensionsProvider3 implementation.
-        // Wait until that has been determined before we publish the wrong configuration.
-        await _tasksService.PrioritizedProjectLoadedInHost.WithCancellation(cancellationToken);
+        async Task WhenProjectLoaded()
+        {
+            // The active configuration can change multiple times during initialization in cases where we've incorrectly
+            // guessed the configuration via our IProjectConfigurationDimensionsProvider3 implementation.
+            // Wait until that has been determined before we publish the wrong configuration.
+            await _tasksService.PrioritizedProjectLoadedInHost.WithCancellation(cancellationToken);
 
-        // We block project load on initialization of the primary workspace.
-        // Therefore by this point we must have set the primary workspace.
-        System.Diagnostics.Debug.Assert(_firstPrimaryWorkspaceSet.Task is { IsCompleted: true, IsFaulted: false });
+            // We block project load on initialization of the primary workspace.
+            // Therefore by this point we must have set the primary workspace.
+            System.Diagnostics.Debug.Assert(_firstPrimaryWorkspaceSet.Task is { IsCompleted: true, IsFaulted: false });
+        }
     }
 
     #endregion

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -296,7 +296,10 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
     {
         await ValidateEnabledAsync(cancellationToken);
 
-        await WhenProjectLoaded(cancellationToken);
+        using (_joinableTaskCollection.Join())
+        {
+            await WhenProjectLoaded(cancellationToken);
+        }
 
         return _primaryWorkspace ?? throw Assumes.Fail("Primary workspace unknown.");
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -333,10 +333,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
         // Ensure the project is not considered loaded until our first publication.
         Task result = _tasksService.PrioritizedProjectLoadedInHostAsync(async () =>
         {
-            using (_joinableTaskCollection.Join())
-            {
-                await WhenInitialized(_tasksService.UnloadCancellationToken);
-            }
+            await WhenInitialized(_tasksService.UnloadCancellationToken);
         });
 
         // While we want make sure it's loaded before PrioritizedProjectLoadedInHost,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -278,8 +278,6 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
     {
         token = _tasksService.LinkUnload(token);
 
-        await ValidateEnabledAsync(token);
-
         Workspace workspace = await GetPrimaryWorkspaceAsync(token);
 
         await workspace.WriteAsync(action, token);
@@ -288,8 +286,6 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
     public async Task<T> WriteAsync<T>(Func<IWorkspace, Task<T>> action, CancellationToken token)
     {
         token = _tasksService.LinkUnload(token);
-
-        await ValidateEnabledAsync(token);
 
         Workspace workspace = await GetPrimaryWorkspaceAsync(token);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -266,10 +266,10 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
 
     public async Task WhenInitialized(CancellationToken token)
     {
-        await ValidateEnabledAsync(token);
-
         using (_joinableTaskCollection.Join())
         {
+            await ValidateEnabledAsync(token);
+
             await _firstPrimaryWorkspaceSet.Task.WithCancellation(token);
         }
     }
@@ -294,10 +294,10 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
 
     private async Task<Workspace> GetPrimaryWorkspaceAsync(CancellationToken cancellationToken)
     {
-        await ValidateEnabledAsync(cancellationToken);
-
         using (_joinableTaskCollection.Join())
         {
+            await ValidateEnabledAsync(cancellationToken);
+
             await WhenProjectLoaded(cancellationToken);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -134,6 +134,10 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         return Task.CompletedTask;
     }
 
+    /// <summary>
+    /// Adds an object that will be disposed along with this <see cref="Workspace"/> instance.
+    /// </summary>
+    /// <param name="disposable">The object to dispose when this object is disposed.</param>
     public void ChainDisposal(IDisposable disposable)
     {
         Verify.NotDisposed(this);
@@ -141,6 +145,23 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         _disposableBag.Add(disposable);
     }
 
+    /// <summary>
+    /// Integrates project updates into the workspace.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This method must always receive an evaluation update first. After that point,
+    /// both evaluation and build updates may arrive in any order, so long as values
+    /// of each type are ordered correctly.
+    /// </para>
+    /// <para>
+    /// Calls must not overlap. This method is not thread-safe. This method is designed
+    /// to be called from a dataflow ActionBlock, which will serialize calls, so we
+    /// needn't perform any locking or protection here.
+    /// </para>
+    /// </remarks>
+    /// <param name="update">The project update to integrate.</param>
+    /// <returns>A task that completes when the update has been integrated.</returns>
     internal async Task OnWorkspaceUpdateAsync(IProjectVersionedValue<WorkspaceUpdate> update)
     {
         Verify.NotDisposed(this);


### PR DESCRIPTION
I recommend reviewing this one commit at a time.

Key changes:

- Remove duplicate validation and `JTC.Join` calls
- Ensure validation occurs within joined block to prevent deadlocks
- Remove a potentially redundant UI thread switch
- Add some API docs
- Give a dataflow action block a name to make debugging easier
