### PR TITLE
[17.4] Fix bug when disabling fast up-to-date check

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 resolvedAnalyzerReferencePaths: ImmutableArray<string>.Empty,
                 resolvedCompilationReferencePaths: ImmutableArray<string>.Empty,
                 copyReferenceInputs: ImmutableArray<string>.Empty,
-                lastItemsChangedAtUtc: DateTime.MinValue,
+                lastItemsChangedAtUtc: null,
                 lastItemChanges: ImmutableArray<(bool IsAdd, string ItemType, UpToDateCheckInputItem)>.Empty,
                 itemHash: null);
         }


### PR DESCRIPTION
We assert that a value is not `DateTime.MinValue`, however we have code that sets that value when the check is disabled.

Using `null` instead fixes a bug that results in:

> System.ArgumentException: Must not be DateTime.MinValue. Parameter name: itemsChangedAtUtc

That exception was thrown in `UpToDateCheckStatePersistence.StoreItemStateAsync` here:

https://github.com/dotnet/project-system/blob/2b89a8976d977f1089dbe7a9df9f03e8a4e07b52/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs#L89

The regression was introduced in 17.3.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8583)