### PR TITLE
Ensure a WPF project does not have UseWindowsForms set to true.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -8,41 +8,26 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [ExportInterceptingPropertyValueProvider(
     new[]
     {
-        ApplicationFrameworkProperty,
-        EnableVisualStylesProperty,
-        SingleInstanceProperty,
-        SaveMySettingsOnExitProperty,
-        HighDpiModeProperty,
-        AuthenticationModeProperty,
-        ShutdownModeProperty,
-        SplashScreenProperty,
-        MinimumSplashScreenDisplayTimeProperty
+        PropertyNameProvider.ApplicationFrameworkProperty,
+        PropertyNameProvider.EnableVisualStylesProperty,
+        PropertyNameProvider.SingleInstanceProperty,
+        PropertyNameProvider.SaveMySettingsOnExitProperty,
+        PropertyNameProvider.HighDpiModeProperty,
+        PropertyNameProvider.AuthenticationModeProperty,
+        PropertyNameProvider.ShutdownModeProperty,
+        PropertyNameProvider.SplashScreenProperty,
+        PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty
     },
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     [AppliesTo(ProjectCapability.VisualBasic)]
     internal sealed class ApplicationFrameworkValueProvider : InterceptingPropertyValueProviderBase
     {
-        private const string ApplicationFrameworkMSBuildProperty = "MyType";
         private const string EnabledValue = "WindowsForms";
         private const string DisabledValue = "WindowsFormsWithCustomSubMain";
         
-        private const string UseWPFMSBuildProperty = "UseWPF";
-        private const string UseWindowsFormProperty = "UseWindowsForms";
-        private const string OutputTypeMSBuildProperty = "OutputType";
         private const string WinExeOutputType = "WinExe";
-        private const string StartupObjectMSBuildProperty = "StartupObject";
         private const string NoneItemType = "None";
         private const string ApplicationDefinitionItemType = "ApplicationDefinition";
-
-        internal const string ApplicationFrameworkProperty = "UseApplicationFramework";
-        internal const string EnableVisualStylesProperty = "EnableVisualStyles";
-        internal const string SingleInstanceProperty = "SingleInstance";
-        internal const string SaveMySettingsOnExitProperty = "SaveMySettingsOnExit";
-        internal const string HighDpiModeProperty = "HighDpiMode";
-        internal const string AuthenticationModeProperty = "VBAuthenticationMode";
-        internal const string ShutdownModeProperty = "ShutdownMode";
-        internal const string SplashScreenProperty = "SplashScreen";
-        internal const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
 
         private readonly UnconfiguredProject _project;
         private readonly IProjectItemProvider _sourceItemsProvider;
@@ -61,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (propertyName == ApplicationFrameworkProperty)
+            if (propertyName == PropertyNameProvider.ApplicationFrameworkProperty)
             {
                 if (await IsWPFApplicationAsync(defaultProperties))
                 {
@@ -80,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            if (propertyName == ApplicationFrameworkProperty)
+            if (propertyName == PropertyNameProvider.ApplicationFrameworkProperty)
             {
                 return GetPropertyValueAsync(defaultProperties);
             }
@@ -92,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            if (propertyName == ApplicationFrameworkProperty)
+            if (propertyName == PropertyNameProvider.ApplicationFrameworkProperty)
             {
                 return GetPropertyValueAsync(defaultProperties);
             }
@@ -116,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueForWPFApplicationAsync(IProjectProperties defaultProperties)
         {
-            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
             if (!string.IsNullOrEmpty(startupObject))
             {
                 // A start-up object is specified for this project. This takes precedence over the Startup URI, so set Use Application Framework to "false".
@@ -135,7 +120,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static async Task<string> GetPropertyValueForDefaultProjectTypesAsync(IProjectProperties defaultProperties)
         {
-            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.ApplicationFrameworkMSBuildProperty);
 
             return value switch
             {
@@ -147,9 +132,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
         {
-            string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWPFMSBuildProperty);
-            string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWindowsFormProperty);
-            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypeMSBuildProperty);
+            string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.UseWPFProperty);
+            string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.UseWindowsFormsProperty);
+            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.OutputTypeMSBuildProperty);
 
             return bool.TryParse(useWPFString, out bool useWPF)
                 && useWPF
@@ -167,15 +152,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 if (value)
                 {
                     // Set in project file: <MyType>WindowsForms</MyType>
-                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, EnabledValue);
+                    await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.ApplicationFrameworkMSBuildProperty, EnabledValue);
 
                     // Set in myapp file: <MySubMain>true</MySubMain>
                     await _myAppXmlFileAccessor.SetMySubMainAsync("true");
 
                     // Set the StartupObject to namespace.My.MyApplication; we should save the actual value in the myapp file.
-                    string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
 
-                    await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + ".My.MyApplication");
+                    await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty, rootNamespace + ".My.MyApplication");
 
                     if (startupObjectValue is not null)
                     {
@@ -190,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 else
                 {
                     // Set in project file: <MyType>WindowsFormsWithCustomSubMain</MyType>
-                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, DisabledValue);
+                    await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.ApplicationFrameworkMSBuildProperty, DisabledValue);
 
                     // Set in myapp file: <MySubMain>false</MySubMain>
                     await _myAppXmlFileAccessor.SetMySubMainAsync("false");
@@ -199,7 +184,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     string? startupObjectValue = await _myAppXmlFileAccessor.GetMainFormAsync();
 
                     if (startupObjectValue is not null)
-                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + "." + startupObjectValue);
+                        await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty, rootNamespace + "." + startupObjectValue);
                 }
             }
 
@@ -234,10 +219,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     }
 
                     // Clear out the StartupObject if it has a value.
-                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
                     if (!string.IsNullOrEmpty(startupObject))
                     {
-                        await defaultProperties.DeletePropertyAsync(StartupObjectMSBuildProperty);
+                        await defaultProperties.DeletePropertyAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
                     }
                 }
                 else
@@ -245,10 +230,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     // Disabled
 
                     // Set the StartupObject if it doesn't already have a value.
-                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
                     if (string.IsNullOrEmpty(startupObject))
                     {
-                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, "Sub Main");
+                        await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty, "Sub Main");
                     }
 
                     // Set the Application.xaml file's build action to None.
@@ -272,20 +257,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             string value = propertyName switch
             {
-                ApplicationFrameworkProperty => (await _myAppXmlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
-                EnableVisualStylesProperty => (await _myAppXmlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
-                SingleInstanceProperty => (await _myAppXmlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
-                SaveMySettingsOnExitProperty => (await _myAppXmlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
-                HighDpiModeProperty => (await _myAppXmlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
-                AuthenticationModeProperty => (await _myAppXmlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
-                ShutdownModeProperty => (await _myAppXmlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
-                SplashScreenProperty => await _myAppXmlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
-                MinimumSplashScreenDisplayTimeProperty => (await _myAppXmlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.ApplicationFrameworkProperty => (await _myAppXmlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.EnableVisualStylesProperty => (await _myAppXmlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.SingleInstanceProperty => (await _myAppXmlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.SaveMySettingsOnExitProperty => (await _myAppXmlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.HighDpiModeProperty => (await _myAppXmlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.AuthenticationModeProperty => (await _myAppXmlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.ShutdownModeProperty => (await _myAppXmlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
+                PropertyNameProvider.SplashScreenProperty => await _myAppXmlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
+                PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty => (await _myAppXmlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
 
                 _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
             };
 
-            if (propertyName == AuthenticationModeProperty)
+            if (propertyName == PropertyNameProvider.AuthenticationModeProperty)
             {
                 value = value switch
                 {
@@ -296,7 +281,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
                 };
             }
-            else if (propertyName == ShutdownModeProperty)
+            else if (propertyName == PropertyNameProvider.ShutdownModeProperty)
             {
                 value = value switch
                 {
@@ -314,7 +299,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private async Task<string?> SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             // ValueProvider needs to convert string enums to valid values to be saved.
-            if (propertyName == AuthenticationModeProperty)
+            if (propertyName == PropertyNameProvider.AuthenticationModeProperty)
             {
                 unevaluatedPropertyValue = unevaluatedPropertyValue switch
                 {
@@ -323,7 +308,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => unevaluatedPropertyValue
                 };
             }
-            else if (propertyName == ShutdownModeProperty)
+            else if (propertyName == PropertyNameProvider.ShutdownModeProperty)
             {
                 unevaluatedPropertyValue = unevaluatedPropertyValue switch
                 {
@@ -335,15 +320,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             await (propertyName switch 
             {
-                ApplicationFrameworkProperty => _myAppXmlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
-                EnableVisualStylesProperty => _myAppXmlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                SingleInstanceProperty => _myAppXmlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                SaveMySettingsOnExitProperty => _myAppXmlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                HighDpiModeProperty => _myAppXmlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                AuthenticationModeProperty => _myAppXmlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                ShutdownModeProperty => _myAppXmlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                SplashScreenProperty => _myAppXmlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
-                MinimumSplashScreenDisplayTimeProperty => _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                PropertyNameProvider.ApplicationFrameworkProperty => _myAppXmlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
+                PropertyNameProvider.EnableVisualStylesProperty => _myAppXmlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                PropertyNameProvider.SingleInstanceProperty => _myAppXmlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                PropertyNameProvider.SaveMySettingsOnExitProperty => _myAppXmlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                PropertyNameProvider.HighDpiModeProperty => _myAppXmlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                PropertyNameProvider.AuthenticationModeProperty => _myAppXmlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                PropertyNameProvider.ShutdownModeProperty => _myAppXmlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                PropertyNameProvider.SplashScreenProperty => _myAppXmlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
+                PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty => _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
 
                 _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -9,15 +9,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [ExportInterceptingPropertyValueProvider(
     new[]
     {
-        ApplicationFrameworkProperty,
-        EnableVisualStylesProperty,
-        SingleInstanceProperty,
-        SaveMySettingsOnExitProperty,
-        HighDpiModeProperty,
-        AuthenticationModeProperty,
-        ShutdownModeProperty,
-        SplashScreenProperty,
-        MinimumSplashScreenDisplayTimeProperty
+        ApplicationFramework,
+        EnableVisualStyles,
+        SingleInstance,
+        SaveMySettingsOnExit,
+        HighDpiMode,
+        AuthenticationMode,
+        ShutdownMode,
+        SplashScreen,
+        MinimumSplashScreenDisplayTime
     },
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
     [AppliesTo(ProjectCapability.WPF + "|" + ProjectCapability.WindowsForms)]
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (propertyName == ApplicationFrameworkProperty)
+            if (propertyName == ApplicationFramework)
             {
                 if (await IsWPFApplicationAsync(defaultProperties))
                 {
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            if (propertyName == ApplicationFrameworkProperty)
+            if (propertyName == ApplicationFramework)
             {
                 return GetPropertyValueAsync(defaultProperties);
             }
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            if (propertyName == ApplicationFrameworkProperty)
+            if (propertyName == ApplicationFramework)
             {
                 return GetPropertyValueAsync(defaultProperties);
             }
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueForWPFApplicationAsync(IProjectProperties defaultProperties)
         {
-            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuild);
             if (!string.IsNullOrEmpty(startupObject))
             {
                 // A start-up object is specified for this project. This takes precedence over the Startup URI, so set Use Application Framework to "false".
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static async Task<string> GetPropertyValueForDefaultProjectTypesAsync(IProjectProperties defaultProperties)
         {
-            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
+            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuild);
 
             return value switch
             {
@@ -137,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             bool useWPF = capabilities.Contains(ProjectCapability.WPF);
             bool useWindowsForms = capabilities.Contains(ProjectCapability.WindowsForms);
-            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypeMSBuildProperty);
+            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypeMSBuild);
 
             return useWPF
                 && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputType)
@@ -153,15 +153,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 if (value)
                 {
                     // Set in project file: <MyType>WindowsForms</MyType>
-                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, EnabledValue);
+                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuild, EnabledValue);
 
                     // Set in myapp file: <MySubMain>true</MySubMain>
                     await _myAppXmlFileAccessor.SetMySubMainAsync("true");
 
                     // Set the StartupObject to namespace.My.MyApplication; we should save the actual value in the myapp file.
-                    string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuild);
 
-                    await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + ".My.MyApplication");
+                    await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuild, rootNamespace + ".My.MyApplication");
 
                     if (startupObjectValue is not null)
                     {
@@ -176,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 else
                 {
                     // Set in project file: <MyType>WindowsFormsWithCustomSubMain</MyType>
-                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, DisabledValue);
+                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuild, DisabledValue);
 
                     // Set in myapp file: <MySubMain>false</MySubMain>
                     await _myAppXmlFileAccessor.SetMySubMainAsync("false");
@@ -185,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     string? startupObjectValue = await _myAppXmlFileAccessor.GetMainFormAsync();
 
                     if (startupObjectValue is not null)
-                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + "." + startupObjectValue);
+                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuild, rootNamespace + "." + startupObjectValue);
                 }
             }
 
@@ -220,10 +220,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     }
 
                     // Clear out the StartupObject if it has a value.
-                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuild);
                     if (!string.IsNullOrEmpty(startupObject))
                     {
-                        await defaultProperties.DeletePropertyAsync(StartupObjectMSBuildProperty);
+                        await defaultProperties.DeletePropertyAsync(StartupObjectMSBuild);
                     }
                 }
                 else
@@ -231,10 +231,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     // Disabled
 
                     // Set the StartupObject if it doesn't already have a value.
-                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuild);
                     if (string.IsNullOrEmpty(startupObject))
                     {
-                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, "Sub Main");
+                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuild, "Sub Main");
                     }
 
                     // Set the Application.xaml file's build action to None.
@@ -258,20 +258,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             string value = propertyName switch
             {
-                ApplicationFrameworkProperty => (await _myAppXmlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
-                EnableVisualStylesProperty => (await _myAppXmlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
-                SingleInstanceProperty => (await _myAppXmlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
-                SaveMySettingsOnExitProperty => (await _myAppXmlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
-                HighDpiModeProperty => (await _myAppXmlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
-                AuthenticationModeProperty => (await _myAppXmlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
-                ShutdownModeProperty => (await _myAppXmlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
-                SplashScreenProperty => await _myAppXmlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
-                MinimumSplashScreenDisplayTimeProperty => (await _myAppXmlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
+                ApplicationFramework => (await _myAppXmlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
+                EnableVisualStyles => (await _myAppXmlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
+                SingleInstance => (await _myAppXmlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
+                SaveMySettingsOnExit => (await _myAppXmlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
+                HighDpiMode => (await _myAppXmlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
+                AuthenticationMode => (await _myAppXmlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
+                ShutdownMode => (await _myAppXmlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
+                SplashScreen => await _myAppXmlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
+                MinimumSplashScreenDisplayTime => (await _myAppXmlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
 
                 _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
             };
 
-            if (propertyName == AuthenticationModeProperty)
+            if (propertyName == AuthenticationMode)
             {
                 value = value switch
                 {
@@ -282,7 +282,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
                 };
             }
-            else if (propertyName == ShutdownModeProperty)
+            else if (propertyName == ShutdownMode)
             {
                 value = value switch
                 {
@@ -300,7 +300,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private async Task<string?> SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             // ValueProvider needs to convert string enums to valid values to be saved.
-            if (propertyName == AuthenticationModeProperty)
+            if (propertyName == AuthenticationMode)
             {
                 unevaluatedPropertyValue = unevaluatedPropertyValue switch
                 {
@@ -309,7 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => unevaluatedPropertyValue
                 };
             }
-            else if (propertyName == ShutdownModeProperty)
+            else if (propertyName == ShutdownMode)
             {
                 unevaluatedPropertyValue = unevaluatedPropertyValue switch
                 {
@@ -321,15 +321,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             await (propertyName switch 
             {
-                ApplicationFrameworkProperty => _myAppXmlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
-                EnableVisualStylesProperty => _myAppXmlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                SingleInstanceProperty => _myAppXmlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                SaveMySettingsOnExitProperty => _myAppXmlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                HighDpiModeProperty => _myAppXmlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                AuthenticationModeProperty => _myAppXmlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                ShutdownModeProperty => _myAppXmlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                SplashScreenProperty => _myAppXmlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
-                MinimumSplashScreenDisplayTimeProperty => _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                ApplicationFramework => _myAppXmlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
+                EnableVisualStyles => _myAppXmlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                SingleInstance => _myAppXmlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                SaveMySettingsOnExit => _myAppXmlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                HighDpiMode => _myAppXmlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                AuthenticationMode => _myAppXmlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                ShutdownMode => _myAppXmlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                SplashScreen => _myAppXmlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
+                MinimumSplashScreenDisplayTime => _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
 
                 _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -130,16 +130,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             };
         }
 
-        private static async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
+        private async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
         {
-            string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.UseWPFProperty);
-            string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.UseWindowsFormsProperty);
+            IProjectCapabilitiesScope capabilities = _project.Capabilities;
+
+            bool useWPF = capabilities.Contains(ProjectCapability.WPF);
+            bool useWindowsForms = capabilities.Contains(ProjectCapability.WindowsForms);
             string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.OutputTypeMSBuildProperty);
 
-            return bool.TryParse(useWPFString, out bool useWPF)
-                && useWPF
+            return useWPF
                 && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputType)
-                && bool.TryParse(useWindowsFormsString, out bool useWindowsForms)
                 && !useWindowsForms;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -2,24 +2,25 @@
 
 using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
+using static Microsoft.VisualStudio.ProjectSystem.Properties.PropertyNames;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     [ExportInterceptingPropertyValueProvider(
     new[]
     {
-        PropertyNameProvider.ApplicationFrameworkProperty,
-        PropertyNameProvider.EnableVisualStylesProperty,
-        PropertyNameProvider.SingleInstanceProperty,
-        PropertyNameProvider.SaveMySettingsOnExitProperty,
-        PropertyNameProvider.HighDpiModeProperty,
-        PropertyNameProvider.AuthenticationModeProperty,
-        PropertyNameProvider.ShutdownModeProperty,
-        PropertyNameProvider.SplashScreenProperty,
-        PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty
+        ApplicationFrameworkProperty,
+        EnableVisualStylesProperty,
+        SingleInstanceProperty,
+        SaveMySettingsOnExitProperty,
+        HighDpiModeProperty,
+        AuthenticationModeProperty,
+        ShutdownModeProperty,
+        SplashScreenProperty,
+        MinimumSplashScreenDisplayTimeProperty
     },
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-    [AppliesTo(ProjectCapability.WPF + "&" + ProjectCapability.WindowsForms)]
+    [AppliesTo(ProjectCapability.WPF + "|" + ProjectCapability.WindowsForms)]
     internal sealed class ApplicationFrameworkValueProvider : InterceptingPropertyValueProviderBase
     {
         private const string EnabledValue = "WindowsForms";
@@ -46,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
-            if (propertyName == PropertyNameProvider.ApplicationFrameworkProperty)
+            if (propertyName == ApplicationFrameworkProperty)
             {
                 if (await IsWPFApplicationAsync(defaultProperties))
                 {
@@ -65,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            if (propertyName == PropertyNameProvider.ApplicationFrameworkProperty)
+            if (propertyName == ApplicationFrameworkProperty)
             {
                 return GetPropertyValueAsync(defaultProperties);
             }
@@ -77,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public override Task<string> OnGetUnevaluatedPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
-            if (propertyName == PropertyNameProvider.ApplicationFrameworkProperty)
+            if (propertyName == ApplicationFrameworkProperty)
             {
                 return GetPropertyValueAsync(defaultProperties);
             }
@@ -101,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private async Task<string> GetPropertyValueForWPFApplicationAsync(IProjectProperties defaultProperties)
         {
-            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
+            string startupObject = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
             if (!string.IsNullOrEmpty(startupObject))
             {
                 // A start-up object is specified for this project. This takes precedence over the Startup URI, so set Use Application Framework to "false".
@@ -120,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         private static async Task<string> GetPropertyValueForDefaultProjectTypesAsync(IProjectProperties defaultProperties)
         {
-            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.ApplicationFrameworkMSBuildProperty);
+            string? value = await defaultProperties.GetEvaluatedPropertyValueAsync(ApplicationFrameworkMSBuildProperty);
 
             return value switch
             {
@@ -136,7 +137,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             bool useWPF = capabilities.Contains(ProjectCapability.WPF);
             bool useWindowsForms = capabilities.Contains(ProjectCapability.WindowsForms);
-            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.OutputTypeMSBuildProperty);
+            string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypeMSBuildProperty);
 
             return useWPF
                 && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputType)
@@ -152,15 +153,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 if (value)
                 {
                     // Set in project file: <MyType>WindowsForms</MyType>
-                    await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.ApplicationFrameworkMSBuildProperty, EnabledValue);
+                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, EnabledValue);
 
                     // Set in myapp file: <MySubMain>true</MySubMain>
                     await _myAppXmlFileAccessor.SetMySubMainAsync("true");
 
                     // Set the StartupObject to namespace.My.MyApplication; we should save the actual value in the myapp file.
-                    string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
+                    string? startupObjectValue = await defaultProperties.GetEvaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
 
-                    await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty, rootNamespace + ".My.MyApplication");
+                    await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + ".My.MyApplication");
 
                     if (startupObjectValue is not null)
                     {
@@ -175,7 +176,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 else
                 {
                     // Set in project file: <MyType>WindowsFormsWithCustomSubMain</MyType>
-                    await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.ApplicationFrameworkMSBuildProperty, DisabledValue);
+                    await defaultProperties.SetPropertyValueAsync(ApplicationFrameworkMSBuildProperty, DisabledValue);
 
                     // Set in myapp file: <MySubMain>false</MySubMain>
                     await _myAppXmlFileAccessor.SetMySubMainAsync("false");
@@ -184,7 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     string? startupObjectValue = await _myAppXmlFileAccessor.GetMainFormAsync();
 
                     if (startupObjectValue is not null)
-                        await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty, rootNamespace + "." + startupObjectValue);
+                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, rootNamespace + "." + startupObjectValue);
                 }
             }
 
@@ -219,10 +220,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     }
 
                     // Clear out the StartupObject if it has a value.
-                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
                     if (!string.IsNullOrEmpty(startupObject))
                     {
-                        await defaultProperties.DeletePropertyAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
+                        await defaultProperties.DeletePropertyAsync(StartupObjectMSBuildProperty);
                     }
                 }
                 else
@@ -230,10 +231,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     // Disabled
 
                     // Set the StartupObject if it doesn't already have a value.
-                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty);
+                    string? startupObject = await defaultProperties.GetUnevaluatedPropertyValueAsync(StartupObjectMSBuildProperty);
                     if (string.IsNullOrEmpty(startupObject))
                     {
-                        await defaultProperties.SetPropertyValueAsync(PropertyNameProvider.StartupObjectMSBuildProperty, "Sub Main");
+                        await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuildProperty, "Sub Main");
                     }
 
                     // Set the Application.xaml file's build action to None.
@@ -257,20 +258,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         {
             string value = propertyName switch
             {
-                PropertyNameProvider.ApplicationFrameworkProperty => (await _myAppXmlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.EnableVisualStylesProperty => (await _myAppXmlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.SingleInstanceProperty => (await _myAppXmlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.SaveMySettingsOnExitProperty => (await _myAppXmlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.HighDpiModeProperty => (await _myAppXmlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.AuthenticationModeProperty => (await _myAppXmlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.ShutdownModeProperty => (await _myAppXmlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
-                PropertyNameProvider.SplashScreenProperty => await _myAppXmlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
-                PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty => (await _myAppXmlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
+                ApplicationFrameworkProperty => (await _myAppXmlFileAccessor.GetMySubMainAsync()).ToString() ?? string.Empty,
+                EnableVisualStylesProperty => (await _myAppXmlFileAccessor.GetEnableVisualStylesAsync()).ToString() ?? string.Empty,
+                SingleInstanceProperty => (await _myAppXmlFileAccessor.GetSingleInstanceAsync()).ToString() ?? string.Empty,
+                SaveMySettingsOnExitProperty => (await _myAppXmlFileAccessor.GetSaveMySettingsOnExitAsync()).ToString() ?? string.Empty,
+                HighDpiModeProperty => (await _myAppXmlFileAccessor.GetHighDpiModeAsync()).ToString() ?? string.Empty,
+                AuthenticationModeProperty => (await _myAppXmlFileAccessor.GetAuthenticationModeAsync()).ToString() ?? string.Empty,
+                ShutdownModeProperty => (await _myAppXmlFileAccessor.GetShutdownModeAsync()).ToString() ?? string.Empty,
+                SplashScreenProperty => await _myAppXmlFileAccessor.GetSplashScreenAsync() ?? string.Empty,
+                MinimumSplashScreenDisplayTimeProperty => (await _myAppXmlFileAccessor.GetMinimumSplashScreenDisplayTimeAsync()).ToString() ?? string.Empty,
 
                 _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
             };
 
-            if (propertyName == PropertyNameProvider.AuthenticationModeProperty)
+            if (propertyName == AuthenticationModeProperty)
             {
                 value = value switch
                 {
@@ -281,7 +282,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
                 };
             }
-            else if (propertyName == PropertyNameProvider.ShutdownModeProperty)
+            else if (propertyName == ShutdownModeProperty)
             {
                 value = value switch
                 {
@@ -299,7 +300,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private async Task<string?> SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
         {
             // ValueProvider needs to convert string enums to valid values to be saved.
-            if (propertyName == PropertyNameProvider.AuthenticationModeProperty)
+            if (propertyName == AuthenticationModeProperty)
             {
                 unevaluatedPropertyValue = unevaluatedPropertyValue switch
                 {
@@ -308,7 +309,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => unevaluatedPropertyValue
                 };
             }
-            else if (propertyName == PropertyNameProvider.ShutdownModeProperty)
+            else if (propertyName == ShutdownModeProperty)
             {
                 unevaluatedPropertyValue = unevaluatedPropertyValue switch
                 {
@@ -320,15 +321,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             await (propertyName switch 
             {
-                PropertyNameProvider.ApplicationFrameworkProperty => _myAppXmlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
-                PropertyNameProvider.EnableVisualStylesProperty => _myAppXmlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                PropertyNameProvider.SingleInstanceProperty => _myAppXmlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                PropertyNameProvider.SaveMySettingsOnExitProperty => _myAppXmlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
-                PropertyNameProvider.HighDpiModeProperty => _myAppXmlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                PropertyNameProvider.AuthenticationModeProperty => _myAppXmlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                PropertyNameProvider.ShutdownModeProperty => _myAppXmlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
-                PropertyNameProvider.SplashScreenProperty => _myAppXmlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
-                PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty => _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                ApplicationFrameworkProperty => _myAppXmlFileAccessor.SetMySubMainAsync(unevaluatedPropertyValue),
+                EnableVisualStylesProperty => _myAppXmlFileAccessor.SetEnableVisualStylesAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                SingleInstanceProperty => _myAppXmlFileAccessor.SetSingleInstanceAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                SaveMySettingsOnExitProperty => _myAppXmlFileAccessor.SetSaveMySettingsOnExitAsync(Convert.ToBoolean(unevaluatedPropertyValue)),
+                HighDpiModeProperty => _myAppXmlFileAccessor.SetHighDpiModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                AuthenticationModeProperty => _myAppXmlFileAccessor.SetAuthenticationModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                ShutdownModeProperty => _myAppXmlFileAccessor.SetShutdownModeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
+                SplashScreenProperty => _myAppXmlFileAccessor.SetSplashScreenAsync(unevaluatedPropertyValue),
+                MinimumSplashScreenDisplayTimeProperty => _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(Convert.ToInt16(unevaluatedPropertyValue)),
 
                 _ => throw new InvalidOperationException($"The provider does not support the '{propertyName}' property.")
             });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         PropertyNameProvider.MinimumSplashScreenDisplayTimeProperty
     },
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-    [AppliesTo(ProjectCapability.VisualBasic)]
+    [AppliesTo(ProjectCapability.WPF + "&" + ProjectCapability.WindowsForms)]
     internal sealed class ApplicationFrameworkValueProvider : InterceptingPropertyValueProviderBase
     {
         private const string EnabledValue = "WindowsForms";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private const string DisabledValue = "WindowsFormsWithCustomSubMain";
         
         private const string UseWPFMSBuildProperty = "UseWPF";
+        private const string UseWindowsFormProperty = "UseWindowsForms";
         private const string OutputTypeMSBuildProperty = "OutputType";
         private const string WinExeOutputType = "WinExe";
         private const string StartupObjectMSBuildProperty = "StartupObject";
@@ -147,11 +148,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private static async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
         {
             string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWPFMSBuildProperty);
+            string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWindowsFormProperty);
             string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypeMSBuildProperty);
 
             return bool.TryParse(useWPFString, out bool useWPF)
                 && useWPF
-                && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputType);
+                && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputType)
+                && bool.TryParse(useWindowsFormsString, out bool useWindowsForms)
+                && !useWindowsForms;
         }
 
         private async Task<string?> SetPropertyValueForDefaultProjectTypesAsync(string unevaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -6,8 +6,8 @@ using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 // The AppliesTo metadata has no effect given the limitations described in https://github.com/dotnet/project-system/issues/8170.
-[ExportInterceptingPropertyValueProvider(StartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-[AppliesTo(ProjectCapability.VisualBasic)]
+[ExportInterceptingPropertyValueProvider(InterceptedStartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+[AppliesTo(ProjectCapability.WPF + "&" + ProjectCapability.WindowsForms)]
 internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBase
 {
     private readonly IMyAppFileAccessor _myAppXmlFileAccessor;
@@ -17,6 +17,7 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     private const string DisabledValue = "WindowsFormsWithCustomSubMain";
 
     internal const string UseWinFormsProperty = "UseWindowsForms";
+    internal const string InterceptedStartupObjectProperty = "StartupObjectVB";
     internal const string StartupObjectProperty = "StartupObject";
     internal const string RootNamespaceProperty = "RootNamespace";
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 // The AppliesTo metadata has no effect given the limitations described in https://github.com/dotnet/project-system/issues/8170.
 [ExportInterceptingPropertyValueProvider(InterceptedStartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-[AppliesTo(ProjectCapability.WPF + "&" + ProjectCapability.WindowsForms)]
+[AppliesTo(ProjectCapability.WPF + "|" + ProjectCapability.WindowsForms)]
 internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBase
 {
     private readonly IMyAppFileAccessor _myAppXmlFileAccessor;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/PropertyNameProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/PropertyNameProvider.cs
@@ -1,0 +1,29 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+    /// <summary>
+    /// Contains constants representing the property names used in the ApplicationPropertyPage folder.
+    /// </summary>
+    internal class PropertyNameProvider
+    {
+        // Project properties
+        internal const string UseWPFProperty = "UseWPF";
+        internal const string UseWindowsFormsProperty = "UseWindowsForms";
+
+        // MSBuild properties
+        internal const string ApplicationFrameworkMSBuildProperty = "MyType";
+        internal const string OutputTypeMSBuildProperty = "OutputType";
+        internal const string StartupObjectMSBuildProperty = "StartupObject";
+
+        // Application.myapp properties
+        internal const string ApplicationFrameworkProperty = "UseApplicationFramework";
+        internal const string EnableVisualStylesProperty = "EnableVisualStyles";
+        internal const string SingleInstanceProperty = "SingleInstance";
+        internal const string SaveMySettingsOnExitProperty = "SaveMySettingsOnExit";
+        internal const string HighDpiModeProperty = "HighDpiMode";
+        internal const string AuthenticationModeProperty = "VBAuthenticationMode";
+        internal const string ShutdownModeProperty = "ShutdownMode";
+        internal const string SplashScreenProperty = "SplashScreen";
+        internal const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
+    }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/PropertyNames.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/PropertyNames.cs
@@ -5,25 +5,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
     /// <summary>
     /// Contains constants representing the property names used in the ApplicationPropertyPage folder.
     /// </summary>
-    internal class PropertyNames
+    internal static class PropertyNames
     {
         // Project properties
-        internal const string UseWPFProperty = "UseWPF";
-        internal const string UseWindowsFormsProperty = "UseWindowsForms";
+        internal const string UseWPF = "UseWPF";
+        internal const string UseWindowsForms = "UseWindowsForms";
 
         // MSBuild properties
-        internal const string ApplicationFrameworkMSBuildProperty = "MyType";
-        internal const string OutputTypeMSBuildProperty = "OutputType";
-        internal const string StartupObjectMSBuildProperty = "StartupObject";
+        internal const string ApplicationFrameworkMSBuild = "MyType";
+        internal const string OutputTypeMSBuild = "OutputType";
+        internal const string StartupObjectMSBuild = "StartupObject";
 
         // Application.myapp properties
-        internal const string ApplicationFrameworkProperty = "UseApplicationFramework";
-        internal const string EnableVisualStylesProperty = "EnableVisualStyles";
-        internal const string SingleInstanceProperty = "SingleInstance";
-        internal const string SaveMySettingsOnExitProperty = "SaveMySettingsOnExit";
-        internal const string HighDpiModeProperty = "HighDpiMode";
-        internal const string AuthenticationModeProperty = "VBAuthenticationMode";
-        internal const string ShutdownModeProperty = "ShutdownMode";
-        internal const string SplashScreenProperty = "SplashScreen";
-        internal const string MinimumSplashScreenDisplayTimeProperty = "MinimumSplashScreenDisplayTime";
+        internal const string ApplicationFramework = "UseApplicationFramework";
+        internal const string EnableVisualStyles = "EnableVisualStyles";
+        internal const string SingleInstance = "SingleInstance";
+        internal const string SaveMySettingsOnExit = "SaveMySettingsOnExit";
+        internal const string HighDpiMode = "HighDpiMode";
+        internal const string AuthenticationMode = "VBAuthenticationMode";
+        internal const string ShutdownMode = "ShutdownMode";
+        internal const string SplashScreen = "SplashScreen";
+        internal const string MinimumSplashScreenDisplayTime = "MinimumSplashScreenDisplayTime";
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/PropertyNames.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/PropertyNames.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
     /// <summary>
     /// Contains constants representing the property names used in the ApplicationPropertyPage folder.
     /// </summary>
-    internal class PropertyNameProvider
+    internal class PropertyNames
     {
         // Project properties
         internal const string UseWPFProperty = "UseWPF";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -16,6 +16,7 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
     internal const string StartupURIPropertyName = "StartupURI";
     internal const string ShutdownModePropertyName = "ShutdownMode_WPF";
     internal const string UseWPFPropertyName = "UseWPF";
+    internal const string UseWindowsFormsPropertyName = "UseWindowsForms";
     internal const string OutputTypePropertyName = "OutputType";
     internal const string WinExeOutputTypeValue = "WinExe";
 
@@ -72,10 +73,13 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
     private static async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
     {
         string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWPFPropertyName);
+        string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWindowsFormsPropertyName);
         string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypePropertyName);
 
         return bool.TryParse(useWPFString, out bool useWPF)
             && useWPF
-            && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputTypeValue);
+            && StringComparers.PropertyLiteralValues.Equals(outputTypeString, WinExeOutputTypeValue)
+            && bool.TryParse(useWindowsFormsString, out bool useWindowsForms)
+            && !useWindowsForms;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -41,7 +41,7 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
 
     public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
     {
-        if (await IsWPFApplicationAsync(defaultProperties))
+        if (await IsWpfAndNotWinFormsApplicationAsync(defaultProperties))
         {
             await (propertyName switch
             {
@@ -57,7 +57,7 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
 
     private async Task<string> GetPropertyValueAsync(string propertyName, IProjectProperties defaultProperties)
     {
-        if (await IsWPFApplicationAsync(defaultProperties))
+        if (await IsWpfAndNotWinFormsApplicationAsync(defaultProperties))
         {
             return propertyName switch
             {
@@ -71,7 +71,12 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
         return string.Empty;
     }
 
-    private async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
+    /// <summary>
+    /// This method will help us determine if we need to load the files
+    /// where the properties are stored. For WPF, that is the Application.xaml file;
+    /// for WinForms, that is the .myApp file.
+    /// </summary>
+    private async Task<bool> IsWpfAndNotWinFormsApplicationAsync(IProjectProperties defaultProperties)
     {
         IProjectCapabilitiesScope capabilities = _project.Capabilities;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -15,8 +15,6 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
 {
     internal const string StartupURIPropertyName = "StartupURI";
     internal const string ShutdownModePropertyName = "ShutdownMode_WPF";
-    internal const string UseWPFPropertyName = "UseWPF";
-    internal const string UseWindowsFormsPropertyName = "UseWindowsForms";
     internal const string OutputTypePropertyName = "OutputType";
     internal const string WinExeOutputTypeValue = "WinExe";
 
@@ -72,8 +70,8 @@ internal class WPFValueProvider : InterceptingPropertyValueProviderBase
 
     private static async Task<bool> IsWPFApplicationAsync(IProjectProperties defaultProperties)
     {
-        string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWPFPropertyName);
-        string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(UseWindowsFormsPropertyName);
+        string useWPFString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.UseWPFProperty);
+        string useWindowsFormsString = await defaultProperties.GetEvaluatedPropertyValueAsync(PropertyNameProvider.UseWindowsFormsProperty);
         string outputTypeString = await defaultProperties.GetEvaluatedPropertyValueAsync(OutputTypePropertyName);
 
         return bool.TryParse(useWPFString, out bool useWPF)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
         ShutdownModePropertyName
     },
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+[AppliesTo(ProjectCapability.WPF)]
 internal class WPFValueProvider : InterceptingPropertyValueProviderBase
 {
     internal const string StartupURIPropertyName = "StartupURI";

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
@@ -1,0 +1,23 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem;
+
+namespace Microsoft.VisualStudio.Mocks;
+
+internal static class IProjectCapabilitiesScopeFactory
+{
+    public static IProjectCapabilitiesScope Create(IEnumerable<string>? capabilities = null)
+    {
+        capabilities ??= Enumerable.Empty<string>();
+        var snapshot = new Mock<IProjectCapabilitiesSnapshot>();
+        snapshot.Setup(s => s.IsProjectCapabilityPresent(It.IsAny<string>())).Returns((string capability) => capabilities.Contains(capability));
+
+        var versionedValue = new Mock<IProjectVersionedValue<IProjectCapabilitiesSnapshot>>();
+        versionedValue.Setup(v => v.Value).Returns(snapshot.Object);
+
+        var scope = new Mock<IProjectCapabilitiesScope>();
+        scope.Setup(s => s.Current).Returns(versionedValue.Object);
+
+        return scope.Object;
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -35,7 +35,7 @@ public class WPFValueProviderTests
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
-            { WPFValueProvider.UseWPFPropertyName, useWPFPropertyValue },
+            { PropertyNameProvider.UseWPFProperty, useWPFPropertyValue },
             { WPFValueProvider.OutputTypePropertyName, outputTypeValue }
         });
 
@@ -87,8 +87,8 @@ public class WPFValueProviderTests
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
-            { WPFValueProvider.UseWPFPropertyName, useWPFPropertyValue },
-            { WPFValueProvider.OutputTypePropertyName, outputTypeValue }
+            { PropertyNameProvider.UseWPFProperty, useWPFPropertyValue },
+            { PropertyNameProvider.OutputTypeMSBuildProperty, outputTypeValue }
         });
 
         var result = await provider.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue: "NewValue", defaultProperties);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -35,7 +35,7 @@ public class WPFValueProviderTests
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
-            { PropertyNameProvider.UseWPFProperty, useWPFPropertyValue },
+            { PropertyNames.UseWPFProperty, useWPFPropertyValue },
             { WPFValueProvider.OutputTypePropertyName, outputTypeValue }
         });
 
@@ -87,8 +87,8 @@ public class WPFValueProviderTests
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
-            { PropertyNameProvider.UseWPFProperty, useWPFPropertyValue },
-            { PropertyNameProvider.OutputTypeMSBuildProperty, outputTypeValue }
+            { PropertyNames.UseWPFProperty, useWPFPropertyValue },
+            { PropertyNames.OutputTypeMSBuildProperty, outputTypeValue }
         });
 
         var result = await provider.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue: "NewValue", defaultProperties);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -30,8 +30,10 @@ public class WPFValueProviderTests
                 getShutdownModeCalled = true;
                 return Task.FromResult<string?>(shutdownModeValue);
             });
+                
+        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here");
 
-        var provider = new WPFValueProvider(applicationXamlFileAccessor);
+        var provider = new WPFValueProvider(applicationXamlFileAccessor, unconfiguredProject);
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
@@ -83,7 +85,9 @@ public class WPFValueProviderTests
                 return Task.CompletedTask;
             });
 
-        var provider = new WPFValueProvider(applicationXamlFileAccessor);
+        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here");
+
+        var provider = new WPFValueProvider(applicationXamlFileAccessor, unconfiguredProject);
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -33,11 +33,21 @@ public class WPFValueProviderTests
                 return Task.FromResult<string?>(shutdownModeValue);
             });
 
-        IEnumerable<string> capabilities = new List<string> { "UseWPF" };
+        IEnumerable<string> capabilities;
 
-        var projectcapabilitiesScope = IProjectCapabilitiesScopeFactory.Create(capabilities);
+        if (bool.TryParse(useWPFPropertyValue, out bool useWPF) && useWPF)
+        {
+            // the capability value is different than the property (WPF vs UseWPF)
+            capabilities = new List<string> { ProjectCapability.WPF };
+        }
+        else
+        {
+            capabilities = new List<string>();
+        }
+
+        var projectCapabilitiesScope = IProjectCapabilitiesScopeFactory.Create(capabilities);
                 
-        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here", scope: projectcapabilitiesScope);
+        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here", scope: projectCapabilitiesScope);
 
         var provider = new WPFValueProvider(applicationXamlFileAccessor, unconfiguredProject);
 
@@ -93,11 +103,11 @@ public class WPFValueProviderTests
 
         IEnumerable<string> capabilities;
 
-        capabilities = (bool.Parse(useWPFPropertyValue) ? new List<string>() {  "UseWPF" } : new List<string>());
+        capabilities = bool.Parse(useWPFPropertyValue) ? new List<string>() {  ProjectCapability.WPF } : new List<string>();
 
-        var projectcapabilitiesScope = IProjectCapabilitiesScopeFactory.Create(capabilities);
+        var projectCapabilitiesScope = IProjectCapabilitiesScopeFactory.Create(capabilities);
 
-        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here", scope: projectcapabilitiesScope);
+        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here", scope: projectCapabilitiesScope);
 
         var provider = new WPFValueProvider(applicationXamlFileAccessor, unconfiguredProject);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.Mocks;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 
 public class WPFValueProviderTests
@@ -30,8 +32,12 @@ public class WPFValueProviderTests
                 getShutdownModeCalled = true;
                 return Task.FromResult<string?>(shutdownModeValue);
             });
+
+        IEnumerable<string> capabilities = new List<string> { "UseWPF" };
+
+        var projectcapabilitiesScope = IProjectCapabilitiesScopeFactory.Create(capabilities);
                 
-        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here");
+        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here", scope: projectcapabilitiesScope);
 
         var provider = new WPFValueProvider(applicationXamlFileAccessor, unconfiguredProject);
 
@@ -85,7 +91,13 @@ public class WPFValueProviderTests
                 return Task.CompletedTask;
             });
 
-        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here");
+        IEnumerable<string> capabilities;
+
+        capabilities = (bool.Parse(useWPFPropertyValue) ? new List<string>() {  "UseWPF" } : new List<string>());
+
+        var projectcapabilitiesScope = IProjectCapabilitiesScopeFactory.Create(capabilities);
+
+        var unconfiguredProject = UnconfiguredProjectFactory.Create(@"C:\Test\Path\Here", scope: projectcapabilitiesScope);
 
         var provider = new WPFValueProvider(applicationXamlFileAccessor, unconfiguredProject);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/WPFValueProviderTests.cs
@@ -35,7 +35,7 @@ public class WPFValueProviderTests
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
-            { PropertyNames.UseWPFProperty, useWPFPropertyValue },
+            { PropertyNames.UseWPF, useWPFPropertyValue },
             { WPFValueProvider.OutputTypePropertyName, outputTypeValue }
         });
 
@@ -87,8 +87,8 @@ public class WPFValueProviderTests
 
         var defaultProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(new Dictionary<string, string?>
         {
-            { PropertyNames.UseWPFProperty, useWPFPropertyValue },
-            { PropertyNames.OutputTypeMSBuildProperty, outputTypeValue }
+            { PropertyNames.UseWPF, useWPFPropertyValue },
+            { PropertyNames.OutputTypeMSBuild, outputTypeValue }
         });
 
         var result = await provider.OnSetPropertyValueAsync(propertyName, unevaluatedPropertyValue: "NewValue", defaultProperties);


### PR DESCRIPTION
Addresses #8436 and [AzDO#1597634](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1597634).

This PR checks for `UseWindowsForms` property before assuming a project is a WPF one. This avoids the scenario where both `UseWPF` and `UseWindowsForms` are set to true and an error message appear when opening the project properties UI, as reported in the linked issues.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8661)