### PR TITLE
Ignore "non-modifiable" fast up-to-date check input files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -351,7 +351,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (inputSourceItemsByItemTypeBuilder.TryGetValue(itemType, out ImmutableArray<UpToDateCheckInputItem> beforeItems))
                     before = beforeItems;
 
+                projectFileClassifier ??= BuildClassifier();
+
                 var after = projectChange.After.Items
+                    .Where(item => !projectFileClassifier.IsNonModifiable(item.Key))
                     .Select(item => new UpToDateCheckInputItem(path: item.Key, itemType, metadata: item.Value))
                     .ToHashSet(UpToDateCheckInputItem.PathComparer);
 


### PR DESCRIPTION
Fixes #8690

See that issue for details on this change. The short version is that we now ignore inputs that come from "non-modifiable" locations such as the NuGet cache, Windows directory and Program Files folders.

## Before

```
1>FastUpToDate: Adding AdditionalFiles inputs: (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.MainThreadSwitchingMethods.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.MainThreadAssertingMethods.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\BannedSymbols.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.MainThreadSwitchingMethods.txt (DeployIntegrationDependencies)
1>FastUpToDate:     D:\repos\project-system\src\Common\BannedSymbols.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.LegacyThreadSwitchingMembers.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.LegacyThreadSwitchingMembers.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.projectsystem\17.5.202-pre-g89e17c9f72\build\AdditionalFiles\vs-threading.MainThreadAssertingMethods.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.MembersRequiringMainThread.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.MainThreadAssertingMethods.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.MembersRequiringMainThread.txt (DeployIntegrationDependencies)
1>FastUpToDate:     C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.projectsystem\17.5.202-pre-g89e17c9f72\build\AdditionalFiles\vs-threading.MainThreadSwitchingMethods.txt (DeployIntegrationDependencies)
```

## After

```
1>FastUpToDate: Adding AdditionalFiles inputs: (DeployIntegrationDependencies)
1>FastUpToDate:     D:\repos\project-system\src\Common\BannedSymbols.txt (DeployIntegrationDependencies)
```