### PR TITLE
Add OutputAssemblyForDesignTimeEvaluation property for Roslyn

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -137,6 +137,10 @@
   <BoolProperty Name="Optimize"
                 Visible="False" />
 
+  <StringProperty Name="OutputAssemblyForDesignTimeEvaluation"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="OutputName"
                   Visible="False" />
 


### PR DESCRIPTION
Roslyn recently added a new required property they wish to consume during `IWorkspaceProjectContext` construction. Because this property is listed in our ConfigurationGeneral rule file, any value in the project is not provided to Roslyn when requested, leading to an exception.

This change adds that property so that requests for it will succeed.

This PR is an alternative to #8622 and avoids the use of `ProjectInstance`. Once @lifengl is back in the office, we will discuss whether there is valid cause for concern around the use of `ProjectInstance` as done in that PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8630)