### PR TITLE
Add skip compliance parameter to build pipeline

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -113,6 +113,11 @@ parameters:
   displayName: Do Not Optimize Assemblies
   type: boolean
   default: false
+# Useful when testing pipeline changes and running compliance is not necessary.
+- name: SkipCompliance
+  displayName: Skip Compliance Validation
+  type: boolean
+  default: false
 # This should only be enabled if we need to create AzDO work items based on Compliance failures.
 - name: UploadTSAResults
   displayName: Create Compliance Work Items
@@ -150,37 +155,39 @@ stages:
   - template: templates/publish-symbols.yml
   - template: templates/publish-richnav.yml
 
-- stage: Compliance
-  displayName: Compliance
-  dependsOn: Build
-  variables:
-  - name: UploadTSAResults
-    value: ${{ parameters.UploadTSAResults }}
-  # Gets the VisualStudioMinimumVersion variable produced by the Build pipeline.
-  # This value is used in the analyze-api.yml template.
-  - name: VisualStudioMinimumVersion
-    value: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetVisualStudioMinimumVersionVariable.VisualStudioMinimumVersion'] ]
-  # https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=434&path=DotNet-Project-System
-  # Variables used:
-  # - ApiScanConnectionString
-  - group: DotNet-Project-System
-  jobs:
-  - template: templates/analyze-compliance.yml
-  - template: templates/analyze-api.yml
+# Skip this stage only when specifically requested (via SkipCompliance).
+- ${{ if eq(parameters.SkipCompliance, false) }}:
+  - stage: Compliance
+    displayName: Compliance
+    dependsOn: Build
+    variables:
+    - name: UploadTSAResults
+      value: ${{ parameters.UploadTSAResults }}
+    # Gets the VisualStudioMinimumVersion variable produced by the Build pipeline.
+    # This value is used in the analyze-api.yml template.
+    - name: VisualStudioMinimumVersion
+      value: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetVisualStudioMinimumVersionVariable.VisualStudioMinimumVersion'] ]
+    # https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=434&path=DotNet-Project-System
+    # Variables used:
+    # - ApiScanConnectionString
+    - group: DotNet-Project-System
+    jobs:
+    - template: templates/analyze-compliance.yml
+    - template: templates/analyze-api.yml
 
-- stage: Localization
-  displayName: Localization
-  # [] clears the dependency on the previous stages allowing parallelism.
-  dependsOn: []
-  variables:
-  # Variable group containing the PATs required for running OneLocBuild.
-  # See: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
-  # Variables used:
-  # - BotAccount-dotnet-bot-repo-PAT
-  # - dn-bot-ceapex-package-r
-  - group: OneLocBuildVariables
-  jobs:
-  - template: templates/generate-localization.yml
+  - stage: Localization
+    displayName: Localization
+    # [] clears the dependency on the previous stages allowing parallelism.
+    dependsOn: []
+    variables:
+    # Variable group containing the PATs required for running OneLocBuild.
+    # See: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
+    # Variables used:
+    # - BotAccount-dotnet-bot-repo-PAT
+    # - dn-bot-ceapex-package-r
+    - group: OneLocBuildVariables
+    jobs:
+    - template: templates/generate-localization.yml
 
 # Run this stage only when specifically requested (via CreateOptimizationData) or when the pipeline was ran on a schedule.
 - ${{ if or(eq(parameters.CreateOptimizationData, true), eq(variables['Build.Reason'], 'Schedule')) }}:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -175,19 +175,19 @@ stages:
     - template: templates/analyze-compliance.yml
     - template: templates/analyze-api.yml
 
-  - stage: Localization
-    displayName: Localization
-    # [] clears the dependency on the previous stages allowing parallelism.
-    dependsOn: []
-    variables:
-    # Variable group containing the PATs required for running OneLocBuild.
-    # See: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
-    # Variables used:
-    # - BotAccount-dotnet-bot-repo-PAT
-    # - dn-bot-ceapex-package-r
-    - group: OneLocBuildVariables
-    jobs:
-    - template: templates/generate-localization.yml
+- stage: Localization
+  displayName: Localization
+  # [] clears the dependency on the previous stages allowing parallelism.
+  dependsOn: []
+  variables:
+  # Variable group containing the PATs required for running OneLocBuild.
+  # See: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
+  # Variables used:
+  # - BotAccount-dotnet-bot-repo-PAT
+  # - dn-bot-ceapex-package-r
+  - group: OneLocBuildVariables
+  jobs:
+  - template: templates/generate-localization.yml
 
 # Run this stage only when specifically requested (via CreateOptimizationData) or when the pipeline was ran on a schedule.
 - ${{ if or(eq(parameters.CreateOptimizationData, true), eq(variables['Build.Reason'], 'Schedule')) }}:

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -199,7 +199,9 @@ stages:
       displayName: Optimization
       dependsOn:
       - Publish
-      - Compliance
+      # Only include the Compliance stage when it is not skipped.
+      - ${{ if eq(parameters.SkipCompliance, false) }}:
+        - Compliance
       variables:
       - name: visualStudioBootstrapperURI
         # If you set this value to the visualStudioBootstrapperURI parameter directly, it does not resolve correctly. Instead, we set it to a variable and pass that variable into the parameter.
@@ -254,7 +256,9 @@ stages:
     # The Build dependsOn is required for putting that stage's variables into the stageDependencies property bag (for PackageVersion).
     - Build
     - Publish
-    - Compliance
+    # Only include the Compliance stage when it is not skipped.
+    - ${{ if eq(parameters.SkipCompliance, false) }}:
+      - Compliance
     variables:
       # Gets the PackageVersion variable produced by the Build pipeline.
       PackageVersion: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetPackageVersion.PackageVersion'] ]


### PR DESCRIPTION
When testing infrastructure changes, it is common for it to be unnecessary to run compliance checks. To speed up testing, I've added a parameter to skip compliance checks to our `official.yml` pipeline.

![image](https://user-images.githubusercontent.com/17788297/195732767-d2fc5038-510e-4cc5-9042-3127d7cb6c38.png)

### Test Run
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6823223&view=results

![image](https://user-images.githubusercontent.com/17788297/195733182-55f0923d-2678-4ec2-bca9-03a3deb00264.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8603)