### PR TITLE
Allow Roslyn to request arbitrary project properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/EvaluationUpdate.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/EvaluationUpdate.cs
@@ -7,13 +7,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 /// </summary>
 internal sealed class EvaluationUpdate
 {
-    public EvaluationUpdate(ConfiguredProject configuredProject, IProjectSubscriptionUpdate evaluationRuleUpdate, IProjectSubscriptionUpdate sourceItemsUpdate)
+    public EvaluationUpdate(ConfiguredProject configuredProject, IProjectSnapshot projectSnapshot, IProjectSubscriptionUpdate evaluationRuleUpdate, IProjectSubscriptionUpdate sourceItemsUpdate)
     {
         Requires.NotNull(configuredProject, nameof(configuredProject));
+        Requires.NotNull(projectSnapshot, nameof(projectSnapshot));
         Requires.NotNull(evaluationRuleUpdate, nameof(evaluationRuleUpdate));
         Requires.NotNull(sourceItemsUpdate, nameof(sourceItemsUpdate));
 
         ConfiguredProject = configuredProject;
+        ProjectSnapshot = projectSnapshot;
         EvaluationRuleUpdate = evaluationRuleUpdate;
         SourceItemsUpdate = sourceItemsUpdate;
     }
@@ -26,6 +28,14 @@ internal sealed class EvaluationUpdate
     /// For example, it changes when switching between Debug and Release configurations.
     /// </remarks>
     public ConfiguredProject ConfiguredProject { get; }
+
+    /// <summary>
+    /// The current MSBuild snapshot of the project. Used only during workspace construction,
+    /// in order to allow Roslyn to request arbitrary properties from the project. Without this,
+    /// we can only serve up properties defined in our rules, which couples the project system
+    /// to Roslyn.
+    /// </summary>
+    public IProjectSnapshot ProjectSnapshot { get; }
 
     public IProjectSubscriptionUpdate EvaluationRuleUpdate { get; }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.Build.Execution;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.OperationProgress;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -265,7 +266,9 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
             try
             {
-                EvaluationDataAdapter evaluationData = new(snapshot.Properties);
+                ProjectInstance projectInstance = evaluationUpdate.Value.ProjectSnapshot.ProjectInstance;
+
+                EvaluationDataAdapter evaluationData = new(projectInstance);
 
                 _contextId = GetWorkspaceProjectContextId(projectFilePath, _projectGuid, _slice);
 
@@ -581,16 +584,16 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     /// </summary>
     private sealed class EvaluationDataAdapter : EvaluationData
     {
-        private readonly IImmutableDictionary<string, string> _properties;
+        private readonly ProjectInstance _projectInstance;
 
-        public EvaluationDataAdapter(IImmutableDictionary<string, string> properties)
+        public EvaluationDataAdapter(ProjectInstance projectInstance)
         {
-            _properties = properties;
+            _projectInstance = projectInstance;
         }
 
         public override string GetPropertyValue(string name)
         {
-            _properties.TryGetValue(name, out string? value);
+            string? value = _projectInstance.GetProperty(name)?.EvaluatedValue;
 
             // Return the empty string rather than null.
             value ??= "";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -603,9 +603,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
             string? value = _projectInstance.GetProperty(name)?.EvaluatedValue;
 
             // Return the empty string rather than null.
-            value ??= "";
-
-            return value;
+            return value ?? "";
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceUpdate.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceUpdate.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 /// </remarks>
 internal sealed class WorkspaceUpdate
 {
-    public static WorkspaceUpdate FromEvaluation((ConfiguredProject ConfiguredProject, IProjectSubscriptionUpdate EvaluationRuleUpdate, IProjectSubscriptionUpdate SourceItemsUpdate) update) => new(new(update.ConfiguredProject, update.EvaluationRuleUpdate, update.SourceItemsUpdate), null);
+    public static WorkspaceUpdate FromEvaluation((ConfiguredProject ConfiguredProject, IProjectSnapshot ProjectSnapshot, IProjectSubscriptionUpdate EvaluationRuleUpdate, IProjectSubscriptionUpdate SourceItemsUpdate) update) => new(new(update.ConfiguredProject, update.ProjectSnapshot, update.EvaluationRuleUpdate, update.SourceItemsUpdate), null);
 
     public static WorkspaceUpdate FromBuild((ConfiguredProject ConfiguredProject, IProjectSubscriptionUpdate BuildRuleUpdate) update) => new(null, new(update.ConfiguredProject, update.BuildRuleUpdate));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -137,10 +137,6 @@
   <BoolProperty Name="Optimize"
                 Visible="False" />
 
-  <StringProperty Name="OutputAssemblyForDesignTimeEvaluation"
-                  ReadOnly="True"
-                  Visible="False" />
-
   <StringProperty Name="OutputName"
                   Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -53,9 +53,6 @@
   <StringProperty Name="Configuration"
                   Visible="False" />
 
-  <StringProperty Name="CommandLineArgsForDesignTimeEvaluation"
-                  Visible="False" />
-
   <StringProperty Name="DebuggerSymbolsPath"
                   Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.cs
@@ -1,9 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers;
 
 namespace Microsoft.VisualStudio.ProjectSystem
 {
+    /// <summary>
+    /// Models properties used in <see cref="ProjectPropertiesItemHandler"/>,
+    /// to set properties on the <see cref="IWorkspaceProjectContext"/>.
+    /// </summary>
     [ExcludeFromCodeCoverage]
     [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
     internal partial class LanguageService

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceFactoryTests.cs
@@ -75,7 +75,8 @@ public class WorkspaceFactoryTests
         ConfiguredProject configuredProject = ConfiguredProjectFactory.Create();
         IProjectSubscriptionUpdate evaluationRuleUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
         IProjectSubscriptionUpdate sourceItemsUpdate = IProjectSubscriptionUpdateFactory.CreateEmpty();
-        var workspaceUpdate = WorkspaceUpdate.FromEvaluation((configuredProject, evaluationRuleUpdate, sourceItemsUpdate));
+        IProjectSnapshot projectSnapshot = IProjectSnapshot2Factory.Create();
+        var workspaceUpdate = WorkspaceUpdate.FromEvaluation((configuredProject, projectSnapshot, evaluationRuleUpdate, sourceItemsUpdate));
 
         return new ProjectVersionedValue<WorkspaceUpdate>(
             workspaceUpdate,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -247,10 +247,7 @@ public class WorkspaceTests
                     "ConfigurationGeneral": {
                         "Properties": {
                             "LanguageServiceName": "LanguageServiceName",
-                            "TargetPath": "TargetPath",
                             "MSBuildProjectFullPath": "MSBuildProjectFullPath",
-                            "AssemblyName": "AssemblyName",
-                            "CommandLineArgsForDesignTimeEvaluation": "CommandLineArgsForDesignTimeEvaluation"
                         }
                     }
                 },
@@ -301,9 +298,6 @@ public class WorkspaceTests
                         "Properties": {
                             "LanguageServiceName": "{{(emptyLanguageService ? "" : "LanguageServiceName")}}",
                             "MSBuildProjectFullPath": "{{(emptyFullPath ? "" : "MSBuildProjectFullPath")}}",
-                            "TargetPath": "TargetPath",
-                            "AssemblyName": "AssemblyName",
-                            "CommandLineArgsForDesignTimeEvaluation": "CommandLineArgsForDesignTimeEvaluation"
                         }
                     }
                 },
@@ -340,10 +334,7 @@ public class WorkspaceTests
                     "ConfigurationGeneral": {
                         "Properties": {
                             "LanguageServiceName": "LanguageServiceName",
-                            "TargetPath": "TargetPath",
                             "MSBuildProjectFullPath": "MSBuildProjectFullPath",
-                            "AssemblyName": "AssemblyName",
-                            "CommandLineArgsForDesignTimeEvaluation": "CommandLineArgsForDesignTimeEvaluation"
                         }
                     }
                 },
@@ -403,10 +394,7 @@ public class WorkspaceTests
                     "ConfigurationGeneral": {
                         "Properties": {
                             "LanguageServiceName": "LanguageServiceName",
-                            "TargetPath": "TargetPath",
                             "MSBuildProjectFullPath": "MSBuildProjectFullPath",
-                            "AssemblyName": "AssemblyName",
-                            "CommandLineArgsForDesignTimeEvaluation": "CommandLineArgsForDesignTimeEvaluation"
                         }
                     }
                 },
@@ -833,10 +821,7 @@ public class WorkspaceTests
                     "ConfigurationGeneral": {
                         "Properties": {
                             "LanguageServiceName": "LanguageServiceName",
-                            "TargetPath": "TargetPath",
                             "MSBuildProjectFullPath": "MSBuildProjectFullPath",
-                            "AssemblyName": "AssemblyName",
-                            "CommandLineArgsForDesignTimeEvaluation": "CommandLineArgsForDesignTimeEvaluation"
                         }
                     }
                 },
@@ -868,7 +853,9 @@ public class WorkspaceTests
             }
             """);
 
-        var update = WorkspaceUpdate.FromEvaluation((configuredProject, evaluationRuleUpdate, sourceItemsUpdate));
+        IProjectSnapshot projectSnapshot = IProjectSnapshot2Factory.Create();
+
+        var update = WorkspaceUpdate.FromEvaluation((configuredProject, projectSnapshot, evaluationRuleUpdate, sourceItemsUpdate));
 
         await workspace.OnWorkspaceUpdateAsync(
             IProjectVersionedValueFactory.Create(update, ProjectDataSources.ConfiguredProjectVersion, configuredProjectVersion));


### PR DESCRIPTION
Historically, the set of project properties we passed to Roslyn when initialising an `IWorkspaceProjectContext` was hard-coded in the project system. We changed this recently in #8499, and introduced a means for Roslyn to request whatever properties they wanted, allowing Roslyn to make changes without requiring a synchronised change in the project system.

With that change, we serviced property value requests using `ProjectRuleSource` data. This limited Roslyn to only those properties present in our `ConfigurationGeneral` XAML rule file.

This commit uses a `ProjectInstance` to service such requests instead. This means that Roslyn can add new projects in their own props/targets, and not need the project system to make any changes in order to provide those values.

Motivated by a bug exposed through https://github.com/dotnet/roslyn/pull/64749 which added required property `OutputAssemblyForDesignTimeEvaluation` which did not exist in our rules, leading to runtime errors.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8622)