### PR TITLE
Use ISafeProjectGuidService

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.ProjectSystem.VS;
-
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
@@ -14,17 +12,20 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private bool _enabled;
 
         private readonly ConfiguredProject _project;
+        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
 
         [ImportingConstructor]
         public MissingSdkRuntimeDetector(
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
             ConfiguredProject configuredProject,
+            ISafeProjectGuidService projectGuidService,
             IProjectThreadingService threadingService)
             : base(threadingService.JoinableTaskContext)
         {
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
             _project = configuredProject;
+            _projectGuidService = projectGuidService;
         }
 
         public Task LoadAsync()
@@ -48,7 +49,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
+            _projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
             _missingSetupComponentRegistrationService.RegisterProjectConfiguration(_projectGuid, _project);
             _ = RegisterSdkRuntimeNeededInProjectAsync(_project);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/MissingWorkloadDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/MissingWorkloadDetector.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.ProjectSystem.VS;
-
 namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 {
     /// <summary>
@@ -13,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
     {
         private readonly ConfiguredProject _project;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
+        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IWorkloadDescriptorDataSource _workloadDescriptorDataSource;
         private readonly IProjectFaultHandlerService _projectFaultHandlerService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
@@ -30,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             ConfiguredProject project,
             IWorkloadDescriptorDataSource workloadDescriptorDataSource,
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
+            ISafeProjectGuidService projectGuidService,
             IProjectThreadingService threadingService,
             IProjectFaultHandlerService projectFaultHandlerService,
             IProjectSubscriptionService projectSubscriptionService)
@@ -38,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             _project = project;
             _workloadDescriptorDataSource = workloadDescriptorDataSource;
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
+            _projectGuidService = projectGuidService;
             _projectFaultHandlerService = projectFaultHandlerService;
             _projectSubscriptionService = projectSubscriptionService;
         }
@@ -68,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
+            _projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
             _joinedDataSources = ProjectDataSources.JoinUpstreamDataSources(JoinableFactory, _projectFaultHandlerService, _projectSubscriptionService.ProjectSource, _workloadDescriptorDataSource);
 
             _missingSetupComponentRegistrationService.RegisterProjectConfiguration(_projectGuid, _project);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/WebMissingWorkloadDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/WebMissingWorkloadDetector.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.ProjectSystem.VS;
-
 namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 {
     /// <summary>
@@ -13,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
     {
         private readonly ConfiguredProject _project;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
+        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IWebWorkloadDescriptorDataSource _wpfWorkloadDescriptorDataSource;
         private readonly IProjectFaultHandlerService _projectFaultHandlerService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
@@ -28,6 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             ConfiguredProject project,
             IWebWorkloadDescriptorDataSource wpfWorkloadDescriptorDataSource,
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
+            ISafeProjectGuidService projectGuidService,
             IProjectThreadingService threadingService,
             IProjectFaultHandlerService projectFaultHandlerService,
             IProjectSubscriptionService projectSubscriptionService)
@@ -36,6 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             _project = project;
             _wpfWorkloadDescriptorDataSource = wpfWorkloadDescriptorDataSource;
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
+            _projectGuidService = projectGuidService;
             _projectFaultHandlerService = projectFaultHandlerService;
             _projectSubscriptionService = projectSubscriptionService;
         }
@@ -64,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
+            _projectGuid = await _projectGuidService.GetProjectGuidAsync();
             _joinedDataSources = ProjectDataSources.JoinUpstreamDataSources(JoinableFactory, _projectFaultHandlerService, _projectSubscriptionService.ProjectSource, _wpfWorkloadDescriptorDataSource);
 
             Action<IProjectVersionedValue<ValueTuple<IProjectSnapshot, ISet<WorkloadDescriptor>>>> action = OnWorkloadDescriptorsComputed;


### PR DESCRIPTION
Replace a few uses of the `UnconfiguredProject.GetProjectGuidAsync()` extension method with the `ISafeProjectGuidService` instead. The extension method comes from the VS layer of CPS and so we really shouldn't be using it in these locations anyway, and the `ISafeProjectGuidService` ensures that the project has loaded to the point where the GUID isn't going to change after we get it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8611)