### PR TITLE
Don't lock for dataflow updates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/LanguageServiceHost.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 [Export(typeof(IWorkspaceWriter))]
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.DotNetLanguageService)]
-internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLockAsync, IProjectDynamicLoadComponent, IWorkspaceWriter
+internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent, IWorkspaceWriter
 {
     private readonly TaskCompletionSource _firstPrimaryWorkspaceSet = new();
 
@@ -130,7 +130,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
                 // We track per-slice data via this source.
                 _activeConfigurationGroupSubscriptionService.SourceBlock.SyncLinkOptions(),
                 target: DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<(ConfiguredProject ActiveConfiguredProject, ConfigurationSubscriptionSources Sources)>>(
-                    async update => await ExecuteUnderLockAsync(cancellationToken => OnSlicesChanged(update, cancellationToken)),
+                    update => OnSlicesChanged(update, cancellationToken),
                     _unconfiguredProject,
                     ProjectFaultSeverity.LimitedFunctionality),
                 linkOptions: DataflowOption.PropagateCompletion,
@@ -344,7 +344,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedUnderLock
         _projectFaultHandler.Forget(result, _unconfiguredProject, ProjectFaultSeverity.LimitedFunctionality);
     }
 
-    protected override Task DisposeCoreUnderLockAsync(bool initialized)
+    protected override Task DisposeCoreAsync(bool initialized)
     {
         _firstPrimaryWorkspaceSet.TrySetCanceled();
 


### PR DESCRIPTION
Split out of https://github.com/dotnet/project-system/pull/8550 to simplify review.

The action block serialises updates, so they won't overlap. There's no race condition with the dispose method either, as the dispose logic just tears down the dataflow links.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8618)