### PR TITLE
[17.4] No fault when insufficient data to create workspace

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -321,17 +321,15 @@ public class WorkspaceTests
             }
             """);
 
-        var task = CreateInstanceAsync(evaluationRuleUpdate: evaluationRuleUpdate);
+        var instance = await CreateInstanceAsync(evaluationRuleUpdate: evaluationRuleUpdate);
 
         if (!empty1 && !empty2 && !empty3)
         {
-            await task;
+            Assert.False(instance.IsDisposed);
         }
         else
         {
-            var ex = await Assert.ThrowsAsync<Exception>(() => task);
-
-            Assert.Equal("Insufficient project data to initialize the language service.", ex.Message);
+            Assert.True(instance.IsDisposed);
         }
     }
 


### PR DESCRIPTION
Fixes #8343

There may be projects that do not provide enough information for us to create the workspace. An example of this is `.ilproj`. We should not fault the project in such cases by throwing. Instead, we dispose the workspace which tears down its dataflow and cleans up gracefully.

This restores the behaviour we had prior to the changes made to the language service code to improve performance of configuration switches.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8582)