### PR TITLE
Fix typos in legacy package property page

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.resx
@@ -1702,7 +1702,7 @@
     <value>4</value>
   </data>
   <data name="FileVersionRevisionTextBox.AccessibleName" xml:space="preserve">
-    <value>Assembly File Verison Revision</value>
+    <value>Assembly File Version Revision</value>
   </data>
   <data name="FileVersionRevisionTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>180, 3</value>
@@ -1726,7 +1726,7 @@
     <value>0</value>
   </data>
   <data name="FileVersionBuildTextBox.AccessibleName" xml:space="preserve">
-    <value>Assembly File Verison Build</value>
+    <value>Assembly File Version Build</value>
   </data>
   <data name="FileVersionBuildTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>121, 3</value>
@@ -1750,7 +1750,7 @@
     <value>1</value>
   </data>
   <data name="FileVersionMinorTextBox.AccessibleName" xml:space="preserve">
-    <value>Assembly File Verison Minor</value>
+    <value>Assembly File Version Minor</value>
   </data>
   <data name="FileVersionMinorTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>62, 3</value>
@@ -1774,7 +1774,7 @@
     <value>2</value>
   </data>
   <data name="FileVersionMajorTextBox.AccessibleName" xml:space="preserve">
-    <value>Assembly File Verison Major</value>
+    <value>Assembly File Version Major</value>
   </data>
   <data name="FileVersionMajorTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 3</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.cs.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Revize verze souboru sestavení</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Revize verze souboru sestavení</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Build verze souboru sestavení</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Build verze souboru sestavení</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Podverze souboru sestavení</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Podverze souboru sestavení</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Hlavní verze souboru sestavení</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Hlavní verze souboru sestavení</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.de.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Revision der Assemblydateiversion</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Revision der Assemblydateiversion</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Versionsbuild der Assemblydatei</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Versionsbuild der Assemblydatei</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Nebenversion der Assemblydatei</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Nebenversion der Assemblydatei</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Hauptversion der Assembly</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Hauptversion der Assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.es.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Revisión de la versión del archivo de ensamblado</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Revisión de la versión del archivo de ensamblado</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Compilación de versión de archivo de ensamblado</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Compilación de versión de archivo de ensamblado</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Versión secundaria del archivo de ensamblado</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Versión secundaria del archivo de ensamblado</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Versión de archivo de ensamblado principal</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Versión de archivo de ensamblado principal</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.fr.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Révision de version de fichier d'assembly</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Révision de version de fichier d'assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Build de version de fichier d'assembly</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Build de version de fichier d'assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Version mineure du fichier d'assembly</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Version mineure du fichier d'assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Version majeure du fichier d'assembly</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Version majeure du fichier d'assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.it.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Revisione versione del file di assembly</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Revisione versione del file di assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Build versione del file di assembly</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Build versione del file di assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Versione secondaria versione del file di assembly</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Versione secondaria versione del file di assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Versione principale della versione del file di assembly</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Versione principale della versione del file di assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ja.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">アセンブリ ファイル バージョンのリビジョン</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">アセンブリ ファイル バージョンのリビジョン</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">アセンブリ ファイル バージョンのビルド</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">アセンブリ ファイル バージョンのビルド</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">アセンブリ ファイルのマイナー バージョン</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">アセンブリ ファイルのマイナー バージョン</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">アセンブリ ファイルのメジャー バージョン</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">アセンブリ ファイルのメジャー バージョン</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ko.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">어셈블리 파일 수정 버전</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">어셈블리 파일 수정 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">어셈블리 파일 버전 빌드</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">어셈블리 파일 버전 빌드</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">어셈블리 파일 부 버전</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">어셈블리 파일 부 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">어셈블리 파일 주 버전</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">어셈블리 파일 주 버전</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pl.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Poprawka wersji pliku zestawu</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Poprawka wersji pliku zestawu</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Kompilacja wersji pliku zestawu</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Kompilacja wersji pliku zestawu</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Wersja pomocnicza pliku zestawu</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Wersja pomocnicza pliku zestawu</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Wersja główna pliku zestawu</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Wersja główna pliku zestawu</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.pt-BR.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Revisão da Versão do Arquivo do Assembly</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Revisão da Versão do Arquivo do Assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Versão do Build do Arquivo do Assembly</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Versão do Build do Arquivo do Assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Versão Secundária do Arquivo do Assembly</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Versão Secundária do Arquivo do Assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Versão Principal do Arquivo do Assembly</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Versão Principal do Arquivo do Assembly</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.ru.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Редакция версии файла сборки</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Редакция версии файла сборки</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Сборка версии файла сборки</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Сборка версии файла сборки</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Дополнительная версия файла сборки</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Дополнительная версия файла сборки</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Основная версия файла сборки</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Основная версия файла сборки</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.tr.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">Derleme Dosyası Sürümünü Düzeltme</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">Derleme Dosyası Sürümünü Düzeltme</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">Derleme Dosya Sürümü Derlemesi</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">Derleme Dosya Sürümü Derlemesi</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">Derleme Dosyası Alt Sürümü</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">Derleme Dosyası Alt Sürümü</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">Derleme Dosyası Ana Sürümü</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">Derleme Dosyası Ana Sürümü</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hans.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">程序集文件版本修订</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">程序集文件版本修订</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">程序集文件版本生成</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">程序集文件版本生成</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">程序集文件次要版本</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">程序集文件次要版本</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">程序集文件主要版本</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">程序集文件主要版本</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/PackagePropPage.zh-Hant.xlf
@@ -103,23 +103,23 @@
         <note />
       </trans-unit>
       <trans-unit id="FileVersionRevisionTextBox.AccessibleName">
-        <source>Assembly File Verison Revision</source>
-        <target state="translated">組件檔案版本修訂</target>
+        <source>Assembly File Version Revision</source>
+        <target state="needs-review-translation">組件檔案版本修訂</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionBuildTextBox.AccessibleName">
-        <source>Assembly File Verison Build</source>
-        <target state="translated">組件檔案版本組建</target>
+        <source>Assembly File Version Build</source>
+        <target state="needs-review-translation">組件檔案版本組建</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMinorTextBox.AccessibleName">
-        <source>Assembly File Verison Minor</source>
-        <target state="translated">組件檔案版本次要</target>
+        <source>Assembly File Version Minor</source>
+        <target state="needs-review-translation">組件檔案版本次要</target>
         <note />
       </trans-unit>
       <trans-unit id="FileVersionMajorTextBox.AccessibleName">
-        <source>Assembly File Verison Major</source>
-        <target state="translated">組件檔案版本主要</target>
+        <source>Assembly File Version Major</source>
+        <target state="needs-review-translation">組件檔案版本主要</target>
         <note />
       </trans-unit>
       <trans-unit id="PackageRequireLicenseAcceptance.Text">


### PR DESCRIPTION
Fixes a simple typo.

These are `AccessibleName` values, so would be exposed via UIA, for example to screen readers.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8660)