### PR TITLE
Make order of checked items deterministic

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -387,18 +387,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), UpToDateCheckInput.SchemaName);
                     log.Indent++;
 
-                    foreach ((string kind, ImmutableArray<string> items) in upToDateCheckInputItems)
+                    foreach (string kind in state.KindNames)
                     {
-                        if (ShouldIgnoreItems(kind, items))
+                        if (upToDateCheckInputItems.TryGetValue(kind, out ImmutableArray<string> items))
                         {
-                            continue;
-                        }
+                            if (ShouldIgnoreItems(kind, items))
+                            {
+                                continue;
+                            }
 
-                        foreach (string path in items)
-                        {
-                            string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.VerboseLiteral(absolutePath);
-                            yield return (Path: absolutePath, ItemType: UpToDateCheckInput.SchemaName, IsRequired: true);
+                            foreach (string path in items)
+                            {
+                                string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                                log.VerboseLiteral(absolutePath);
+                                yield return (Path: absolutePath, ItemType: UpToDateCheckInput.SchemaName, IsRequired: true);
+                            }
                         }
                     }
 
@@ -413,18 +416,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputs_1), UpToDateCheckOutput.SchemaName);
                     log.Indent++;
 
-                    foreach ((string kind, ImmutableArray<string> items) in upToDateCheckOutputItems)
+                    foreach (string kind in state.KindNames)
                     {
-                        if (ShouldIgnoreItems(kind, items))
+                        if (upToDateCheckOutputItems.TryGetValue(kind, out ImmutableArray<string> items))
                         {
-                            continue;
-                        }
+                            if (ShouldIgnoreItems(kind, items))
+                            {
+                                continue;
+                            }
 
-                        foreach (string path in items)
-                        {
-                            string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.VerboseLiteral(absolutePath);
-                            yield return absolutePath;
+                            foreach (string path in items)
+                            {
+                                string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                                log.VerboseLiteral(absolutePath);
+                                yield return absolutePath;
+                            }
                         }
                     }
 
@@ -436,18 +442,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputs_1), UpToDateCheckBuilt.SchemaName);
                     log.Indent++;
 
-                    foreach ((string kind, ImmutableArray<string> items) in upToDateCheckBuiltItems)
+                    foreach (string kind in state.KindNames)
                     {
-                        if (ShouldIgnoreItems(kind, items))
+                        if (upToDateCheckBuiltItems.TryGetValue(kind, out ImmutableArray<string> items))
                         {
-                            continue;
-                        }
+                            if (ShouldIgnoreItems(kind, items))
+                            {
+                                continue;
+                            }
 
-                        foreach (string path in items)
-                        {
-                            string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.VerboseLiteral(absolutePath);
-                            yield return absolutePath;
+                            foreach (string path in items)
+                            {
+                                string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                                log.VerboseLiteral(absolutePath);
+                                yield return absolutePath;
+                            }
                         }
                     }
 
@@ -462,18 +471,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputsInSet_2), UpToDateCheckInput.SchemaName, setName);
                     log.Indent++;
 
-                    foreach ((string kind, ImmutableArray<string> items) in upToDateCheckInputItems)
+                    foreach (string kind in state.KindNames)
                     {
-                        if (ShouldIgnoreItems(kind, items))
+                        if (upToDateCheckInputItems.TryGetValue(kind, out ImmutableArray<string> items))
                         {
-                            continue;
-                        }
+                            if (ShouldIgnoreItems(kind, items))
+                            {
+                                continue;
+                            }
 
-                        foreach (string path in items)
-                        {
-                            string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.VerboseLiteral(absolutePath);
-                            yield return (Path: absolutePath, ItemType: UpToDateCheckInput.SchemaName, IsRequired: true);
+                            foreach (string path in items)
+                            {
+                                string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                                log.VerboseLiteral(absolutePath);
+                                yield return (Path: absolutePath, ItemType: UpToDateCheckInput.SchemaName, IsRequired: true);
+                            }
                         }
                     }
 
@@ -488,18 +500,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputsInSet_2), UpToDateCheckOutput.SchemaName, setName);
                     log.Indent++;
 
-                    foreach ((string kind, ImmutableArray<string> items) in upToDateCheckOutputItems)
+                    foreach (string kind in state.KindNames)
                     {
-                        if (ShouldIgnoreItems(kind, items))
+                        if (upToDateCheckOutputItems.TryGetValue(kind, out ImmutableArray<string> items))
                         {
-                            continue;
-                        }
+                            if (ShouldIgnoreItems(kind, items))
+                            {
+                                continue;
+                            }
 
-                        foreach (string path in items)
-                        {
-                            string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.VerboseLiteral(absolutePath);
-                            yield return absolutePath;
+                            foreach (string path in items)
+                            {
+                                string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                                log.VerboseLiteral(absolutePath);
+                                yield return absolutePath;
+                            }
                         }
                     }
 
@@ -511,18 +526,21 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputsInSet_2), UpToDateCheckBuilt.SchemaName, setName);
                     log.Indent++;
 
-                    foreach ((string kind, ImmutableArray<string> items) in upToDateCheckBuiltItems)
+                    foreach (string kind in state.KindNames)
                     {
-                        if (ShouldIgnoreItems(kind, items))
+                        if (upToDateCheckBuiltItems.TryGetValue(kind, out ImmutableArray<string> items))
                         {
-                            continue;
-                        }
+                            if (ShouldIgnoreItems(kind, items))
+                            {
+                                continue;
+                            }
 
-                        foreach (string path in items)
-                        {
-                            string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
-                            log.VerboseLiteral(absolutePath);
-                            yield return absolutePath;
+                            foreach (string path in items)
+                            {
+                                string absolutePath = _configuredProject.UnconfiguredProject.MakeRooted(path);
+                                log.VerboseLiteral(absolutePath);
+                                yield return absolutePath;
+                            }
                         }
                     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -1419,17 +1419,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 $"""
                 Adding UpToDateCheckOutput outputs:
-                    C:\Dev\Solution\Project\TaggedOutput
                     C:\Dev\Solution\Project\Output
+                    C:\Dev\Solution\Project\TaggedOutput
                 Adding UpToDateCheckBuilt outputs:
-                    C:\Dev\Solution\Project\TaggedBuilt
                     C:\Dev\Solution\Project\Built
+                    C:\Dev\Solution\Project\TaggedBuilt
                 Adding project file inputs:
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
                 Adding UpToDateCheckInput inputs:
-                    C:\Dev\Solution\Project\TaggedInput
                     C:\Dev\Solution\Project\Input
                 Input UpToDateCheckInput item 'C:\Dev\Solution\Project\Input' is newer ({ToLocalTime(input1Time)}) than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(output1Time)}), not up-to-date.
                 """,
@@ -1493,8 +1492,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 [UpToDateCheckOutput.SchemaName] = ItemsWithMetadata(("Output", "Kind", ""), ("TaggedOutput", "Kind", "Tagged"))
             };
 
-            var itemChangeTime = DateTime.UtcNow.AddMinutes(-7);
-            var inputTime      = DateTime.UtcNow.AddMinutes(-6);
+            var itemChangeTime = DateTime.UtcNow.AddMinutes(-8);
+            var input2Time     = DateTime.UtcNow.AddMinutes(-7);
+            var input1Time     = DateTime.UtcNow.AddMinutes(-6);
             var lastBuildTime  = DateTime.UtcNow.AddMinutes(-5);
             var output4Time    = DateTime.UtcNow.AddMinutes(-4);
             var output3Time    = DateTime.UtcNow.AddMinutes(-3);
@@ -1506,8 +1506,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 lastSuccessfulBuildStartTimeUtc: lastBuildTime,
                 lastItemsChangedAtUtc: itemChangeTime);
 
-            _fileSystem.AddFile(@"C:\Dev\Solution\Project\Input",        inputTime);
-            _fileSystem.AddFile(@"C:\Dev\Solution\Project\TaggedInput",  inputTime);
+            _fileSystem.AddFile(@"C:\Dev\Solution\Project\Input",        input2Time);
+            _fileSystem.AddFile(@"C:\Dev\Solution\Project\TaggedInput",  input1Time);
             _fileSystem.AddFile(@"C:\Dev\Solution\Project\Output",       output4Time);
             _fileSystem.AddFile(@"C:\Dev\Solution\Project\TaggedOutput", output3Time);
             _fileSystem.AddFile(@"C:\Dev\Solution\Project\Built",        output2Time);
@@ -1516,19 +1516,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertUpToDateAsync(
                 $"""
                 Adding UpToDateCheckOutput outputs:
-                    C:\Dev\Solution\Project\TaggedOutput
                     C:\Dev\Solution\Project\Output
+                    C:\Dev\Solution\Project\TaggedOutput
                 Adding UpToDateCheckBuilt outputs:
-                    C:\Dev\Solution\Project\TaggedBuilt
                     C:\Dev\Solution\Project\Built
+                    C:\Dev\Solution\Project\TaggedBuilt
                 Adding project file inputs:
                     {_projectPath}
                 Adding newest import input:
                     {_projectPath}
                 Adding UpToDateCheckInput inputs:
-                    C:\Dev\Solution\Project\TaggedInput
                     C:\Dev\Solution\Project\Input
-                No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(output4Time)}). Newest input is 'C:\Dev\Solution\Project\TaggedInput' ({ToLocalTime(inputTime)}).
+                    C:\Dev\Solution\Project\TaggedInput
+                No inputs are newer than earliest output 'C:\Dev\Solution\Project\Output' ({ToLocalTime(output4Time)}). Newest input is 'C:\Dev\Solution\Project\TaggedInput' ({ToLocalTime(input1Time)}).
                 Project is up-to-date.
                 """,
                 ignoreKinds: "");


### PR DESCRIPTION
Fixes #8642

Two facts conspired here to motivate this change:

1. Items were stored in data structures that order based on hash codes.
2. Unit tests validate the verbatim log output from the FUTDC to validate correct behaviour.

This means that in different environments, unit tests would enumerate items in different orders and the log output would change in subtle ways, leading to unit test failures.

This change ensures we enumerate (and therefore log) items in a deterministic order. This ensures our tests don't fail in certain environments. It may also help to compare log output between machines/environments/runs for the same project.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8645)