### PR TITLE
Create VS insertion description without using tags

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -265,5 +265,7 @@ stages:
       # Gets the AssemblyVersion variable produced by the Build pipeline.
       AssemblyVersion: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetAssemblyVersion.AssemblyVersion'] ]
       InsertionVSBranch: ${{ parameters.InsertionVSBranch }}
+      # Hard-coded assumption that the commit referenced by the previous VS insertion is within the last 100 commits in the $(InsertionVSBranch) of the VS repo.
+      PriorInsertionCommitDepth: 100
     jobs:
     - template: templates/generate-insertion.yml

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -26,9 +26,7 @@ jobs:
   # Create the VS folder and fetch the VS repo Git information into it, excluding the files themselves (only .git history is required).
   # Doing this manual process over the checkout: VS task saves around 3 minutes. See: https://stackoverflow.com/a/43136160/294804
   # The System.AccessToken is required for the clone to occur. See: https://stackoverflow.com/a/56734304/294804
-  # The Git config change is for disabling a warning message because we are fetching a specific commit instead of a branch. See: https://stackoverflow.com/a/36794768/294804
   - powershell: |
-      # git config --global advice.detachedHead false
       $null = New-Item -Path '$(Pipeline.Workspace)' -Name VS -ItemType Directory
       Set-Location '$(Pipeline.Workspace)/VS'
       git init

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -3,8 +3,38 @@
 jobs:
 - job: GenerateInsertion
   displayName: Generate Insertion
-  timeoutInMinutes: 30
+  timeoutInMinutes: 45
   steps:
+
+  ###################################################################################################################################################################
+  # REPO PREPARATION
+  ###################################################################################################################################################################
+
+  # Use a disabled, empty script to display the section header in the pipeline UI.
+  - script:
+    displayName: === Repo Preparation ===
+    condition: false
+
+  # Checkout the repo itself and apply settings for the process.
+  - checkout: self
+    # Required for using Git commands in the subsequent tasks below. See:
+    # - https://stackoverflow.com/questions/56733922/fatal-could-not-read-password-for-https-organizationnamedev-azure-com-ter#comment108309839_56734304
+    # - https://learn.microsoft.com/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#allow-scripts-to-access-the-system-token
+    persistCredentials: true
+    # Changes Build.SourcesDirectory from $(Pipeline.Workspace)/s to $(Pipeline.Workspace)/project-system
+    path: project-system
+  # Create the VS folder and fetch the VS repo Git information into it, excluding the files themselves (only .git history is required).
+  # Doing this manual process over the checkout: VS task saves around 3 minutes. See: https://stackoverflow.com/a/43136160/294804
+  # The System.AccessToken is required for the clone to occur. See: https://stackoverflow.com/a/56734304/294804
+  # The Git config change is for disabling a warning message because we are fetching a specific commit instead of a branch. See: https://stackoverflow.com/a/36794768/294804
+  - powershell: |
+      # git config --global advice.detachedHead false
+      $null = New-Item -Path '$(Pipeline.Workspace)' -Name VS -ItemType Directory
+      Set-Location '$(Pipeline.Workspace)/VS'
+      git init
+      git remote add origin https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS
+      git fetch --depth $(PriorInsertionCommitDepth) origin $(InsertionVSBranch)
+    displayName: Fetch VS Repo
 
   ###################################################################################################################################################################
   # GENERATE VS INSERTION
@@ -28,7 +58,7 @@ jobs:
       AccessToken: $(System.AccessToken)
 
   # Creates the description for the VS Insertion PR and sets it to the InsertionDescription variable. Also sets the ShortCommitId variable based on currentSha.
-  - powershell: . '$(Build.SourcesDirectory)/eng/scripts/GetInsertionPRDescription.ps1' -currentSha '$(Build.SourceVersion)' -repoUrl '$(Build.Repository.Uri)' -projectName '$(Build.DefinitionName)'
+  - powershell: . '$(Build.SourcesDirectory)/eng/scripts/GetInsertionPRDescription.ps1' -vsDirectory '$(Pipeline.Workspace)/VS/' -currentSha '$(Build.SourceVersion)' -repoUrl '$(Build.Repository.Uri)' -projectName '$(Build.DefinitionName)'
     displayName: Create VS Insertion Description
     failOnStderr: true
 

--- a/eng/scripts/GetInsertionPRDescription.ps1
+++ b/eng/scripts/GetInsertionPRDescription.ps1
@@ -34,7 +34,7 @@ if($LastExitCode -eq 0)
   # See this for how complex branch names can be:
   # - https://stackoverflow.com/a/12093994/294804
   # - https://stackoverflow.com/a/3651867/294804
-  $hasPreviousShaShort = $vsCommitTitle -match 'DotNet-Project-System \([a-zA-Z0-9._-]+:\d+(\.\d+)*:(\w+)\)'
+  $hasPreviousShaShort = $vsCommitTitle -match "$projectName \([a-zA-Z0-9._-]+:\d+(\.\d+)*:(\w+)\)"
   if($hasPreviousShaShort)
   {
     $previousShaShort = $matches[2]

--- a/eng/scripts/GetInsertionPRDescription.ps1
+++ b/eng/scripts/GetInsertionPRDescription.ps1
@@ -19,7 +19,6 @@ Set-Location $vsDirectory
 # https://git-scm.com/docs/git-rev-list
 # https://stackoverflow.com/a/1862542/294804
 $vsCommitId = (git rev-list --grep="Insert $projectName" --all -1)
-
 # Gets the subject (title) from the provided commit ID (via vsCommitId). See:
 # - https://stackoverflow.com/a/7293026/294804
 # - https://git-scm.com/docs/git-log#_pretty_formats
@@ -39,17 +38,15 @@ if($LastExitCode -eq 0)
   if($hasPreviousShaShort)
   {
     $previousShaShort = $matches[2]
-    # https://stackoverflow.com/a/41717108/294804
-    $previousSha = (git rev-parse $previousShaShort)
   }
 }
 
-Write-Host "previousSha: $previousSha"
+Write-Host "previousShaShort: $previousShaShort"
 Write-Host "currentSha: $currentSha"
 
 $description = @()
 # Since a previous insertion commit ID was not found, we create a basic description.
-if(-Not $previousSha)
+if(-Not $previousShaShort)
 {
   $description += "Updating $projectName to [$currentShaShort]($repoUrl/commit/$currentSha)"
   $description += '---------------------------------------------------------------------------'
@@ -62,6 +59,9 @@ if(-Not $previousSha)
 }
 
 Set-Location $PSScriptRoot
+# https://stackoverflow.com/a/41717108/294804
+$previousSha = (git rev-parse $previousShaShort)
+
 $description += "Updating $projectName from [$previousShaShort]($repoUrl/commit/$previousSha) to [$currentShaShort]($repoUrl/commit/$currentSha)"
 $description += '---------------------------------------------------------------------------'
 # The 'w' query parameter is for ignoring whitespace.

--- a/eng/scripts/GetInsertionPRDescription.ps1
+++ b/eng/scripts/GetInsertionPRDescription.ps1
@@ -1,10 +1,10 @@
 # Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 # Creates a description for VS Insertion PRs that contains a list of PRs that have been merged between since the previous VS Insertion.
-# The previous VS Insertion relies on finding the last tag in our repo that matches the pattern: insertion/*
+# The previous VS Insertion finds the last commit title in the VS repo that matches the pattern: Insert $projectName
 # This script outputs the description string into the InsertionDescription variable within the Azure Pipeline.
 
-param ([Parameter(Mandatory=$true)] [string] $currentSha, [Parameter(Mandatory=$true)] [string] $repoUrl, [Parameter(Mandatory=$true)] [string] $projectName)
+param ([Parameter(Mandatory=$true)] [string] $vsDirectory, [Parameter(Mandatory=$true)] [string] $currentSha, [Parameter(Mandatory=$true)] [string] $repoUrl, [Parameter(Mandatory=$true)] [string] $projectName)
 
 # Using 10 characters since that will make it incredibly unlikely that there will be a collision.
 # https://stackoverflow.com/a/18134919/294804
@@ -13,14 +13,42 @@ $currentShaShort = $currentSha.Substring(0,10)
 # https://docs.microsoft.com/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=powershell#set-an-output-variable-for-use-in-the-same-job
 Write-Host "##vso[task.setvariable variable=ShortCommitId]$currentShaShort"
 
-$description = @()
-# Gets the commit ID of the latest tag that matches insertion/*
+Set-Location $vsDirectory
+# Gets the commit ID of the latest insertion commit that matches "Insert $projectName"
+# --all is required as the fetched Git history may not be the current branch.
 # https://git-scm.com/docs/git-rev-list
 # https://stackoverflow.com/a/1862542/294804
-$previousSha = (git rev-list --tags=insertion/* -1)
+$vsCommitId = (git rev-list --grep="Insert $projectName" --all -1)
+
+# Gets the subject (title) from the provided commit ID (via vsCommitId). See:
+# - https://stackoverflow.com/a/7293026/294804
+# - https://git-scm.com/docs/git-log#_pretty_formats
+$vsCommitTitle = (git log -1 --pretty=%s $vsCommitId)
+# If the VS commit ID wasn't found, it'll be empty, causing the above command to throw an error.
+# https://stackoverflow.com/a/48877892/294804
+if($LastExitCode -eq 0)
+{
+  # Parse the short commit ID out of the commit title. See:
+  # - https://stackoverflow.com/a/3697210/294804
+  # - https://stackoverflow.com/a/12001377/294804
+  # Note: Only including alphanumeric and dot, underscore, and hyphen in the branch name.
+  # See this for how complex branch names can be:
+  # - https://stackoverflow.com/a/12093994/294804
+  # - https://stackoverflow.com/a/3651867/294804
+  $hasPreviousShaShort = $vsCommitTitle -match 'DotNet-Project-System \([a-zA-Z0-9._-]+:\d+(\.\d+)*:(\w+)\)'
+  if($hasPreviousShaShort)
+  {
+    $previousShaShort = $matches[2]
+    # https://stackoverflow.com/a/41717108/294804
+    $previousSha = (git rev-parse $previousShaShort)
+  }
+}
+
 Write-Host "previousSha: $previousSha"
 Write-Host "currentSha: $currentSha"
-# Since a previous commit ID was not found, we create a basic description.
+
+$description = @()
+# Since a previous insertion commit ID was not found, we create a basic description.
 if(-Not $previousSha)
 {
   $description += "Updating $projectName to [$currentShaShort]($repoUrl/commit/$currentSha)"
@@ -32,8 +60,8 @@ if(-Not $previousSha)
   Write-Host "##vso[task.setvariable variable=InsertionDescription]$($description -join '<br>')"
   exit 0
 }
-$previousShaShort = $previousSha.Substring(0,10)
 
+Set-Location $PSScriptRoot
 $description += "Updating $projectName from [$previousShaShort]($repoUrl/commit/$previousSha) to [$currentShaShort]($repoUrl/commit/$currentSha)"
 $description += '---------------------------------------------------------------------------'
 # The 'w' query parameter is for ignoring whitespace.


### PR DESCRIPTION
Continuation of: https://github.com/dotnet/project-system/pull/8517

## Description
The original solution in the linked PR above did not actually work. The multi-repo trigger mechanism for tagging required that the YAML file also be within the same AzDO org (this is not documented). After explaining this situation to the team, I realized the logic used for the tagging mechanism I made in the previous PR can simply be directly added to the insertion job. Thus, we can create the insertion description without the use of tagging.

The reason I didn't arrive at this solution originally was that checking out the VS repo is quite large and time consuming. Not only that, but we need to checkout up to a certain commit depth so we can find the previous insertion. (*For the sake of this PR, I've set the commit depth to 100. *) I originally dismissed this idea as I thought it would add a lot of overhead to producing insertions. Additionally, the original mechanism for insertions checked out the repo, inspected the files, and parsed data out of them. At that time, I hadn't learned how to filter Git commit history or really do anything as advanced at this with manipulating Git metadata. 

During the creation of the tagger, I realized how long checkout takes for the VS repo and decided to make my own checkout implementation. I tested various Git commands and found a way to only fetch the history and not actually populate the files on-disk. Additionally, I needed to filter the tags for creating the insertion description, and I knew how to parse (RegEx) the commit title information. Using those bits of script, I simply moved them from the tagging mechanism and simplified them so that I could:
- Fetch the VS repo at depth 100
- Find the latest commit with title matching `Insert DotNet-Project-System`
- Parse the injected short commit ID (I added previously) from the commit title

That short commit ID represents the previous insertion we completed. This solution will now **work for branches too**, since the fetch of the VS repo will fetch from the branch that the insertion is targeting. Doing the fetch (and this additional parsing) only adds ~3 minutes to the insertion process. This solution is much simpler than the original design, but the original design got me to this point; so I can't fault it. Live and learn, and continue to grow. 🌳

## Test Insertion
- Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6855498&view=results
  - Insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/430988?_a=overview
![image](https://user-images.githubusercontent.com/17788297/197083909-4db1df4b-c886-4f7c-afe5-837017a140cb.png)
- Build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6855880&view=results
  - Insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/431005?_a=overview
![image](https://user-images.githubusercontent.com/17788297/197089805-102ddf04-d82b-4f97-bf3a-e328a4fd5e1f.png)