### PR TITLE
Build events property page buttons shouldn't overlap

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx
@@ -208,7 +208,7 @@
     <value>0, 3, 0, 3</value>
   </data>
   <data name="btnPreBuildBuilder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>10, 0, 10, 0</value>
+    <value>5, 0, 5, 0</value>
   </data>
   <data name="btnPreBuildBuilder.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 23</value>
@@ -502,7 +502,7 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>359, 259</value>
+    <value>718, 500</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
     <value>418, 536</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.resx
@@ -208,7 +208,7 @@
     <value>0, 3, 0, 3</value>
   </data>
   <data name="btnPreBuildBuilder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 0, 5, 0</value>
+    <value>20, 0, 20, 0</value>
   </data>
   <data name="btnPreBuildBuilder.Size" type="System.Drawing.Size, System.Drawing">
     <value>111, 23</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -90,6 +90,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End If
         End Function
 
+        Friend Sub EnsureMinimumSize()
+            Me.MinimumSize = overarchingTableLayoutPanel.MinimumSize
+        End Sub
+
         Private Sub PostBuildBuilderButton_Click(sender As Object, e As EventArgs) Handles btnPostBuildBuilder.Click
             Dim CommandLineText As String
             CommandLineText = txtPostBuildEventCommandLine.Text
@@ -166,6 +170,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Return MacroValue
         End Function
 
+        Private Sub BuildEventsPropPage_SizeChanged(sender As Object, e As EventArgs) Handles MyBase.SizeChanged
+            EnsureMinimumSize()
+        End Sub
     End Class
 
 End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildEventsPropPage.vb
@@ -91,7 +91,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Function
 
         Friend Sub EnsureMinimumSize()
-            Me.MinimumSize = overarchingTableLayoutPanel.MinimumSize
+            MinimumSize = overarchingTableLayoutPanel.MinimumSize
         End Sub
 
         Private Sub PostBuildBuilderButton_Click(sender As Object, e As EventArgs) Handles btnPostBuildBuilder.Click


### PR DESCRIPTION
**Problem:** On small screens, build events property page won't fit the window. As a result:
- Some parts of the page are clipped,
- Some of the content gets behind the "OK" and "Cancel" buttons, causing an overlap.

**Cause:** The issue is caused by the owner window [PropPageUserControlPage](https://github.com/dotnet/project-system/blob/main/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb#L2880), scaling the minimum size of the property page up based on the font:
-> [SetDialogFont(ScaleDialog As Boolean)](https://github.com/dotnet/project-system/blob/main/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb#L3541)
-> [MinimumSize = ScaleSize(MinimumSize, dx, dy)](https://github.com/dotnet/project-system/blob/main/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPageUserControlBase.vb#L3603)

 Thinking that they have a larger space to lay on, the controls are enlarging themselves to the point they don't fit the window.

**Fix:** The window that displays our property page is responsible for displaying other windows as well. I'm not sure why a font-based scaling is being done here, but I think it is risky to make a change in the owner and potentially break other property pages that use it. Therefore, the fix only handles the case for the Build Events property page.
    Build Events page listens to size change event and makes sure that its minimum size is always the same as the minimum size of its child control.

Screenshots:
**Before**
![d1](https://user-images.githubusercontent.com/60651445/193289598-2c9ffb7f-2f33-4a87-95f5-7586a5d407fe.png)

**After**
![d2](https://user-images.githubusercontent.com/60651445/193289629-00bc323e-ffab-4c1b-80e7-9d0d57e3b0c5.png)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8555)