### PR TITLE
Startup Object fix

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 // The AppliesTo metadata has no effect given the limitations described in https://github.com/dotnet/project-system/issues/8170.
-[ExportInterceptingPropertyValueProvider(StartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+[ExportInterceptingPropertyValueProvider(InterceptedStartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 [AppliesTo(ProjectCapability.VisualBasic)]
 internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBase
 {
@@ -17,6 +17,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     private const string DisabledValue = "WindowsFormsWithCustomSubMain";
 
     internal const string UseWinFormsProperty = "UseWindowsForms";
+    internal const string InterceptedStartupObjectProperty = "StartupObjectVB";
     internal const string StartupObjectProperty = "StartupObject";
     internal const string RootNamespaceProperty = "RootNamespace";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -43,6 +43,10 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
             if (Equals(applicationFrameworkValue, EnabledValue))
             {
                 // Set the startup object in the myapp file.
+                if(unevaluatedPropertyValue.StartsWith(rootNameSpace + ".", StringComparison.OrdinalIgnoreCase))
+                {
+                    unevaluatedPropertyValue = unevaluatedPropertyValue.Substring((rootNameSpace + ".").Length);
+                }
                 await _myAppXmlFileAccessor.SetMainFormAsync(unevaluatedPropertyValue);
 
                 // And save namespace.My.MyApplication in the project file.
@@ -52,7 +56,8 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
 
         // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
         // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-        return rootNameSpace + "." + unevaluatedPropertyValue;
+        await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, rootNameSpace + "." + unevaluatedPropertyValue);
+        return null;
     }
 
     public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -21,18 +21,22 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     internal const string StartupObjectProperty = "StartupObject";
     internal const string RootNamespaceProperty = "RootNamespace";
 
+    private readonly UnconfiguredProject _project;
+
     [ImportingConstructor]
-    public StartupObjectValueProvider(IMyAppFileAccessor myAppXmlFileAccessor)
+    public StartupObjectValueProvider(IMyAppFileAccessor myAppXmlFileAccessor, UnconfiguredProject project)
     {
         _myAppXmlFileAccessor = myAppXmlFileAccessor;
+        _project = project;
     }
 
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
-        string isWindowsFormsProject = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWinFormsProperty);
+        IProjectCapabilitiesScope capabilities = _project.Capabilities;
+        bool isWindowsForms = capabilities.Contains(ProjectCapability.WindowsForms);
         string rootNameSpace = await defaultProperties.GetEvaluatedPropertyValueAsync(RootNamespaceProperty);
 
-        if (bool.TryParse(isWindowsFormsProject, out bool b) && b)
+        if (isWindowsForms)
         {
             string applicationFrameworkValue = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkProperty);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -90,8 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 enumValues.AddRange(entryPoints.Select(ep =>
                 {
                     string name = ep.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
-                    string minimalName = ep.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
-                    return new PageEnumValue(new EnumValue { Name = minimalName, DisplayName = name });
+                    return new PageEnumValue(new EnumValue { Name = name, DisplayName = name });
                 }));
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -37,7 +37,7 @@
        For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
        We specify this by setting the SearchForEntryPointsInFormsOnly to true.
        We also want to ensure that the property always has a value. -->
-  <DynamicEnumProperty Name="StartupObject"
+  <DynamicEnumProperty Name="StartupObjectVB"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Úvodní obrazovka</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Definuje vstupní bod, který se má volat při načtení aplikace. Obecně je tato možnost nastavena buď na hlavní formulář v aplikaci, nebo na proceduru Main, která se má spustit při spuštění aplikace. Knihovny tříd vstupní bod nedefinují.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Spouštěcí objekt</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Begrüßungsbildschirm</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Hiermit wird der Einstiegspunkt definiert, der beim Laden der Anwendung aufgerufen werden soll. Im Allgemeinen wird dies entweder auf das Hauptformular in Ihrer Anwendung oder auf die Main-Prozedur festgelegt, die beim Starten der Anwendung ausgeführt werden soll. Klassenbibliotheken definieren keinen Einstiegspunkt.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Startobjekt</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Pantalla de presentación</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Define el punto de entrada al que se va a llamar cuando se cargue la aplicación. Normalmente, se establece en el formulario principal de la aplicación o en el procedimiento "Principal" que debe ejecutarse cuando se inicia la aplicación. Las bibliotecas de clases no definen ningún punto de entrada.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Objeto de inicio</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Écran de démarrage</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Définit le point d'entrée à appeler au chargement de l'application. En règle générale, il s'agit du formulaire principal de votre application ou de la procédure 'Main' qui doit s'exécuter au démarrage de l'application. Les bibliothèques de classes ne définissent pas de point d'entrée.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Objet de démarrage</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Schermata iniziale</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Definisce il punto di ingresso da chiamare quando l'applicazione viene caricata. In genere viene impostato sul modulo principale dell'applicazione o sulla routine 'Main' che deve essere eseguita all'avvio dell'applicazione. Le librerie di classi non definiscono un punto di ingresso.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Oggetto di avvio</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -82,14 +82,14 @@
         <target state="translated">スプラッシュ スクリーン</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">アプリケーションの読み込み時に呼び出されるエントリ ポイントを定義します。通常、これはアプリケーションのメイン フォームか、アプリケーションの起動時に実行する必要がある 'Main' プロシージャに設定されます。クラス ライブラリではエントリ ポイントが定義されていません。</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">スタートアップ オブジェクト</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -82,14 +82,14 @@
         <target state="translated">시작 화면</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">애플리케이션이 로드될 때 호출할 진입점을 정의합니다. 일반적으로 애플리케이션의 기본 양식 또는 애플리케이션이 시작할 때 실행되어야 하는 '기본' 프로시저로 설정됩니다. 클래스 라이브러리는 진입점을 정의하지 않습니다.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">시작 개체</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Ekran powitalny</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Definiuje punkt wejścia do wywołania, gdy aplikacja zostanie załadowana. Ta opcja jest zazwyczaj ustawiana na formularz główny w aplikacji lub na procedurę „Main”, która ma być uruchamiana po uruchomieniu aplikacji. Biblioteki klas nie definiują punktu wejścia.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Obiekt startowy</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Tela inicial</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Define o ponto de entrada a ser chamado quando o aplicativo é carregado. Geralmente, essa opção é definida como o formulário principal no aplicativo ou como o procedimento 'Main' que deve ser executado quando o aplicativo é iniciado. As bibliotecas de classe não definem um ponto de entrada.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Objeto de inicialização</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Экран-заставка</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Определяет точку входа, вызываемую при загрузке приложения. Обычно в качестве этой точки входа задается главная форма приложения или процедура "Main", которая должна выполняться при запуске приложения. В библиотеках классов точка входа не определяется.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Автоматически запускаемый объект</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -82,14 +82,14 @@
         <target state="translated">Giriş ekranı</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Uygulama yüklediğinde çağrılacak giriş noktasını tanımlar. Bu, genellikle uygulamanızda ana form olarak veya uygulama başladığında çalışması gereken 'Ana' yordam olarak ayarlanır. Sınıf kitaplıkları bir giriş noktası tanımlamaz.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Başlangıç nesnesi</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -82,14 +82,14 @@
         <target state="translated">初始屏幕</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">定义在加载应用程序时要调用的入口点。通常，此项设置为应用程序中的主窗体或应用程序启动时运行的 "Main" 过程。类库不定义入口点。</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">启动对象</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -82,14 +82,14 @@
         <target state="translated">啟動顯示畫面</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">定義應用程式載入時要呼叫的進入點。通常會設定為應用程式的主表單，或應用程式啟動時應執行的 'Main' 程序。類別庫未定義進入點。</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">啟始物件</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">


### PR DESCRIPTION
Addresses this [feedback ticket](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1631593).

When I introduced the changes in https://github.com/dotnet/project-system/pull/8419, I tried to avoid the namespace duplication in the code generated by the myapp file to the Application.Designer.vb file; I did this by modifying the EnumProvider to get the entry points without the root namespace in their name.

As the interceptor's filtering (`AppliesTo(ProjectCapability.VisualBasic)`) is not currently doing the actual filtering, C# users were affected by this and have discovered this produced a build to fail.

This PR reverts the modification I made to the EnumProvider; instead, we will remove the namespace when setting the property and identifying is a VB WinForms project.

I have been doing manual testing for the following scenarios:

| | Console | WinForms| 
| ---            | :--        | :--       | 
| C#            | ✅      | 
| VB            | ✅      | ✅

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8565)