### PR TITLE
Replace uses of IProjectDiagnosticOutputService

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -71,6 +71,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "items", "items", "{5204CAC5
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Microsoft.VisualStudio.Editors.UnitTests", "tests\Microsoft.VisualStudio.Editors.UnitTests\Microsoft.VisualStudio.Editors.UnitTests.vbproj", "{A0B3F2BD-C92A-4037-A9F0-4EC484267E75}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{2BEDB95B-AAC2-4F6D-92EA-61F07E77887E}"
+	ProjectSection(SolutionItems) = preProject
+		src\Common\BannedSymbols.txt = src\Common\BannedSymbols.txt
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -154,6 +159,7 @@ Global
 		{C16993CC-6063-4447-AE16-BE671AFDE08A} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
 		{02578366-DFA9-4827-93F7-08E2AE5CE6A4} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
 		{A0B3F2BD-C92A-4037-A9F0-4EC484267E75} = {7349958E-C619-481F-BB2A-8A4CA2E349D9}
+		{2BEDB95B-AAC2-4F6D-92EA-61F07E77887E} = {1FF0293B-6808-4BB1-8370-1FE222986654}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6B652C28-D1FD-4885-A0CA-4704C54E78E7}

--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -13,6 +13,8 @@ T:Microsoft.VisualStudio.ProjectSystem.IProjectLockService; Using IProjectAccess
 T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectGuidService; Using ISafeProjectGuidService avoids reading the GUID before it is safe to do so during initialisation
 T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectGuidService2; Using ISafeProjectGuidService avoids reading the GUID before it is safe to do so during initialisation
 
+T:Microsoft.VisualStudio.ProjectSystem.VS.IProjectDiagnosticOutputService; Use IManagedProjectDiagnosticOutputService instead as it is more widely available
+
 T:NuGet.VisualStudio.IVsFrameworkParser; FrameworkName does not support the platform information added in .NET 5
 
 P:Microsoft.VisualStudio.ProjectSystem.VS.IProjectAsyncLoadDashboard.ProjectLoadedInHost; Using IUnconfiguredProjectTasksService.ProjectLoadedInHost prevents waiting indefinitely when the project is closed before it has finished loading

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/VsManagedProjectDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/VsManagedProjectDiagnosticOutputService.cs
@@ -2,11 +2,18 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging;
 
+#pragma warning disable RS0030 // Do not used banned APIs
 /// <summary>
 ///   An implementation of the <see cref="IManagedProjectDiagnosticOutputService"/> that
 ///   delegates to the CPS <see cref="IProjectDiagnosticOutputService"/>.
 /// </summary>
+/// <remarks>
+///   Note <see cref="IProjectDiagnosticOutputService"/> has been banned in order to
+///   encourage the use of the more widely available <see cref="IManagedProjectDiagnosticOutputService"/>,
+///   not for any technical reason.
+/// </remarks>
 [Export(typeof(IManagedProjectDiagnosticOutputService))]
+#pragma warning restore RS0030 // Do not used banned APIs
 [AppliesTo(ProjectCapability.DotNet)]
 internal class VsManagedProjectDiagnosticOutputService : IManagedProjectDiagnosticOutputService
 {
@@ -18,10 +25,14 @@ internal class VsManagedProjectDiagnosticOutputService : IManagedProjectDiagnost
         _projectDiagnosticOutputService = projectDiagnosticOutputService;
     }
 
+#pragma warning disable RS0030 // Do not used banned APIs
     public bool IsEnabled => _projectDiagnosticOutputService.IsEnabled;
+#pragma warning restore RS0030 // Do not used banned APIs
 
     public void WriteLine(string outputMessage)
     {
+#pragma warning disable RS0030 // Do not used banned APIs
         _projectDiagnosticOutputService.WriteLine(outputMessage);
+#pragma warning restore RS0030 // Do not used banned APIs
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/VsManagedProjectDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Logging/VsManagedProjectDiagnosticOutputService.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Logging;
+
+/// <summary>
+///   An implementation of the <see cref="IManagedProjectDiagnosticOutputService"/> that
+///   delegates to the CPS <see cref="IProjectDiagnosticOutputService"/>.
+/// </summary>
+[Export(typeof(IManagedProjectDiagnosticOutputService))]
+[AppliesTo(ProjectCapability.DotNet)]
+internal class VsManagedProjectDiagnosticOutputService : IManagedProjectDiagnosticOutputService
+{
+    private readonly IProjectDiagnosticOutputService _projectDiagnosticOutputService;
+
+    [ImportingConstructor]
+    public VsManagedProjectDiagnosticOutputService(IProjectDiagnosticOutputService projectDiagnosticOutputService)
+    {
+        _projectDiagnosticOutputService = projectDiagnosticOutputService;
+    }
+
+    public bool IsEnabled => _projectDiagnosticOutputService.IsEnabled;
+
+    public void WriteLine(string outputMessage)
+    {
+        _projectDiagnosticOutputService.WriteLine(outputMessage);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/PackageRestoreDataSource.cs
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
         private readonly IProjectAsynchronousTasksService _projectAsynchronousTasksService;
         private readonly IVsSolutionRestoreService3 _solutionRestoreService;
         private readonly IFileSystem _fileSystem;
-        private readonly IProjectDiagnosticOutputService _logger;
+        private readonly IManagedProjectDiagnosticOutputService _logger;
         private readonly IVsSolutionRestoreService4 _solutionRestoreService4;
         private byte[]? _latestHash;
         private bool _enabled;
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService projectAsynchronousTasksService,
             IVsSolutionRestoreService3 solutionRestoreService,
             IFileSystem fileSystem,
-            IProjectDiagnosticOutputService logger,
+            IManagedProjectDiagnosticOutputService logger,
             IVsSolutionRestoreService4 solutionRestoreService4,
             PackageRestoreSharedJoinableTaskCollection sharedJoinableTaskCollection)
             : base(project, sharedJoinableTaskCollection, synchronousDisposal: true, registerDataSource: false)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/RestoreLogger.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
 {
     internal static class RestoreLogger
     {
-        public static void BeginNominateRestore(IProjectDiagnosticOutputService logger, string fullPath, IVsProjectRestoreInfo2 projectRestoreInfo)
+        public static void BeginNominateRestore(IManagedProjectDiagnosticOutputService logger, string fullPath, IVsProjectRestoreInfo2 projectRestoreInfo)
         {
             if (logger.IsEnabled)
             {
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             }
         }
 
-        public static void EndNominateRestore(IProjectDiagnosticOutputService logger, string fullPath)
+        public static void EndNominateRestore(IManagedProjectDiagnosticOutputService logger, string fullPath)
         {
             if (logger.IsEnabled)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         ///     </para>
         ///     <paramref name="logger" /> is <see langword="null"/>.
         /// </exception>
-        public void ApplyProjectEvaluation(IWorkspaceProjectContext context, IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        public void ApplyProjectEvaluation(IWorkspaceProjectContext context, IComparable version, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             if (!difference.AnyChanges)
                 return;
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         ///     </para>
         ///     <paramref name="logger" /> is <see langword="null"/>.
         /// </exception>
-        public void ApplyProjectBuild(IWorkspaceProjectContext context, IComparable version, IProjectChangeDiff difference, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        public void ApplyProjectBuild(IWorkspaceProjectContext context, IComparable version, IProjectChangeDiff difference, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             if (!difference.AnyChanges)
                 return;
@@ -141,11 +141,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             ApplyChangesToContext(context, difference, ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal, ImmutableStringDictionary<IImmutableDictionary<string, string>>.EmptyOrdinal, isActiveContext, logger, evaluation: false);
         }
 
-        protected abstract void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectDiagnosticOutputService logger);
+        protected abstract void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger);
 
-        protected abstract void RemoveFromContext(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger);
+        protected abstract void RemoveFromContext(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger);
 
-        protected abstract void UpdateInContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger);
+        protected abstract void UpdateInContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger);
 
         private static bool IsItemInCurrentConfiguration(string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata)
         {
@@ -158,7 +158,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             return true;
         }
 
-        private void ApplyChangesToContext(IWorkspaceProjectContext context, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger, bool evaluation)
+        private void ApplyChangesToContext(IWorkspaceProjectContext context, IProjectChangeDiff difference, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger, bool evaluation)
         {
             foreach (string includePath in difference.RemovedItems)
             {
@@ -194,7 +194,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assumes.True(difference.RenamedItems.Count == 0, "We should have normalized renames.");
         }
 
-        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string includePath, IProjectDiagnosticOutputService logger)
+        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string includePath, IManagedProjectDiagnosticOutputService logger)
         {
             string fullPath = _project.MakeRooted(includePath);
 
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> metadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             string fullPath = _project.MakeRooted(includePath);
 
@@ -224,7 +224,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void UpdateInContextIfPresent(IWorkspaceProjectContext context, string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        private void UpdateInContextIfPresent(IWorkspaceProjectContext context, string includePath, IImmutableDictionary<string, IImmutableDictionary<string, string>> previousMetadata, IImmutableDictionary<string, IImmutableDictionary<string, string>> currentMetadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             string fullPath = _project.MakeRooted(includePath);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach (CommandLineSourceFile additionalFile in removed.AdditionalFiles)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             if (!_paths.Contains(fullPath))
             {
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
         {
             if (_paths.Contains(fullPath))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerConfigItemHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach (string analyzerConfigFile in removed.AnalyzerConfigFiles)
             {
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
         {
             if (!_paths.Contains(fullPath))
             {
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
         {
             if (_paths.Contains(fullPath))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/AnalyzerItemHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach (CommandLineAnalyzerReference analyzer in removed.AnalyzerReferences)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
         {
             if (!_paths.Contains(fullPath))
             {
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
         {
             if (_paths.Contains(fullPath))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CommandLineNotificationHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [ImportMany]
         public OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>> CommandLineNotifications { get; }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach (Lazy<Action<string, BuildOptions, BuildOptions>, IOrderPrecedenceMetadataView> value in CommandLineNotifications)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/CompileItemHandler.cs
@@ -26,19 +26,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return Compile.SchemaName; }
         }
 
-        public void Handle(IWorkspaceProjectContext context, ProjectConfiguration projectConfiguration, IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, ProjectConfiguration projectConfiguration, IComparable version, IProjectChangeDescription projectChange, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             ApplyProjectEvaluation(context, version, projectChange.Difference, projectChange.Before.Items, projectChange.After.Items, state.IsActiveEditorContext, logger);
         }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             IProjectChangeDiff difference = ConvertToProjectDiff(added, removed);
 
             ApplyProjectBuild(context, version, difference, state.IsActiveEditorContext, logger);
         }
 
-        protected override void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        protected override void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             string[]? folderNames = FileItemServices.GetLogicalFolderNames(Path.GetDirectoryName(_project.FullPath), fullPath, metadata);
 
@@ -46,13 +46,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             context.AddSourceFile(fullPath, isInCurrentContext: isActiveContext, folderNames: folderNames);
         }
 
-        protected override void RemoveFromContext(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+        protected override void RemoveFromContext(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
         {
             logger.WriteLine("Removing source file '{0}'", fullPath);
             context.RemoveSourceFile(fullPath);
         }
 
-        protected override void UpdateInContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+        protected override void UpdateInContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
         {
             if (LinkMetadataChanged(previousMetadata, currentMetadata))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/DynamicItemHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, IImmutableDictionary<string, IProjectChangeDescription> projectChanges, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, IImmutableDictionary<string, IProjectChangeDescription> projectChanges, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach ((_, IProjectChangeDescription projectChange) in projectChanges)
             {
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string includePath, IImmutableDictionary<string, string> metadata, IProjectDiagnosticOutputService logger)
+        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string includePath, IImmutableDictionary<string, string> metadata, IManagedProjectDiagnosticOutputService logger)
         {
             string fullPath = _project.MakeRooted(includePath);
 
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string includePath, IProjectDiagnosticOutputService logger)
+        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string includePath, IManagedProjectDiagnosticOutputService logger)
         {
             string fullPath = _project.MakeRooted(includePath);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _project = project;
         }
 
-        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach (CommandLineReference reference in removed.MetadataReferences)
             {
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             }
         }
 
-        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, MetadataReferenceProperties properties, IProjectDiagnosticOutputService logger)
+        private void AddToContextIfNotPresent(IWorkspaceProjectContext context, string fullPath, MetadataReferenceProperties properties, IManagedProjectDiagnosticOutputService logger)
         {
             if (_addedPathsWithMetadata.TryGetValue(fullPath, out MetadataReferenceProperties existingProperties))
             {
@@ -64,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             _addedPathsWithMetadata[fullPath] = properties;
         }
 
-        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, MetadataReferenceProperties properties, IProjectDiagnosticOutputService logger)
+        private void RemoveFromContextIfPresent(IWorkspaceProjectContext context, string fullPath, MetadataReferenceProperties properties, IManagedProjectDiagnosticOutputService logger)
         {
             if (_addedPathsWithMetadata.TryGetValue(fullPath, out MetadataReferenceProperties existingProperties))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectFilePathAndDisplayNameEvaluationHandler.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return ConfigurationGeneral.SchemaName; }
         }
 
-        public void Handle(IWorkspaceProjectContext context, ProjectConfiguration projectConfiguration, IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, ProjectConfiguration projectConfiguration, IComparable version, IProjectChangeDescription projectChange, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             if (projectChange.Difference.ChangedProperties.Contains(ConfigurationGeneral.MSBuildProjectFullPathProperty))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Handlers/ProjectPropertiesItemHandler.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             get { return LanguageService.SchemaName; }
         }
 
-        public void Handle(IWorkspaceProjectContext context, ProjectConfiguration projectConfiguration, IComparable version, IProjectChangeDescription projectChange, ContextState state, IProjectDiagnosticOutputService logger)
+        public void Handle(IWorkspaceProjectContext context, ProjectConfiguration projectConfiguration, IComparable version, IProjectChangeDescription projectChange, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
             foreach (string name in projectChange.Difference.ChangedProperties)
             {
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             context.IsPrimary = state.IsActiveConfiguration;
         }
 
-        private static bool TryHandleSpecificProperties(IWorkspaceProjectContext context, string name, string value, IProjectDiagnosticOutputService logger)
+        private static bool TryHandleSpecificProperties(IWorkspaceProjectContext context, string name, string value, IManagedProjectDiagnosticOutputService logger)
         {
             // The language service wants both the intermediate (bin\obj) and output (bin\debug)) paths
             // so that it can automatically hook up project-to-project references. It does this by matching the 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ICommandLineHandler.cs
@@ -32,8 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     A <see cref="ContextState"/> describing the state of the <see cref="IWorkspaceProjectContext"/>.
         /// </param>
         /// <param name="logger">
-        ///     The <see cref="IProjectDiagnosticOutputService"/> for logging to the log.
+        ///     The <see cref="IManagedProjectDiagnosticOutputService"/> for logging to the log.
         /// </param>
-        void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IProjectDiagnosticOutputService logger);
+        void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectEvaluationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/IProjectEvaluationHandler.cs
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     A <see cref="ContextState"/> describing the state of the <see cref="IWorkspaceProjectContext"/>.
         /// </param>
         /// <param name="logger">
-        ///     The <see cref="IProjectDiagnosticOutputService"/> for logging to the log.
+        ///     The <see cref="IManagedProjectDiagnosticOutputService"/> for logging to the log.
         /// </param>
         void Handle(
             IWorkspaceProjectContext context,
@@ -46,6 +46,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             IComparable version,
             IProjectChangeDescription projectChange,
             ContextState state,
-            IProjectDiagnosticOutputService logger);
+            IManagedProjectDiagnosticOutputService logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ISourceItemsHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ISourceItemsHandler.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         ///     A <see cref="ContextState"/> describing the state of the <see cref="IWorkspaceProjectContext"/>.
         /// </param>
         /// <param name="logger">
-        ///     The <see cref="IProjectDiagnosticOutputService"/> for logging to the log.
+        ///     The <see cref="IManagedProjectDiagnosticOutputService"/> for logging to the log.
         /// </param>
-        void Handle(IWorkspaceProjectContext context, IComparable version, IImmutableDictionary<string, IProjectChangeDescription> projectChanges, ContextState state, IProjectDiagnosticOutputService logger);
+        void Handle(IWorkspaceProjectContext context, IComparable version, IImmutableDictionary<string, IProjectChangeDescription> projectChanges, ContextState state, IManagedProjectDiagnosticOutputService logger);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -33,7 +33,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     private readonly UnconfiguredProject _unconfiguredProject;
     private readonly Guid _projectGuid;
     private readonly UpdateHandlers _updateHandlers;
-    private readonly IProjectDiagnosticOutputService _logger;
+    private readonly IManagedProjectDiagnosticOutputService _logger;
     private readonly IActiveEditorContextTracker _activeEditorContextTracker;
     private readonly OrderPrecedenceImportCollection<ICommandLineParserService> _commandLineParserServices;
     private readonly IDataProgressTrackerService _dataProgressTrackerService;
@@ -83,7 +83,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         UnconfiguredProject unconfiguredProject,
         Guid projectGuid,
         UpdateHandlers updateHandlers,
-        IProjectDiagnosticOutputService logger,
+        IManagedProjectDiagnosticOutputService logger,
         IActiveEditorContextTracker activeEditorContextTracker,
         OrderPrecedenceImportCollection<ICommandLineParserService> commandLineParserServices,
         IDataProgressTrackerService dataProgressTrackerService,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
@@ -21,7 +21,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
     private readonly UnconfiguredProject _unconfiguredProject;
     private readonly IProjectService _projectService;
     private readonly IProjectThreadingService _threadingService;
-    private readonly IProjectDiagnosticOutputService _logger;
+    private readonly IManagedProjectDiagnosticOutputService _logger;
     private readonly IDataProgressTrackerService _dataProgressTrackerService;
     private readonly IActiveEditorContextTracker _activeWorkspaceProjectContextTracker;
     private readonly IProjectFaultHandlerService _faultHandlerService;
@@ -37,7 +37,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
         IProjectService projectService,
         IProjectThreadingService threadingService,
         IUnconfiguredProjectTasksService tasksService,
-        IProjectDiagnosticOutputService logger,
+        IManagedProjectDiagnosticOutputService logger,
         IDataProgressTrackerService dataProgressTrackerService,
         IActiveEditorContextTracker activeWorkspaceProjectContextTracker,
         IProjectFaultHandlerService faultHandlerService,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/BatchLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/BatchLogger.cs
@@ -10,11 +10,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     /// </summary>
     internal sealed class BatchLogger : IDisposable
     {
-        private readonly IProjectDiagnosticOutputService _outputService;
+        private readonly IManagedProjectDiagnosticOutputService _outputService;
         private StringBuilder? _builder;
         private int _indentLevel;
 
-        public BatchLogger(IProjectDiagnosticOutputService outputService)
+        public BatchLogger(IManagedProjectDiagnosticOutputService outputService)
         {
             Requires.NotNull(outputService, nameof(outputService));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IManagedProjectDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IManagedProjectDiagnosticOutputService.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS;
+
+/// <summary>
+///   A service to print out diagnostic messages about project system functionality.
+///   Meant to be used in place of the IProjectDiagnosticOutputService from CPS.
+/// </summary>
+[ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
+internal interface IManagedProjectDiagnosticOutputService
+{
+    /// <summary>
+    ///    Gets a value indicating whether the output service is enabled.
+    /// </summary>
+    bool IsEnabled { get; }
+
+    /// <summary>
+    ///   Writes a line of message to the output service.
+    /// </summary>
+    /// <param name="outputMessage">The message string.</param>
+    void WriteLine(string outputMessage);
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IManagedProjectDiagnosticOutputService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/IManagedProjectDiagnosticOutputService.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS;
 
 /// <summary>
 ///   A service to print out diagnostic messages about project system functionality.
-///   Meant to be used in place of the IProjectDiagnosticOutputService from CPS.
+///   Meant to be used in place of the IManagedProjectDiagnosticOutputService from CPS.
 /// </summary>
 [ProjectSystemContract(ProjectSystemContractScope.ProjectService, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
 internal interface IManagedProjectDiagnosticOutputService

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectDiagnosticOutputServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectDiagnosticOutputServiceExtensions.cs
@@ -3,12 +3,12 @@
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {
     /// <summary>
-    ///     Provides extension methods for <see cref="IProjectDiagnosticOutputService"/> instances.
+    ///     Provides extension methods for <see cref="IManagedProjectDiagnosticOutputService"/> instances.
     /// </summary>
     internal static partial class ProjectDiagnosticOutputServiceExtensions
     {
         /// <summary>
-        ///     If <see cref="IProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
+        ///     If <see cref="IManagedProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
         ///     writes the text representation of the specified object, followed
         ///     by the current line terminator, to the log using the specified
         ///     format information.
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <exception cref="FormatException">
         ///     The format specification in <paramref name="format"/> is invalid.
         /// </exception>
-        public static void WriteLine(this IProjectDiagnosticOutputService logger, string format, object? argument)
+        public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, object? argument)
         {
             Requires.NotNull(logger, nameof(logger));
 
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         /// <summary>
-        ///     If <see cref="IProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
+        ///     If <see cref="IManagedProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
         ///     writes the text representation of the specified objects, followed
         ///     by the current line terminator, to the log using the specified format
         ///     information.
@@ -49,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <exception cref="FormatException">
         ///     The format specification in <paramref name="format"/> is invalid.
         /// </exception>
-        public static void WriteLine(this IProjectDiagnosticOutputService logger, string format, object? argument1, object? argument2)
+        public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, object? argument1, object? argument2)
         {
             Requires.NotNull(logger, nameof(logger));
 
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         /// <summary>
-        ///     If <see cref="IProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
+        ///     If <see cref="IManagedProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
         ///     writes the text representation of the specified objects, followed
         ///     by the current line terminator, to the log using the specified
         ///     format information.
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <exception cref="FormatException">
         ///     The format specification in <paramref name="format"/> is invalid.
         /// </exception>
-        public static void WriteLine(this IProjectDiagnosticOutputService logger, string format, object? argument1, object? argument2, object? argument3)
+        public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, object? argument1, object? argument2, object? argument3)
         {
             Requires.NotNull(logger, nameof(logger));
 
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         }
 
         /// <summary>
-        ///     If <see cref="IProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
+        ///     If <see cref="IManagedProjectDiagnosticOutputService.IsEnabled"/> is <see langword="true"/>,
         ///     writes the  text representation of the specified array of objects,
         ///     followed  by the current line terminator, to the log using the
         ///     specified format information.
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <exception cref="FormatException">
         ///     The format specification in <paramref name="format"/> is invalid.
         /// </exception>
-        public static void WriteLine(this IProjectDiagnosticOutputService logger, string format, params object?[] arguments)
+        public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, params object?[] arguments)
         {
             Requires.NotNull(logger, nameof(logger));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectEvaluationHandlerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectEvaluationHandlerFactory.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     internal static class IProjectEvaluationHandlerFactory
     {
         public static IProjectEvaluationHandler ImplementHandle(
-            Action<IWorkspaceProjectContext, ProjectConfiguration, IComparable, IProjectChangeDescription, ContextState, IProjectDiagnosticOutputService> action,
+            Action<IWorkspaceProjectContext, ProjectConfiguration, IComparable, IProjectChangeDescription, ContextState, IManagedProjectDiagnosticOutputService> action,
             string? projectEvaluationRule = null)
         {
             var mock = new Mock<IProjectEvaluationHandler>();
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
                     It.IsAny<IComparable>(),
                     It.IsAny<IProjectChangeDescription>(),
                     It.IsAny<ContextState>(),
-                    It.IsAny<IProjectDiagnosticOutputService>()))
+                    It.IsAny<IManagedProjectDiagnosticOutputService>()))
                 .Callback(action);
 
             mock.SetupGet(o => o.ProjectEvaluationRule).Returns(projectEvaluationRule ?? "MyEvaluationRule");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLoggerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectLoggerFactory.cs
@@ -4,11 +4,11 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
-    internal static class IProjectDiagnosticOutputServiceFactory
+    internal static class IManagedProjectDiagnosticOutputServiceFactory
     {
-        public static IProjectDiagnosticOutputService Create()
+        public static IManagedProjectDiagnosticOutputService Create()
         {
-            return Mock.Of<IProjectDiagnosticOutputService>();
+            return Mock.Of<IManagedProjectDiagnosticOutputService>();
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.EvaluationCommandLineHandler.cs
@@ -22,17 +22,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             public Dictionary<string, IImmutableDictionary<string, string>> Files { get; }
 
-            protected override void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+            protected override void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
             {
                 Files.Add(fullPath, metadata);
             }
 
-            protected override void RemoveFromContext(IWorkspaceProjectContext context, string fullPath, IProjectDiagnosticOutputService logger)
+            protected override void RemoveFromContext(IWorkspaceProjectContext context, string fullPath, IManagedProjectDiagnosticOutputService logger)
             {
                 Files.Remove(fullPath);
             }
 
-            protected override void UpdateInContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IProjectDiagnosticOutputService logger)
+            protected override void UpdateInContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> previousMetadata, IImmutableDictionary<string, string> currentMetadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
             {
                 RemoveFromContext(context, fullPath, logger);
                 AddToContext(context, fullPath, currentMetadata, isActiveContext, logger);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -377,7 +377,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             metadata ??= ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
             var previousMetadata = ImmutableDictionary<string, IImmutableDictionary<string, string>>.Empty;
             bool isActiveContext = true;
-            var logger = IProjectDiagnosticOutputServiceFactory.Create();
+            var logger = IManagedProjectDiagnosticOutputServiceFactory.Create();
 
             handler.ApplyProjectEvaluation(context, version, difference, previousMetadata, metadata, isActiveContext, logger);
         }
@@ -385,7 +385,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         private static void ApplyProjectBuild(IWorkspaceProjectContext context, AbstractEvaluationCommandLineHandler handler, IComparable version, IProjectChangeDiff difference)
         {
             bool isActiveContext = true;
-            var logger = IProjectDiagnosticOutputServiceFactory.Create();
+            var logger = IManagedProjectDiagnosticOutputServiceFactory.Create();
 
             handler.ApplyProjectBuild(context, version, difference, isActiveContext, logger);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Myproject.csproj");
             var context = IWorkspaceProjectContextMockFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
-            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+            var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new CompileItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\ProjectFolder\Myproject.csproj");
             var context = IWorkspaceProjectContextMockFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
-            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+            var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new CompileItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/DynamicItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/DynamicItemHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                     }
                     """));
 
-            handler.Handle(context, 1, projectChanges, new ContextState(), IProjectDiagnosticOutputServiceFactory.Create());
+            handler.Handle(context, 1, projectChanges, new ContextState(), IManagedProjectDiagnosticOutputServiceFactory.Create());
 
             Assert.Equal(2, dynamicFiles.Count);
             Assert.Contains(@"C:\File1.razor", dynamicFiles);
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                         }
                         """));
 
-            handler.Handle(context, 1, projectChanges, new ContextState(), IProjectDiagnosticOutputServiceFactory.Create());
+            handler.Handle(context, 1, projectChanges, new ContextState(), IManagedProjectDiagnosticOutputServiceFactory.Create());
 
             Assert.Equal(2, dynamicFiles.Count);
             Assert.Contains(@"C:\File1.razor", dynamicFiles);
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
                         }
                         """));
 
-            handler.Handle(context, 1, projectChanges, new ContextState(), IProjectDiagnosticOutputServiceFactory.Create());
+            handler.Handle(context, 1, projectChanges, new ContextState(), IManagedProjectDiagnosticOutputServiceFactory.Create());
 
             Assert.Equal(2, dynamicFiles.Count);
             Assert.Contains(@"C:\File1.razor", dynamicFiles);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/EvaluationHandlerTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             projectConfiguration ??= ProjectConfigurationFactory.Create("Debug|AnyCPU");
 
-            handler.Handle(context, projectConfiguration, 1, projectChange, new ContextState(), IProjectDiagnosticOutputServiceFactory.Create());
+            handler.Handle(context, projectConfiguration, 1, projectChange, new ContextState(), IManagedProjectDiagnosticOutputServiceFactory.Create());
         }
 
         internal abstract IProjectEvaluationHandler CreateInstance();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Myproject.csproj");
             var context = IWorkspaceProjectContextMockFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
-            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+            var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
 
             var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\ProjectFolder\Myproject.csproj");
             var context = IWorkspaceProjectContextMockFactory.CreateForMetadataReferences(project, onReferenceAdded, onReferenceRemoved);
-            var logger = Mock.Of<IProjectDiagnosticOutputService>();
+            var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new MetadataReferenceItemHandler(project);
             var projectDir = Path.GetDirectoryName(project.FullPath);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemsHandlerTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/Handlers/SourceItemsHandlerTestBase.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     {
         internal static void Handle(IWorkspaceProjectContext context, ISourceItemsHandler handler, IImmutableDictionary<string, IProjectChangeDescription> projectChanges)
         {
-            handler.Handle(context, 1, projectChanges, new ContextState(), IProjectDiagnosticOutputServiceFactory.Create());
+            handler.Handle(context, 1, projectChanges, new ContextState(), IManagedProjectDiagnosticOutputServiceFactory.Create());
         }
 
         internal abstract ISourceItemsHandler CreateInstance();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -379,7 +379,7 @@ public class WorkspaceTests
                     1,
                     It.IsAny<IProjectChangeDescription>(),
                     It.IsAny<ContextState>(),
-                    It.IsAny<IProjectDiagnosticOutputService>()));
+                    It.IsAny<IManagedProjectDiagnosticOutputService>()));
         }
 
         var workspace = await CreateInstanceAsync(
@@ -443,7 +443,7 @@ public class WorkspaceTests
                         1,
                         It.IsAny<IProjectChangeDescription>(),
                         new ContextState(false, true),
-                        It.IsAny<IProjectDiagnosticOutputService>()));
+                        It.IsAny<IManagedProjectDiagnosticOutputService>()));
         }
 
         var workspace = await CreateInstanceAsync(
@@ -489,7 +489,7 @@ public class WorkspaceTests
                         1,
                         It.IsAny<ImmutableDictionary<string, IProjectChangeDescription>>(),
                         new ContextState(false, true),
-                        It.IsAny<IProjectDiagnosticOutputService>()));
+                        It.IsAny<IManagedProjectDiagnosticOutputService>()));
         }
 
         var workspace = await CreateInstanceAsync(
@@ -548,7 +548,7 @@ public class WorkspaceTests
                     It.Is<BuildOptions>(options => options.MetadataReferences.Select(r => r.Reference).SingleOrDefault() == "Added.dll"),
                     It.Is<BuildOptions>(options => options.MetadataReferences.Select(r => r.Reference).SingleOrDefault() == "Removed.dll"),
                     new ContextState(false, true),
-                    It.IsAny<IProjectDiagnosticOutputService>()));
+                    It.IsAny<IManagedProjectDiagnosticOutputService>()));
         }
 
         var parser = ICommandLineParserServiceFactory.CreateCSharp();
@@ -746,7 +746,7 @@ public class WorkspaceTests
         Guid? projectGuid = null,
         UpdateHandlers? updateHandlers = null,
         bool isPrimary = true,
-        IProjectDiagnosticOutputService? logger = null,
+        IManagedProjectDiagnosticOutputService? logger = null,
         IActiveEditorContextTracker? activeWorkspaceProjectContextTracker = null,
         OrderPrecedenceImportCollection<ICommandLineParserService>? commandLineParserServices = null,
         IDataProgressTrackerService? dataProgressTrackerService = null,
@@ -770,7 +770,7 @@ public class WorkspaceTests
         unconfiguredProject ??= UnconfiguredProjectFactory.ImplementFullPath("""C:\MyProject\MyProject.csproj""");
         projectGuid ??= Guid.NewGuid();
         updateHandlers ??= new UpdateHandlers(Array.Empty<ExportFactory<IWorkspaceUpdateHandler>>());
-        logger ??= IProjectDiagnosticOutputServiceFactory.Create();
+        logger ??= IManagedProjectDiagnosticOutputServiceFactory.Create();
         activeWorkspaceProjectContextTracker ??= IActiveEditorContextTrackerFactory.Create();
         commandLineParserServices ??= new(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst) { commandLineParserService.Object };
         dataProgressTrackerService ??= IDataProgressTrackerServiceFactory.Create();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Logging/ProjectLoggingExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Logging/ProjectLoggingExtensionsTests.cs
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             Assert.Equal("Line1\r\n    Line2\r\nLine3", logger.Text, ignoreLineEndingDifferences: true);
         }
 
-        private class MockOutputService : IProjectDiagnosticOutputService
+        private class MockOutputService : IManagedProjectDiagnosticOutputService
         {
             public bool IsEnabled { get; set; } = true;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreDataSourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/PackageRestoreDataSourceTests.cs
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             dataSource ??= IPackageRestoreUnconfiguredInputDataSourceFactory.Create();
             IProjectAsynchronousTasksService projectAsynchronousTasksService = IProjectAsynchronousTasksServiceFactory.Create();
             solutionRestoreService ??= IVsSolutionRestoreServiceFactory.Create();
-            IProjectDiagnosticOutputService logger = IProjectDiagnosticOutputServiceFactory.Create();
+            IManagedProjectDiagnosticOutputService logger = IManagedProjectDiagnosticOutputServiceFactory.Create();
             IFileSystem fileSystem = IFileSystemFactory.Create();
             var vsSolutionRestoreService4 = IVsSolutionRestoreService4Factory.ImplementRegisterRestoreInfoSourceAsync();
             var sharedJoinableTaskCollection = new PackageRestoreSharedJoinableTaskCollection(IProjectThreadingServiceFactory.Create());

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreDataSourceMocked.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PackageRestore/Snapshots/PackageRestoreDataSourceMocked.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore.Snapshots
             IProjectAsynchronousTasksService projectAsynchronousTasksService, 
             IVsSolutionRestoreService3 solutionRestoreService, 
             IFileSystem fileSystem, 
-            IProjectDiagnosticOutputService logger, 
+            IManagedProjectDiagnosticOutputService logger, 
             IVsSolutionRestoreService4 solutionRestoreService4, 
             PackageRestoreSharedJoinableTaskCollection sharedJoinableTaskCollection) 
             : base(featureFlagsService, telemetryService, infoBarService, project, dataSource, projectAsynchronousTasksService, solutionRestoreService, fileSystem, logger, solutionRestoreService4, sharedJoinableTaskCollection)


### PR DESCRIPTION
The `IProjectDiagnosticOutputService` type is defined in the VS layer of CPS, but we use it extensively in our non-VS layer (that is, the Microsoft.VisualStudio.ProjectSystem.Managed.csproj project). To enforce the expected layering, uses of this interface are replaced with a new `IManagedProjectDiagnosticOutputService`. This is defined in Microsoft.VisualStudio.ProjectSystem.Managed.csproj, but the implementation is in Microsoft.VisualStudio.ProjectSystem.Managed.**VS**.csproj.

`IProjectDiagnosticOutputService` has also been marked as banned, with a message saying that `IManagedProjectDiagnosticOutputService` should be used instead.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8602)