### PR TITLE
LinkLabel on Settings PropPage should be accessible by tab key

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsDesignerView.vb
@@ -9,16 +9,15 @@ Imports System.Web.ClientServices.Providers
 Imports System.Windows.Forms
 Imports System.Windows.Forms.Design
 Imports System.Xml
-
 Imports Microsoft.VisualStudio.Designer.Interfaces
 Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.DesignerFramework
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.Editors.PropertyPages
-Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.Shell.Interop
-Imports Microsoft.VSDesigner.VSDesignerPackage
+Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VSDesigner
+Imports Microsoft.VSDesigner.VSDesignerPackage
 
 Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 
@@ -175,13 +174,17 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             _settingsGridView.EditMode = DataGridViewEditMode.EditOnKeystrokeOrF2
             _settingsGridView.Text = "m_SettingsGridView"
             _settingsGridView.DefaultCellStyle.NullValue = ""
+            _settingsGridView.TabIndex = 1
 
             ScopeColumn.Items.Add(DesignTimeSettingInstance.SettingScope.Application)
             ScopeColumn.Items.Add(DesignTimeSettingInstance.SettingScope.User)
 
             SetLinkLabelText()
+            _descriptionLinkLabel.TabIndex = 0
 
             _settingsGridView.ColumnHeadersHeight = _settingsGridView.Rows(0).GetPreferredHeight(0, DataGridViewAutoSizeRowMode.AllCells, False)
+            AddHandler _settingsGridView.KeyDown, AddressOf OnGridKeyDown
+
             _toolbarPanel = New DesignerToolbarPanel With {
                 .Name = "ToolbarPanel",
                 .Text = "ToolbarPanel"
@@ -189,6 +192,17 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             _settingsTableLayoutPanel.Controls.Add(_toolbarPanel, 0, 0)
             _settingsTableLayoutPanel.ResumeLayout()
             ResumeLayout()
+        End Sub
+
+        Private Sub OnGridKeyDown(s As Object, e As KeyEventArgs)
+            If e.KeyCode = Keys.Tab Then
+                ' Tab key shouldn't be used to move us to the next cell. Otherwise we can't leave the grid view without traversing
+                ' the whole table with Tab key (even then, we get stuck at the last cell).
+                ' Tab key should instead get us to the next tab stop, making all the controls accessible by keyboard.
+                ' Moving between cells can be done using arrow keys.
+                _descriptionLinkLabel.Focus()
+                e.Handled = True
+            End If
         End Sub
 
         ''' <summary>


### PR DESCRIPTION
DataGrid in Settings property page traps the keyboard and won't allow selecting the link label using tab key.

The fix repurposes the tab key to be used by navigating between other controls in the page while leaving the job of navigating within the data grid to arrow keys.

Before:
Tab key will get you into the data grid and stops functioning after all the cells in the table are traversed.
<img width="518" alt="accessibility_before" src="https://user-images.githubusercontent.com/60651445/196472146-59119c06-7cb6-4002-8be3-a8a30a10deb9.png">


After:
Tab key will first visit the link label, then go into the table. Pressing the tab key will then move back to the label. To navigate within the table, user will need to use the arrow keys instead of the tab key.
<img width="496" alt="accessibility_after" src="https://user-images.githubusercontent.com/60651445/196472467-edd27bbb-ba30-4581-b192-935df063c048.png">


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8619)