### PR TITLE
Revert "Use ISafeProjectGuidService"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Runtimes/MissingSdkRuntimeDetector.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [Export(ExportContractNames.Scopes.ConfiguredProject, typeof(IProjectDynamicLoadComponent))]
@@ -12,20 +14,17 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private bool _enabled;
 
         private readonly ConfiguredProject _project;
-        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
 
         [ImportingConstructor]
         public MissingSdkRuntimeDetector(
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
             ConfiguredProject configuredProject,
-            ISafeProjectGuidService projectGuidService,
             IProjectThreadingService threadingService)
             : base(threadingService.JoinableTaskContext)
         {
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
             _project = configuredProject;
-            _projectGuidService = projectGuidService;
         }
 
         public Task LoadAsync()
@@ -49,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            _projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
+            _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
             _missingSetupComponentRegistrationService.RegisterProjectConfiguration(_projectGuid, _project);
             _ = RegisterSdkRuntimeNeededInProjectAsync(_project);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/MissingWorkloadDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/MissingWorkloadDetector.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 {
     /// <summary>
@@ -11,7 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
     {
         private readonly ConfiguredProject _project;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
-        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IWorkloadDescriptorDataSource _workloadDescriptorDataSource;
         private readonly IProjectFaultHandlerService _projectFaultHandlerService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
@@ -29,7 +30,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             ConfiguredProject project,
             IWorkloadDescriptorDataSource workloadDescriptorDataSource,
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
-            ISafeProjectGuidService projectGuidService,
             IProjectThreadingService threadingService,
             IProjectFaultHandlerService projectFaultHandlerService,
             IProjectSubscriptionService projectSubscriptionService)
@@ -38,7 +38,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             _project = project;
             _workloadDescriptorDataSource = workloadDescriptorDataSource;
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
-            _projectGuidService = projectGuidService;
             _projectFaultHandlerService = projectFaultHandlerService;
             _projectSubscriptionService = projectSubscriptionService;
         }
@@ -69,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            _projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
+            _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
             _joinedDataSources = ProjectDataSources.JoinUpstreamDataSources(JoinableFactory, _projectFaultHandlerService, _projectSubscriptionService.ProjectSource, _workloadDescriptorDataSource);
 
             _missingSetupComponentRegistrationService.RegisterProjectConfiguration(_projectGuid, _project);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/WebMissingWorkloadDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Workloads/WebMissingWorkloadDetector.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.ProjectSystem.VS;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 {
     /// <summary>
@@ -11,7 +13,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
     {
         private readonly ConfiguredProject _project;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
-        private readonly ISafeProjectGuidService _projectGuidService;
         private readonly IWebWorkloadDescriptorDataSource _wpfWorkloadDescriptorDataSource;
         private readonly IProjectFaultHandlerService _projectFaultHandlerService;
         private readonly IProjectSubscriptionService _projectSubscriptionService;
@@ -27,7 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             ConfiguredProject project,
             IWebWorkloadDescriptorDataSource wpfWorkloadDescriptorDataSource,
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
-            ISafeProjectGuidService projectGuidService,
             IProjectThreadingService threadingService,
             IProjectFaultHandlerService projectFaultHandlerService,
             IProjectSubscriptionService projectSubscriptionService)
@@ -36,7 +36,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             _project = project;
             _wpfWorkloadDescriptorDataSource = wpfWorkloadDescriptorDataSource;
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
-            _projectGuidService = projectGuidService;
             _projectFaultHandlerService = projectFaultHandlerService;
             _projectSubscriptionService = projectSubscriptionService;
         }
@@ -65,7 +64,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
 
         protected override async Task InitializeCoreAsync(CancellationToken cancellationToken)
         {
-            _projectGuid = await _projectGuidService.GetProjectGuidAsync();
+            _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
             _joinedDataSources = ProjectDataSources.JoinUpstreamDataSources(JoinableFactory, _projectFaultHandlerService, _projectSubscriptionService.ProjectSource, _wpfWorkloadDescriptorDataSource);
 
             Action<IProjectVersionedValue<ValueTuple<IProjectSnapshot, ISet<WorkloadDescriptor>>>> action = OnWorkloadDescriptorsComputed;


### PR DESCRIPTION
Reverts dotnet/project-system#8611. That PR was causing a hang when loading projects.

`git bisect` attributed the bug to 6a3d113ad2f8d8960279b4ee1ea4b2d5022473dd.

@tmeschter can you investigate the hang? I'm in the middle of debugging another important bug and don't want to get sidetracked.