### PR TITLE
Allow allocation-free Array.Any call

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollection.cs
@@ -85,8 +85,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         bool IAggregateRelationCollection.HasItems
             => _isMaterialized
-                ? _spans.Any(span => span.Items?.Count > 0)
-                : _spans.Any(span => span.Relation.HasContainedItem(_item));
+                ? _spans.Any(static span => span.Items?.Count > 0)
+                : _spans.Any(static (span, item) => span.Relation.HasContainedItem(item), _item);
 
         int ICollection.Count => _spans.Sum(span => span.Items?.Count ?? 0);
 
@@ -186,7 +186,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
             return -1;
         }
 
-        bool IList.Contains(object value) => value is IRelatableItem item && _spans.Any(span => span.Items?.Contains(item) == true);
+        bool IList.Contains(object value) => value is IRelatableItem item && _spans.Any(static (span, item) => span.Items?.Contains(item) == true, item);
 
         void ICollection.CopyTo(Array array, int index) => throw new NotSupportedException();
         object ICollection.SyncRoot => throw new NotSupportedException();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/LinqExtensions.cs
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio
         }
 
         /// <summary>
-        /// Specialisation of <see cref="System.Linq.Enumerable.Any{TSource}(IEnumerable{TSource})"/>
+        /// Specialisation of <see cref="Enumerable.Any{TSource}(IEnumerable{TSource})"/>
         /// that avoids allocation when the sequence is statically known to be an array.
         /// </summary>
         public static bool Any<T>(this T[] array, Func<T, bool> predicate)
@@ -64,6 +64,23 @@ namespace Microsoft.VisualStudio
             foreach (T item in array)
             {
                 if (predicate(item))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Specialisation of <see cref="Enumerable.Any{TSource}(IEnumerable{TSource})"/>
+        /// that avoids allocation when the sequence is statically known to be an array.
+        /// </summary>
+        public static bool Any<T, TArg>(this T[] array, Func<T, TArg, bool> predicate, TArg arg)
+        {
+            foreach (T item in array)
+            {
+                if (predicate(item, arg))
                 {
                     return true;
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return (_programFiles64 is not null && filePath.StartsWith(_programFiles64, StringComparisons.Paths))
                    || filePath.StartsWith(_programFiles86, StringComparisons.Paths)
                    || filePath.StartsWith(_windows, StringComparisons.Paths)
-                   || _nuGetPackageFolders.Any(nugetFolder => filePath.StartsWith(nugetFolder, StringComparisons.Paths))
+                   || _nuGetPackageFolders.Any(static (nuGetFolder, filePath) => filePath.StartsWith(nuGetFolder, StringComparisons.Paths), filePath)
                    || (_vsInstallationDirectory is not null && filePath.StartsWith(_vsInstallationDirectory, StringComparisons.Paths));
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal static async Task<bool> IsValueDefinedInContextMSBuildPropertiesAsync(IProjectProperties defaultProperties, string[] msBuildPropertyNames)
         {
             string[] propertiesDefinedInProjectFile = (await defaultProperties.GetDirectPropertyNamesAsync()).ToArray();
-            return !msBuildPropertyNames.Any(name => propertiesDefinedInProjectFile.Contains(name, StringComparers.PropertyNames));
+            return !msBuildPropertyNames.Any(static (name, properties) => properties.Contains(name, StringComparers.PropertyNames), propertiesDefinedInProjectFile);
         }
     }
 }


### PR DESCRIPTION
This adds an overload for the extension method so that calling code doesn't have to allocate a closure object on the heap. Instead, additional state for the predicate can be passed on the stack.

We also update existing callers to avoid such allocations. This applies primarily in the Solution Explorer and FUTDC (during solution open).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8692)