### PR TITLE
Add analyser to catch multiple enumeration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -230,6 +230,7 @@ dotnet_diagnostic.CA1806.severity = none        # Do not ignore method results
 dotnet_diagnostic.CA1821.severity = none        # Remove empty Finalizers
 dotnet_diagnostic.CA1823.severity = warning     # Avoid unused private fields
 dotnet_diagnostic.CA1824.severity = none        # Mark assemblies with NeutralResourcesLanguageAttribute
+dotnet_diagnostic.CA1851.severity = warning     # Detect multiple enumeration
 dotnet_diagnostic.CA2200.severity = none        # Rethrow to preserve stack details
 
 # Microsoft.NetCore.Analyzers

--- a/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ApplicationPropPageInternalBase.vb
@@ -132,7 +132,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                     Dim supportedTargetFrameworksDescriptor As PropertyDescriptor = GetPropertyDescriptor("SupportedTargetFrameworks")
 
-                    Dim supportedFrameworks As IEnumerable(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor?.Converter)
+                    Dim supportedFrameworks As IReadOnlyList(Of TargetFrameworkMoniker) = TargetFrameworkMoniker.GetSupportedTargetFrameworkMonikers(vsFrameworkMultiTargeting, DTEProject, supportedTargetFrameworksDescriptor?.Converter)
 
                     'If the list doesn't contain any tfm, it means the project can't retarget.
                     If Not supportedFrameworks.Any() Then

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworkMoniker.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Public Shared Function GetSupportedTargetFrameworkMonikers(
                 frameworkMultiTargeting As IVsFrameworkMultiTargeting,
                 project As Project,
-                converter As TypeConverter) As IEnumerable(Of TargetFrameworkMoniker)
+                converter As TypeConverter) As IReadOnlyList(Of TargetFrameworkMoniker)
 
             Dim provider = GetSupportedTargetFrameworksProvider(frameworkMultiTargeting, project, converter)
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/FrameworkMultiTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/FrameworkMultiTargetProvider.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             End Get
         End Property
 
-        Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As ICollection(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
+        Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As IReadOnlyList(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
 
             Requires.NotNull(framework, NameOf(framework))
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/ISupportedTargetFrameworksProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/ISupportedTargetFrameworksProvider.vb
@@ -6,7 +6,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
     Friend Interface ISupportedTargetFrameworksProvider
 
-        Function GetSupportedTargetFrameworks(framework As FrameworkName) As ICollection(Of TargetFrameworkMoniker)
+        Function GetSupportedTargetFrameworks(framework As FrameworkName) As IReadOnlyList(Of TargetFrameworkMoniker)
 
     End Interface
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/TypeConverterTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/TypeConverterTargetProvider.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             _converter = converter
         End Sub
 
-        Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As ICollection(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
+        Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As IReadOnlyList(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
 
             Requires.NotNull(framework, NameOf(framework))
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ProjectConfigurationDimensionProviderTestBase.cs
@@ -560,18 +560,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
             var result = await provider.GetBestGuessDefaultValuesForDimensionsAsync(UnconfiguredProjectFactory.Create());
 
-            Assert.Single(result);
-            Assert.Equal(provider.DimensionName, result.First().Key);
-            Assert.Equal("expected", result.First().Value);
+            (string key, string value) = Assert.Single(result);
+            Assert.Equal(provider.DimensionName, key);
+            Assert.Equal("expected", value);
         }
 
         private static void AssertDefaultOrEmpty(BaseProjectConfigurationDimensionProvider provider, IEnumerable<KeyValuePair<string, string>> result)
         {
             if (provider.DimensionDefaultValue is not null)
             {
-                Assert.Single(result);
-                Assert.Equal(provider.DimensionName, result.First().Key);
-                Assert.Equal(provider.DimensionDefaultValue, result.First().Value);
+                (string key, string value) = Assert.Single(result);
+                Assert.Equal(provider.DimensionName, key);
+                Assert.Equal(provider.DimensionDefaultValue, value);
             }
             else
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProviderTests.cs
@@ -90,10 +90,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
 
         private static void VerifySameValue(IEnumerable<IEnumValue> actual, IEnumerable<IEnumValue> expected, bool checkMapNameOnly = false)
         {
-            Assert.Equal(actual.Count(), expected.Count());
-            for (var i = 0; i < actual.Count(); ++i)
+            var actualAsArray = actual.ToArray();
+            var expectedAsArray = expected.ToArray();
+
+            Assert.Equal(actualAsArray.Length, expectedAsArray.Length);
+
+            for (var i = 0; i < actualAsArray.Length; ++i)
             {
-                VerifySameValue(actual.ElementAt(i), expected.ElementAt(i), checkMapNameOnly);
+                VerifySameValue(actualAsArray[i], expectedAsArray[i], checkMapNameOnly);
             }
         }
 
@@ -120,15 +124,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
 
         private static Dictionary<string, IEnumValue> CreateEnumValueMap(List<string> keys, IEnumerable<PageEnumValue> pageEnumValues)
         {
-            Assert.True(keys.Count == pageEnumValues.Count(), "This is a test authoring error");
+            int index = 0;
+            Dictionary<string, IEnumValue> map = new();
 
-            var dict = new Dictionary<string, IEnumValue>();
-            for (int i = 0; i < keys.Count; i++)
+            foreach (var item in pageEnumValues)
             {
-                dict.Add(keys[i], pageEnumValues.ElementAt(i));
+                map[keys[index]] = item;
+                index++;
             }
 
-            return dict;
+            Assert.Equal(index, keys.Count);
+
+            return map;
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/SwrTests.cs
@@ -44,13 +44,13 @@ namespace Microsoft.VisualStudio.Setup
             var ruleFilesByCulture = Directory.EnumerateFiles(rulesPath, "*", SearchOption.AllDirectories)
                 .Select(ParseRepoFile)
                 .Where(pair => pair.Culture is not null)
-                .ToLookup(pair => pair.Culture, pair => pair.File);
+                .ToLookup(pair => pair.Culture!, pair => pair.File);
 
-            var setupCultures = setupFilesByCulture.Select(p => p.Key);
-            var ruleCultures = ruleFilesByCulture.Select(p => p.Key);
+            var setupCultures = setupFilesByCulture.Select(p => p.Key).ToList();
+            var ruleCultures = ruleFilesByCulture.Select(p => p.Key).ToList();
 
             Assert.True(
-                setupCultures.ToHashSet().SetEquals(ruleCultures!),
+                setupCultures.ToHashSet().SetEquals(ruleCultures),
                 "Set of cultures must match.");
 
             var guilty = false;
@@ -61,10 +61,11 @@ namespace Microsoft.VisualStudio.Setup
                 var ruleFiles = ruleFilesByCulture[culture];
 
                 var embeddedRules = RuleServices.GetAllEmbeddedRules()
-                                                .Select(name => name + ".xaml");
+                                                .Select(name => name + ".xaml")
+                                                .ToList();
 
                 // Exclude the ones that are embedded, they won't be installed
-                ruleFiles = ruleFiles.Except(embeddedRules);
+                ruleFiles = ruleFiles.Except(embeddedRules).ToList();
 
                 foreach (var missing in ruleFiles.Except(setupFiles, StringComparer.OrdinalIgnoreCase))
                 {


### PR DESCRIPTION
This is a pattern that comes up in PR review fairly often. It's easy to inadvertently enumerate a lazy sequence more than once in code, which can have undesirable performance characteristics, or produce invalid behaviour.

This change enables an analyzer that catches such issues, and fixes the existing occurrences of it in our code base.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8688)