### PR TITLE
Fix ReadMe status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # The .NET Project System for Visual Studio
 
-| Release             | Unit Tests (Debug)                      | Unit Tests (Release)                      | Localization
-|---------------------|:---------------------------------------:|:-----------------------------------------:|:------------:
-| [16.11][1611Branch] | [![Build Status][1611Debug]][1611Build] | [![Build Status][1611Release]][1611Build] | [![Build Status][1611Spanish]][1611Build]
-| [17.0][170Branch]   | [![Build Status][170Debug]][170Build]   | [![Build Status][170Release]][170Build]   | [![Build Status][170Spanish]][170Build]
-| [17.1][171Branch]   | [![Build Status][171Debug]][171Build]   | [![Build Status][171Release]][171Build]   | [![Build Status][171Spanish]][171Build]
-| [17.2][172Branch]   | [![Build Status][172Debug]][172Build]   | [![Build Status][172Release]][172Build]   | [![Build Status][172Spanish]][172Build]
-| [17.3][173Branch]   | [![Build Status][173Debug]][173Build]   | [![Build Status][173Release]][173Build]   | [![Build Status][173Spanish]][173Build]
-| [main][MainBranch]  | [![Build Status][MainDebug]][MainBuild] | [![Build Status][MainRelease]][MainBuild] | [![Build Status][MainSpanish]][MainBuild]
+| Release             | Build                   | Compliance                   | Publish                   | Localization
+|---------------------|:-----------------------:|:----------------------------:|:-------------------------:|:-------------------------:
+| [main][MainBranch]  | [![MainBuild]][MainRun] | [![MainCompliance]][MainRun] | [![MainPublish]][MainRun] | [![MainLocalization]][MainRun]
+| [16.11][1611Branch] | [![1611Build]][1611Run] |                              |                           |
+| [17.0][170Branch]   | [![170Build]][170Run]   |                              |                           |
+| [17.1][171Branch]   | [![171Build]][171Run]   |                              |                           |
+| [17.2][172Branch]   | [![172Build]][172Run]   |                              |                           |
+| [17.3][173Branch]   | [![173Build]][173Run]   |                              |                           |
+| [17.4][173Branch]   | [![174Build]][174Run]   | [![174Compliance]][174Run]   | [![174Publish]][174Run]   | [![174Localization]][174Run]
 
 [![Join the chat at https://gitter.im/dotnet/project-system](https://badges.gitter.im/dotnet/project-system.svg)](https://gitter.im/dotnet/project-system?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -73,38 +74,36 @@ This project has adopted a code of conduct adapted from the [Contributor Covenan
 
 <!-- References -->
 
-[MainBranch]: https://github.com/dotnet/project-system/tree/main
-[MainDebug]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=main&jobName=Windows_Debug&%20Debug&label=main
-[MainRelease]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=main&jobName=Windows_Release&%20Release&label=main
-[MainSpanish]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=main&jobName=Spanish&label=main
-[MainBuild]: https://dev.azure.com/dnceng/public/_build/latest?definitionId=406&branchName=main
+[MainBranch]:       https://github.com/dotnet/project-system/tree/main
+[MainBuild]:        https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=main&label=main&stageName=Build
+[MainCompliance]:   https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=main&label=main&stageName=Compliance
+[MainPublish]:      https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=main&label=main&stageName=Publish
+[MainLocalization]: https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=main&label=main&stageName=Localization
+[MainRun]:          https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=main
 
 [1611Branch]: https://github.com/dotnet/project-system/tree/dev16.11.x
-[1611Debug]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev16.11.x&jobName=Windows_Debug&%20Debug&label=dev16.11.x
-[1611Release]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev16.11.x&jobName=Windows_Release&%20Release&label=dev16.11.x
-[1611Spanish]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev16.11.x&jobName=Spanish&label=dev16.11.x
-[1611Build]: https://dev.azure.com/dnceng/public/_build/latest?definitionId=406&branchName=dev16.11.x
+[1611Build]:  https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev16.11.x&label=dev16.11.x
+[1611Run]:    https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=dev16.11.x
 
 [170Branch]: https://github.com/dotnet/project-system/tree/dev17.0.x
-[170Debug]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.0.x&jobName=Windows_Debug&%20Debug&label=dev17.0.x
-[170Release]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.0.x&jobName=Windows_Release&%20Release&label=dev17.0.x
-[170Spanish]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.0.x&jobName=Spanish&label=dev17.0.x
-[170Build]: https://dev.azure.com/dnceng/public/_build/latest?definitionId=406&branchName=dev17.0.x
+[170Build]:  https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.0.x&label=dev17.0.x
+[170Run]:    https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=dev17.0.x
 
 [171Branch]: https://github.com/dotnet/project-system/tree/dev17.1.x
-[171Debug]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.1.x&jobName=Windows_Debug&%20Debug&label=dev17.1.x
-[171Release]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.1.x&jobName=Windows_Release&%20Release&label=dev17.1.x
-[171Spanish]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.1.x&jobName=Spanish&label=dev17.1.x
-[171Build]: https://dev.azure.com/dnceng/public/_build/latest?definitionId=406&branchName=dev17.1.x
+[171Build]:  https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.1.x&label=dev17.1.x
+[171Run]:    https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=dev17.1.x
 
 [172Branch]: https://github.com/dotnet/project-system/tree/dev17.2.x
-[172Debug]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.2.x&jobName=Windows_Debug&%20Debug&label=dev17.2.x
-[172Release]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.2.x&jobName=Windows_Release&%20Release&label=dev17.2.x
-[172Spanish]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.2.x&jobName=Spanish&label=dev17.2.x
-[172Build]: https://dev.azure.com/dnceng/public/_build/latest?definitionId=406&branchName=dev17.2.x
+[172Build]:  https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.2.x&label=dev17.2.x
+[172Run]:    https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=dev17.2.x
 
 [173Branch]: https://github.com/dotnet/project-system/tree/dev17.3.x
-[173Debug]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.3.x&jobName=Windows_Debug&%20Debug&label=dev17.3.x
-[173Release]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.3.x&jobName=Windows_Release&%20Release&label=dev17.3.x
-[173Spanish]: https://dev.azure.com/dnceng/public/_apis/build/status/dotnet/project-system/unit-tests?branchName=dev17.3.x&jobName=Spanish&label=dev17.3.x
-[173Build]: https://dev.azure.com/dnceng/public/_build/latest?definitionId=406&branchName=dev17.3.x
+[173Build]:  https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.3.x&label=dev17.3.x
+[173Run]:    https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=dev17.3.x
+
+[174Branch]:       https://github.com/dotnet/project-system/tree/dev17.4.x
+[174Build]:        https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.4.x&label=dev17.4.x&stageName=Build
+[174Compliance]:   https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.4.x&label=dev17.4.x&stageName=Compliance
+[174Publish]:      https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.4.x&label=dev17.4.x&stageName=Publish
+[174Localization]: https://dev.azure.com/devdiv/DevDiv/_apis/build/status/DotNet/project-system/DotNet-Project-System?branchName=dev17.4.x&label=dev17.4.x&stageName=Localization
+[174Run]:          https://dev.azure.com/devdiv/DevDiv/_build/latest?definitionId=9675&branchName=dev17.4.x


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/17788297/199601857-06e60fae-fbcc-4bd0-8c03-1ef205abe4b7.png)

## After
![image](https://user-images.githubusercontent.com/17788297/199602217-9acdc3a3-f9c3-4f14-8c85-af7fb5081e3c.png)

## Description
The status badges were linking to our previous PR build pipeline, which is odd because that pipeline (AFAIK) didn't build from our branches. It only built via pull requests, which are generated by GitHub. Here, I've opted to use the status of our internal builds, which is more accurately represents our build status. The statuses can be displayed publicly, but to actually follow the links, you need access to the internal project.

I've made them show the primary stages of the pipeline. I decided to not add Optimization and Insertion since those are only ran on a schedule. We can add them if we want. Builds prior to 17.4 will not have this stage information, so they only have the primary pipeline status being shown in the Build column. I've also added the 17.4 branch to the list. And I simplified the image links on the table to no longer contain the "Build Status" alt text, which wasn't useful anyway.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8652)