### PR TITLE
Implement EvaluationData.GetItemValues

### DIFF
--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -43,8 +43,8 @@
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.VisualStudio.Telemetry"                                       Version="16.6.7" />
     <PackageReference Update="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.3.32804.24" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.3.44" />
-    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.3.44" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.4.16-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.4.16-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.4.0-preview-3-32908-042" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.64" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
@@ -64,8 +64,8 @@
     
     <!-- Roslyn -->
     <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="4.4.0-2.final" />
-    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.4.0-2.final" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.4.0-2.final" />
+    <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.5.0-2.22528.3" />
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.5.0-2.22528.3" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 


### PR DESCRIPTION
Roslyn needs the ability to query item specs during `IWorkspaceProjectContext` construction. This change implements that facility.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8647)