### PR TITLE
Remove reference to IProjectAsyncLoadDashboard

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectTasksService.cs
@@ -1,111 +1,108 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.ProjectSystem.VS;
+namespace Microsoft.VisualStudio.ProjectSystem;
 
-namespace Microsoft.VisualStudio.ProjectSystem
+/// <summary>
+///     Provides methods for that assist in managing project-related background tasks. This interface replaces
+///     the IProjectAsyncLoadDashboard interface from CPS.
+/// </summary>
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
+internal interface IUnconfiguredProjectTasksService
 {
     /// <summary>
-    ///     Provides methods for that assist in managing project-related background tasks. This interface replaces
-    ///     <see cref="IProjectAsyncLoadDashboard"/> usage.
+    ///     Gets a token that is cancelled when the project has started to unload.
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private)]
-    internal interface IUnconfiguredProjectTasksService
-    {
-        /// <summary>
-        ///     Gets a token that is cancelled when the project has started to unload.
-        /// </summary>
-        /// <remarks>
-        ///     NOTE: This token is cancelled before <see cref="LoadedProjectAsync"/> actions
-        ///     have been completed, so callers can bail early if needed.
-        /// </remarks>
-        CancellationToken UnloadCancellationToken { get; }
+    /// <remarks>
+    ///     NOTE: This token is cancelled before <see cref="LoadedProjectAsync"/> actions
+    ///     have been completed, so callers can bail early if needed.
+    /// </remarks>
+    CancellationToken UnloadCancellationToken { get; }
 
-        /// <summary>
-        ///     Gets a task that completes when the host recognizes that the solution is loaded,
-        ///     or is cancelled if the project is unloaded before that occurs.
-        /// </summary>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was unloaded before the solution finished loading.
-        /// </exception>
-        Task SolutionLoadedInHost { get; }
+    /// <summary>
+    ///     Gets a task that completes when the host recognizes that the solution is loaded,
+    ///     or is cancelled if the project is unloaded before that occurs.
+    /// </summary>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was unloaded before the solution finished loading.
+    /// </exception>
+    Task SolutionLoadedInHost { get; }
 
-        /// <summary>
-        ///     Gets a task that completes when the host recognizes that the project is loaded,
-        ///     or is cancelled if the project is unloaded before that occurs.
-        /// </summary>
-        /// <remarks>
-        ///     This task completes after <see cref="PrioritizedProjectLoadedInHost"/> and is intended for
-        ///     non-critical services that need to complete after the project has been loaded, but
-        ///     after critical services.
-        /// </remarks>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was unloaded.
-        /// </exception>
-        Task ProjectLoadedInHost { get; }
+    /// <summary>
+    ///     Gets a task that completes when the host recognizes that the project is loaded,
+    ///     or is cancelled if the project is unloaded before that occurs.
+    /// </summary>
+    /// <remarks>
+    ///     This task completes after <see cref="PrioritizedProjectLoadedInHost"/> and is intended for
+    ///     non-critical services that need to complete after the project has been loaded, but
+    ///     after critical services.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was unloaded.
+    /// </exception>
+    Task ProjectLoadedInHost { get; }
 
-        /// <summary>
-        ///     Gets a task that completes when the host recognizes that the project is loaded,
-        ///     or is cancelled if the project is unloaded before that occurs.
-        /// </summary>
-        /// <remarks>
-        ///     This task completes before <see cref="ProjectLoadedInHost"/> and is intended for
-        ///     critical services that need to do work before non-critical services.
-        /// </remarks>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was unloaded.
-        /// </exception>
-        Task PrioritizedProjectLoadedInHost { get; }
+    /// <summary>
+    ///     Gets a task that completes when the host recognizes that the project is loaded,
+    ///     or is cancelled if the project is unloaded before that occurs.
+    /// </summary>
+    /// <remarks>
+    ///     This task completes before <see cref="ProjectLoadedInHost"/> and is intended for
+    ///     critical services that need to do work before non-critical services.
+    /// </remarks>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was unloaded.
+    /// </exception>
+    Task PrioritizedProjectLoadedInHost { get; }
 
-        /// <summary>
-        ///     Provides protection for an operation that the project will not close before the completion of some task.
-        /// </summary>
-        /// <param name="action">
-        ///     The action to execute within the context of a loaded project.
-        /// </param>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was already unloaded before this method was invoked.
-        /// </exception>
-        Task LoadedProjectAsync(Func<Task> action);
+    /// <summary>
+    ///     Provides protection for an operation that the project will not close before the completion of some task.
+    /// </summary>
+    /// <param name="action">
+    ///     The action to execute within the context of a loaded project.
+    /// </param>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was already unloaded before this method was invoked.
+    /// </exception>
+    Task LoadedProjectAsync(Func<Task> action);
 
-        /// <summary>
-        ///     Provides protection for an operation that the project will not close before the completion of some task.
-        /// </summary>
-        /// <typeparam name="T">
-        ///     The type of value returned by the joinable.
-        /// </typeparam>
-        /// <param name="action">
-        ///     The action to execute within the context of a loaded project.
-        /// </param>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was already unloaded before this method was invoked.
-        /// </exception>
-        Task<T> LoadedProjectAsync<T>(Func<Task<T>> action);
+    /// <summary>
+    ///     Provides protection for an operation that the project will not close before the completion of some task.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type of value returned by the joinable.
+    /// </typeparam>
+    /// <param name="action">
+    ///     The action to execute within the context of a loaded project.
+    /// </param>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was already unloaded before this method was invoked.
+    /// </exception>
+    Task<T> LoadedProjectAsync<T>(Func<Task<T>> action);
 
-        /// <summary>
-        ///     Provides protection for an operation that the project will not be considered loaded in the host before
-        ///     the completion of some task.
-        /// </summary>
-        /// <typeparam name="T">
-        ///     The type of value returned by the joinable.
-        /// </typeparam>
-        /// <param name="action">
-        ///     The action to execute before the project is considered loaded in the host.
-        /// </param>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was already unloaded before this method was invoked.
-        /// </exception>
-        Task<T> PrioritizedProjectLoadedInHostAsync<T>(Func<Task<T>> action);
+    /// <summary>
+    ///     Provides protection for an operation that the project will not be considered loaded in the host before
+    ///     the completion of some task.
+    /// </summary>
+    /// <typeparam name="T">
+    ///     The type of value returned by the joinable.
+    /// </typeparam>
+    /// <param name="action">
+    ///     The action to execute before the project is considered loaded in the host.
+    /// </param>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was already unloaded before this method was invoked.
+    /// </exception>
+    Task<T> PrioritizedProjectLoadedInHostAsync<T>(Func<Task<T>> action);
 
-        /// <summary>
-        ///     Provides protection for an operation that the project will not be considered loaded in the host before
-        ///     the completion of some task.
-        /// </summary>
-        /// <param name="action">
-        ///     The action to execute before the project is considered loaded in the host.
-        /// </param>
-        /// <exception cref="OperationCanceledException">
-        ///     Thrown if the project was already unloaded before this method was invoked.
-        /// </exception>
-        Task PrioritizedProjectLoadedInHostAsync(Func<Task> action);
-    }
+    /// <summary>
+    ///     Provides protection for an operation that the project will not be considered loaded in the host before
+    ///     the completion of some task.
+    /// </summary>
+    /// <param name="action">
+    ///     The action to execute before the project is considered loaded in the host.
+    /// </param>
+    /// <exception cref="OperationCanceledException">
+    ///     Thrown if the project was already unloaded before this method was invoked.
+    /// </exception>
+    Task PrioritizedProjectLoadedInHostAsync(Func<Task> action);
 }


### PR DESCRIPTION
The `IProjectAsyncLoadDashboard` interface comes from the VS layer of CPS, but we have a reference to it in a doc comment in Microsoft.ProjectSystem.VisualStudio.Managed.csproj. This removes the reference in order to enforce proper layering.

While I was at it, I updated the affected file to use a file-scoped namespace.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8601)