### PR TITLE
Refactor ProjectSystem/VS/Tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/UIImageService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/UIImageService.cs
@@ -3,6 +3,7 @@
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio.ProjectSystem.Tree;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree;
 
@@ -13,15 +14,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree;
 internal class UIImageService : IUIImageService
 {
     private readonly IVsUIService<SVsImageService, IVsImageService2> _vsImageService;
+    private readonly JoinableTaskContext _context;
 
     [ImportingConstructor]
-    public UIImageService(IVsUIService<SVsImageService, IVsImageService2> vsImageService)
+    public UIImageService(IVsUIService<SVsImageService, IVsImageService2> vsImageService, JoinableTaskContext context)
     {
         _vsImageService = vsImageService;
+        _context = context;
     }
 
     public ImageMoniker GetImageMonikerForFile(string filename)
     {
+        _context.VerifyIsOnMainThread();
+
         return _vsImageService.Value.GetImageMonikerForFile(filename);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/UIImageService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/UIImageService.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Tree;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree;
+
+/// <summary>
+/// Wrapper around the VS Service that provides ImageMonikers
+/// </summary>
+[Export(typeof(IUIImageService))]
+internal class UIImageService : IUIImageService
+{
+    private readonly IVsUIService<SVsImageService, IVsImageService2> _vsImageService;
+
+    [ImportingConstructor]
+    public UIImageService(IVsUIService<SVsImageService, IVsImageService2> vsImageService)
+    {
+        _vsImageService = vsImageService;
+    }
+
+    public ImageMoniker GetImageMonikerForFile(string filename)
+    {
+        return _vsImageService.Value.GetImageMonikerForFile(filename);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Shipped.txt
@@ -303,8 +303,6 @@ Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.Re
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.RelatableItemBase.RelatableItemBase(string! name) -> void
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.RelationBase<TParent, TChild>
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.RelationBase<TParent, TChild>.RelationBase() -> void
-Microsoft.VisualStudio.ProjectSystem.VS.Tree.IFileIconProvider
-Microsoft.VisualStudio.ProjectSystem.VS.Tree.IFileIconProvider.GetFileExtensionImageMoniker(string! path) -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker
 Microsoft.VisualStudio.ProjectSystem.VS.Utilities.FocusAttacher
 Microsoft.VisualStudio.ProjectSystem.VS.Utilities.FocusAttacher.FocusAttacher() -> void
 override Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.AttachedCollectionItemBase.ToString() -> string!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/TypeForwards.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/TypeForwards.cs
@@ -17,5 +17,6 @@ using System.Runtime.CompilerServices;
 [assembly: TypeForwardedTo(destination: typeof(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelatableItem))]
 [assembly: TypeForwardedTo(destination: typeof(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelation))]
 [assembly: TypeForwardedTo(destination: typeof(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider))]
+[assembly: TypeForwardedTo(destination: typeof(Microsoft.VisualStudio.ProjectSystem.VS.Tree.IFileIconProvider))]
 
 #pragma warning restore RS0016

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
@@ -2,8 +2,9 @@
 
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
+using Microsoft.VisualStudio.ProjectSystem.Tree;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Tree
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
 {
     [Export(typeof(IFileIconProvider))]
     internal sealed class FileIconProvider : IFileIconProvider

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
@@ -2,21 +2,20 @@
 
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
-using Microsoft.VisualStudio.Shell.Interop;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
+namespace Microsoft.VisualStudio.ProjectSystem.Tree
 {
     [Export(typeof(IFileIconProvider))]
     internal sealed class FileIconProvider : IFileIconProvider
     {
-        private readonly IVsUIService<SVsImageService, IVsImageService2> _vsImageService;
+        private readonly IUIImageService _imageService;
 
         private ImmutableDictionary<string, ImageMoniker> _imageMonikerByExtensions = ImmutableDictionary.Create<string, ImageMoniker>(StringComparers.Paths);
 
         [ImportingConstructor]
-        public FileIconProvider(IVsUIService<SVsImageService, IVsImageService2> vsImageService)
+        public FileIconProvider(IUIImageService vsImageService)
         {
-            _vsImageService = vsImageService;
+            _imageService = vsImageService;
         }
 
         public ImageMoniker GetFileExtensionImageMoniker(string path)
@@ -29,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
 
             ImageMoniker GetImageMoniker(string _, string p)
             {
-                ImageMoniker imageMoniker = _vsImageService.Value.GetImageMonikerForFile(p);
+                ImageMoniker imageMoniker = _imageService.GetImageMonikerForFile(p);
 
                 if (imageMoniker.Id == -1)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
@@ -14,9 +14,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
         private ImmutableDictionary<string, ImageMoniker> _imageMonikerByExtensions = ImmutableDictionary.Create<string, ImageMoniker>(StringComparers.Paths);
 
         [ImportingConstructor]
-        public FileIconProvider(IUIImageService vsImageService)
+        public FileIconProvider(IUIImageService imageService)
         {
-            _imageService = vsImageService;
+            _imageService = imageService;
         }
 
         public ImageMoniker GetFileExtensionImageMoniker(string path)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IFileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IFileIconProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
+namespace Microsoft.VisualStudio.ProjectSystem.Tree
 {
     /// <summary>
     /// Provides icons for files based on their file names.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IFileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IFileIconProvider.cs
@@ -4,7 +4,7 @@ using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.Imaging.Interop;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Tree
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
 {
     /// <summary>
     /// Provides icons for files based on their file names.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IUIImageService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IUIImageService.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Imaging.Interop;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Tree;
+
+[ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, Provider = ProjectSystemContractProvider.Private)]
+internal interface IUIImageService
+{
+    ImageMoniker GetImageMonikerForFile(string filename);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IUIImageService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/IUIImageService.cs
@@ -8,5 +8,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree;
 [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne, Provider = ProjectSystemContractProvider.Private)]
 internal interface IUIImageService
 {
+    /// <summary>
+    /// Returns an image moniker based on the file type.
+    /// </summary>
+    /// <remarks>
+    /// This requires the main thread.
+    /// </remarks>
+    /// <param name="filename"></param>
+    /// <returns></returns>
     ImageMoniker GetImageMonikerForFile(string filename);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI.Shipped.txt
@@ -216,3 +216,5 @@ Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IR
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider.GetContainedByRelationsFor(System.Type! childType) -> System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelation!>
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelationProvider.GetContainsRelationsFor(System.Type! parentType) -> System.Collections.Immutable.ImmutableArray<Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedCollections.IRelation!>
+Microsoft.VisualStudio.ProjectSystem.VS.Tree.IFileIconProvider
+Microsoft.VisualStudio.ProjectSystem.VS.Tree.IFileIconProvider.GetFileExtensionImageMoniker(string! path) -> Microsoft.VisualStudio.Imaging.Interop.ImageMoniker


### PR DESCRIPTION
Refactor `FileIconProvider` type to isolate dependencies with Vs
Move `FileIconProvider` to `Microsoft.VisualStudio.ProjectSystem.Managed` project.

This is part of https://github.com/dotnet/project-system/issues/8576

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8594)