### PR TITLE
Revert ImportedNamespaces to use DynamicEnumProperty

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -233,13 +233,21 @@ The property's string value should be encoded with format resembling `A=1,B=2`, 
 
 ### Multi-String Selector Editor
 
-When a property contains a variable number of strings, you can use the `MultiStringSelector` editor on a StringProperty to display a list of checkable/uncheckable strings.
+When a property contains a variable number of strings, you can use the `MultiStringSelector` editor on a StringProperty or DynamicEnumProperty to display a list of checkable/uncheckable strings.
 
 The `TypeDescriptorText` metadata must be included in order to describe what is actually being selected.
 
 By default, users will not be able to add their own custom strings to the list. To allow custom strings, set the `AllowsCustomStrings` metadata value to True.
 
 To show the evaluated value of the property below the multi-string selector, set the `ShouldDisplayEvaluatedPreview` metadata value to True.
+
+#### StringProperty vs DynamicEnumProperty
+
+If your multi-string selector control needs to include _non-selected_ items as part of the options, you should use 
+a DynamicEnumProperty instead of a StringProperty. All `SupportedValues` that are not part of the unevaluated value 
+will be added as unchecked list items.
+
+#### Example
 
 ```xml
 <StringProperty Name="ImportedNamespaces"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ReferencesPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ReferencesPage.VisualBasic.xaml
@@ -19,16 +19,17 @@
                 HasConfigurationCondition="False" />
   </Rule.DataSource>
 
-  <StringProperty Name="ImportedNamespaces"
+  <DynamicEnumProperty Name="ImportedNamespaces"
                        DisplayName="Import Namespaces"
                        Description="Manage which namespaces to import in your application."
-                       Category="General">
-    <StringProperty.DataSource>
+                       Category="General"
+                       EnumProvider="DotNetImportsEnumProvider">
+    <DynamicEnumProperty.DataSource>
       <DataSource PersistedName="ImportedNamespaces"
                   Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
-    </StringProperty.DataSource>
-    <StringProperty.ValueEditors>
+    </DynamicEnumProperty.DataSource>
+    <DynamicEnumProperty.ValueEditors>
       <ValueEditor EditorType="MultiStringSelector">
         <ValueEditor.Metadata>
           <NameValuePair Name="TypeDescriptorText" Value="Imported Namespaces" />
@@ -36,7 +37,6 @@
           <NameValuePair Name="ShouldDisplayEvaluatedPreview" Value="True" />
         </ValueEditor.Metadata>
       </ValueEditor>
-    </StringProperty.ValueEditors>
-  </StringProperty> 
-
+    </DynamicEnumProperty.ValueEditors>
+  </DynamicEnumProperty> 
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.cs.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Obecné</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Určuje odkazy projektu a importy oborů názvů.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Odkazy</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.de.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Allgemein</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Gibt die Verweise und Namespaceimporte des Projekts an.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Verweise</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.es.xlf
@@ -12,6 +12,16 @@
         <target state="translated">General</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Especifica las referencias del proyecto y las importaciones de espacio de nombres.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Referencias</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.fr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Général</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Indique les importations de références et d’espaces de noms du projet.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Références</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.it.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Generale</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Specifica i riferimenti e le importazioni dello spazio dei nomi del progetto.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Riferimenti</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.ja.xlf
@@ -12,6 +12,16 @@
         <target state="translated">全般</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">プロジェクトの参照と名前空間のインポートを指定します。</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">参照</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.ko.xlf
@@ -12,6 +12,16 @@
         <target state="translated">일반</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">프로젝트의 참조 및 네임스페이스 가져오기를 지정합니다.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">참조</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.pl.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Ogólne</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Określa odwołania projektu i importy przestrzeni nazw.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Odwołania</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Geral</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Especifica as referências do projeto e as importações de namespace.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Referencias</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.ru.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Общие</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Определяет ссылки проекта и импорт пространства имен.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Ссылки</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.tr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Genel</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">Projenin başvurularını ve ad alanı içeri aktarmalarını belirtir.</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">Başvurular</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="translated">常规</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">指定项目的引用和命名空间导入。</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">引用</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ReferencesPage.VisualBasic.xaml.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="translated">一般</target>
         <note />
       </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|Description">
+        <source>Manage which namespaces to import in your application.</source>
+        <target state="new">Manage which namespaces to import in your application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|ImportedNamespaces|DisplayName">
+        <source>Import Namespaces</source>
+        <target state="new">Import Namespaces</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|References|Description">
         <source>Specifies the project's references and namespace imports.</source>
         <target state="translated">指定專案的參考和命名空間匯入。</target>
@@ -20,16 +30,6 @@
       <trans-unit id="Rule|References|DisplayName">
         <source>References</source>
         <target state="translated">參考</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|Description">
-        <source>Manage which namespaces to import in your application.</source>
-        <target state="new">Manage which namespaces to import in your application.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="StringProperty|ImportedNamespaces|DisplayName">
-        <source>Import Namespaces</source>
-        <target state="new">Import Namespaces</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
This PR reverts changes making ImportedNamespaces a StringProperty. This is so we pick up all of the unselected namespaces again. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8670)