### PR TITLE
Convert property to field to reduce allocations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         internal static readonly StringComparer SetNameComparer = StringComparers.ItemNames;
         internal static readonly StringComparer KindNameComparer = StringComparers.ItemNames;
 
-        private static ImmutableHashSet<string> NonCompilationItemTypes => ImmutableHashSet<string>.Empty
+        private static readonly ImmutableHashSet<string> s_nonCompilationItemTypes = ImmutableHashSet<string>.Empty
             .WithComparer(StringComparers.ItemTypes)
             .Add(None.SchemaName)
             .Add(Content.SchemaName);
@@ -336,7 +336,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     //
                     // These items may have CopyToOutputDirectory metadata, which is why we don't exclude them earlier.
                     // The need to schedule a build in order to copy files is handled separately.
-                    if (!NonCompilationItemTypes.Contains(itemType))
+                    if (!s_nonCompilationItemTypes.Contains(itemType))
                     {
                         log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), itemType);
                         log.Indent++;


### PR DESCRIPTION
The previous code would allocate a new ImmutableHashSet on every call to the property's getter. This is essentially constant data, so can be allocated once and reused in order to reduce allocations.

During builds, the property would be called several times per project, per target framework.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8656)