### PR TITLE
Disable RichNav

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -153,7 +153,8 @@ stages:
   jobs:
   - template: templates/publish-assets-and-packages.yml
   - template: templates/publish-symbols.yml
-  - template: templates/publish-richnav.yml
+  # Disabling RichNav due to an acquisition issue. See: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1659507
+  # - template: templates/publish-richnav.yml
 
 # Skip this stage only when specifically requested (via SkipCompliance).
 - ${{ if eq(parameters.SkipCompliance, false) }}:

--- a/eng/pipelines/pull-request.yml
+++ b/eng/pipelines/pull-request.yml
@@ -67,10 +67,11 @@ stages:
       BuildConfiguration: Release
       ArtifactName: '$(Build.BuildNumber)'
 
-- stage: PostBuild
-  displayName: Post-Build
-  dependsOn: Build
-  variables:
-    BuildConfiguration: Release
-  jobs:
-  - template: templates/publish-richnav.yml
+# Disabling RichNav due to an acquisition issue. See: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1659507
+# - stage: PostBuild
+#   displayName: Post-Build
+#   dependsOn: Build
+#   variables:
+#     BuildConfiguration: Release
+#   jobs:
+#   - template: templates/publish-richnav.yml


### PR DESCRIPTION
Disabling RichNav due to issue with the task. See: https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1659507
Disabling this erroring task will no longer cause the build to 'Partially Succeed' which causes scheduled builds to run multiple times on the same commit.

## Description
I have details about this, but it was all shared on an internal Teams chat. The errors state how they can't find certain DLLs. The issues started on September 24th 2022 and became completely broken on October 13th 2022. The team I spoke with stated that it is only problematic for GitHub repos.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8678)