### PR TITLE
[17.4] Join upstream data sources in LanguageServiceHost

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -136,6 +136,8 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                 linkOptions: DataflowOption.PropagateCompletion,
                 cancellationToken: cancellationToken),
 
+            ProjectDataSources.JoinUpstreamDataSources(_joinableTaskFactory, _projectFaultHandler, _activeConfiguredProjectProvider, _activeConfigurationGroupSubscriptionService),
+
             new DisposableDelegate(() =>
             {
                 // Dispose all workspaces. Note that this happens within a lock, so we will not race with project updates.


### PR DESCRIPTION
Relates to [AB#1357805](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1357805)

To avoid hangs, we must ensure that the LanguageServiceHost's upstream data sources are joined.

Thanks to @adrianvmsft for discovering this issue.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8614)