### PR TITLE
Remove indentation from log output

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -539,15 +539,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (log.Level >= LogLevel.Verbose)
                 {
-                    log.Indent++;
-                   
                     foreach (string path in items)
                     {
                         string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
                         log.Verbose(nameof(Resources.FUTD_SkippingIgnoredKindItem_2), absolutePath, kind);
                     }
-
-                    log.Indent--;
                 }
 
                 return true;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             _state = new UpToDateCheckConfiguredInput(ImmutableArray.Create(configuredInput));
 
             var subscription = new Mock<BuildUpToDateCheck.ISubscription>(MockBehavior.Strict);
-            
+
             subscription.Setup(s => s.EnsureInitialized());
 
             subscription
@@ -1371,10 +1371,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Ignoring up-to-date check items with Kind="Ignored"
                 Adding UpToDateCheckOutput outputs:
                     C:\Dev\Solution\Project\Output
-                        Skipping 'C:\Dev\Solution\Project\IgnoredOutput' with ignored Kind="Ignored"
+                    Skipping 'C:\Dev\Solution\Project\IgnoredOutput' with ignored Kind="Ignored"
                 Adding UpToDateCheckBuilt outputs:
                     C:\Dev\Solution\Project\Built
-                        Skipping 'C:\Dev\Solution\Project\IgnoredBuilt.dll' with ignored Kind="Ignored"
+                    Skipping 'C:\Dev\Solution\Project\IgnoredBuilt.dll' with ignored Kind="Ignored"
                 Adding project file inputs:
                     {_projectPath}
                 Adding newest import input:
@@ -1466,17 +1466,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Ignoring up-to-date check items with Kind="Ignored"
                 Adding UpToDateCheckOutput outputs:
                     C:\Dev\Solution\Project\Output
-                        Skipping 'C:\Dev\Solution\Project\IgnoredOutput' with ignored Kind="Ignored"
+                    Skipping 'C:\Dev\Solution\Project\IgnoredOutput' with ignored Kind="Ignored"
                 Adding UpToDateCheckBuilt outputs:
                     C:\Dev\Solution\Project\Built
-                        Skipping 'C:\Dev\Solution\Project\IgnoredBuilt' with ignored Kind="Ignored"
+                    Skipping 'C:\Dev\Solution\Project\IgnoredBuilt' with ignored Kind="Ignored"
                 Adding project file inputs:
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
                 Adding UpToDateCheckInput inputs:
                     C:\Dev\Solution\Project\Input
-                        Skipping 'C:\Dev\Solution\Project\IgnoredInput' with ignored Kind="Ignored"
+                    Skipping 'C:\Dev\Solution\Project\IgnoredInput' with ignored Kind="Ignored"
                 No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(outputTime)}). Newest input is 'C:\Dev\Solution\Project\Input' ({ToLocalTime(inputTime)}).
                 Project is up-to-date.
                 """,


### PR DESCRIPTION
This indentation makes the output harder to understand as it implies a relationship with the previous line that does not exist.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8644)