### PR TITLE
Remove unused option in the FUTDC

### DIFF
--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -208,8 +208,6 @@ There is one valid use case for `Always`, which is to restore a data file in the
 
 In VS 17.2, we changed the fast up-to-date check to be less strict about `Always` items. With this new behaviour, the check verifies the size and timestamps of the source and destination files. If they differ a build will be scheduled. This change can have a massively positive impact on inner loop productivity, when `Always` items exist.
 
-To opt-out of this optimization and preserve the pre-17.2 behaviour, set the `DisableFastUpToDateCopyAlwaysOptimization` MSBuild property to `true` in your project. Consider also opening an issue on this repo to explain why the optimization doesn't work for you, to give us a chance to improve it further.
-
 ## Reference assemblies and mixed SDK-style/non-SDK-style projects
 
 [Reference assemblies](https://docs.microsoft.com/dotnet/standard/assembly/reference-assemblies) can be used during .NET builds to avoid unnecessary compilation in the following case:
@@ -264,7 +262,6 @@ There are several reasons that a project may fail its up-to-date check and be sc
 | *CopyToOutputDirectoryDestinationNotFound* | A `CopyToOutputDirectory` input file is not present in the output directory. The build will copy it. |
 | *CopyToOutputDirectorySourceNotFound* | A `CopyToOutputDirectory` input file does not exist. A build is scheduled that may either produce this file and copy it, or emit an error about the missing file. |
 | *CopyToOutputDirectorySourceNewer* | A `CopyToOutputDirectory` input file has a newer time stamp than its destination. The build will update the output file. |
-| *CopyAlwaysItemExists* | Since 17.2 we only report this when `DisableFastUpToDateCopyAlwaysOptimization` is set on the project. [More info](#copytooutputdirectory-always-vs-preservenewest). |
 | *Disabled* | The project has `DisableFastUpToDateCheck` set. [More info](#disabling-the-up-to-date-check). |
 | *CriticalTasks* | Critical build tasks are running. This is very uncommon, and is not something the user has control over. |
 | *Exception* | An exception occurred in the implementation of the fast up-to-date check. We schedule a build at this point, as we don't know whether it is safe not to. |

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -81,9 +81,6 @@
   <BoolProperty Name="DisableFastUpToDateCheck"
                 Visible="False" />
 
-  <BoolProperty Name="DisableFastUpToDateCopyAlwaysOptimization"
-                Visible="False" />
-
   <StringProperty Name="DocumentationFile"
                   Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -163,23 +163,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return false;
             }
 
-            if (state.IsCopyAlwaysOptimizationDisabled)
-            {
-                // By default, we optimize CopyAlways to only copy if the time stamps or file sizes differ.
-                // If we got here, then the user has opted out of that optimisation, and we must fail if any CopyAlways items exist.
-
-                foreach ((string itemType, ImmutableArray<UpToDateCheckInputItem> items) in state.InputSourceItemsByItemType)
-                {
-                    foreach (UpToDateCheckInputItem item in items)
-                    {
-                        if (item.CopyType == CopyType.Always)
-                        {
-                            return log.Fail("CopyAlwaysItemExists", nameof(Resources.FUTD_CopyAlwaysItemExists_2), itemType, _configuredProject.UnconfiguredProject.MakeRooted(item.Path));
-                        }
-                    }
-                }
-            }
-
             return true;
         }
 
@@ -684,14 +667,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     if (item.CopyType == CopyType.Never)
                     {
                         // Ignore items which are never copied. Only process Always and PreserveNewest items.
-                        //
-                        // Note that if we see Always items, then state.IsTreatCopyAlwaysAsPreserveNewestDisabled must
-                        // be false, as when it is true and any Always item exists, the check returns before this point.
-
                         continue;
                     }
-
-                    System.Diagnostics.Debug.Assert(item.CopyType != CopyType.Always || !state.IsCopyAlwaysOptimizationDisabled);
 
                     string sourcePath = _configuredProject.UnconfiguredProject.MakeRooted(item.Path);
                     string filename = Strings.IsNullOrEmpty(item.TargetPath) ? sourcePath : item.TargetPath;
@@ -738,8 +715,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
                     else if (item.CopyType == CopyType.Always)
                     {
-                        log.Info(nameof(Resources.FUTD_OptimizingCopyAlwaysItem));
-
                         // We have already validated the presence of these files, so we don't expect these to return
                         // false. If one of them does, the corresponding size would be zero, so we would schedule a build.
                         // The odds of both source and destination disappearing between the gathering of the timestamps

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -28,7 +28,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 outputRelativeOrFullPath: null,
                 newestImportInput: null,
                 isDisabled: true,
-                isCopyAlwaysOptimizationDisabled: false,
                 inputSourceItemTypes: ImmutableArray<string>.Empty,
                 inputSourceItemsByItemType: ImmutableDictionary<string, ImmutableArray<UpToDateCheckInputItem>>.Empty,
                 upToDateCheckInputItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
@@ -81,22 +80,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// </para>
         /// </remarks>
         public bool IsDisabled { get; }
-
-        /// <summary>
-        /// Gets whether the fast up-to-date check should not optimize copy-always items.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// In VS17.2 we introduced an optimization for <c>CopyToOutputDirectory="Always"</c> items.
-        /// Previously, the presence of such an item in the project would cause the FUTD check to immediately
-        /// fail. With this optimization, we only fail if the timestamps or file sizes differ.
-        /// </para>
-        /// <para>
-        /// Customers can restore the old behaviour by setting the <c>DisableFastUpToDateCopyAlwaysOptimization</c>
-        /// project property to <c>true</c>.
-        /// </para>
-        /// </remarks>
-        public bool IsCopyAlwaysOptimizationDisabled { get; }
 
         /// <summary>
         /// Gets the time at which the set of items changed.
@@ -200,7 +183,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             string? outputRelativeOrFullPath,
             string? newestImportInput,
             bool isDisabled,
-            bool isCopyAlwaysOptimizationDisabled,
             ImmutableArray<string> inputSourceItemTypes,
             ImmutableDictionary<string, ImmutableArray<UpToDateCheckInputItem>> inputSourceItemsByItemType,
             ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>> upToDateCheckInputItemsByKindBySetName,
@@ -221,7 +203,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             OutputRelativeOrFullPath = outputRelativeOrFullPath;
             NewestImportInput = newestImportInput;
             IsDisabled = isDisabled;
-            IsCopyAlwaysOptimizationDisabled = isCopyAlwaysOptimizationDisabled;
             InputSourceItemTypes = inputSourceItemTypes;
             InputSourceItemsByItemType = inputSourceItemsByItemType;
             UpToDateCheckInputItemsByKindBySetName = upToDateCheckInputItemsByKindBySetName;
@@ -286,7 +267,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             string? msBuildProjectOutputPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, OutputRelativeOrFullPath);
             string? outputRelativeOrFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutDirProperty, msBuildProjectOutputPath);
             string msBuildAllProjects = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildAllProjectsProperty, "");
-            bool isCopyAlwaysOptimizationDisabled = jointRuleUpdate.CurrentState.IsPropertyTrue(ConfigurationGeneral.SchemaName, ConfigurationGeneral.DisableFastUpToDateCopyAlwaysOptimizationProperty, defaultValue: false);
 
             // The first item in this semicolon-separated list of project files will always be the one
             // with the newest timestamp. As we are only interested in timestamps on these files, we can
@@ -404,7 +384,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 outputRelativeOrFullPath,
                 newestImportInput,
                 isDisabled: isDisabled,
-                isCopyAlwaysOptimizationDisabled: isCopyAlwaysOptimizationDisabled,
                 inputSourceItemTypes: inputSourceItemTypes.ToImmutableArray(),
                 inputSourceItemsByItemType: inputSourceItemsByItemType,
                 upToDateCheckInputItemsByKindBySetName:  UpdateItemsByKindBySetName(UpToDateCheckInputItemsByKindBySetName,  jointRuleUpdate, UpToDateCheckInput.SchemaName,  UpToDateCheckInput.KindProperty,  UpToDateCheckInput.SetProperty),
@@ -600,7 +579,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 OutputRelativeOrFullPath,
                 NewestImportInput,
                 IsDisabled,
-                IsCopyAlwaysOptimizationDisabled,
                 InputSourceItemTypes,
                 InputSourceItemsByItemType,
                 UpToDateCheckInputItemsByKindBySetName,
@@ -625,7 +603,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 OutputRelativeOrFullPath,
                 NewestImportInput,
                 IsDisabled,
-                IsCopyAlwaysOptimizationDisabled,
                 InputSourceItemTypes,
                 InputSourceItemsByItemType,
                 UpToDateCheckInputItemsByKindBySetName,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -331,15 +331,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} item &apos;{1}&apos; has CopyToOutputDirectory set to &apos;Always&apos;, and the project has DisableFastUpToDateCopyAlwaysOptimization set to &apos;true&apos;, not up-to-date..
-        /// </summary>
-        internal static string FUTD_CopyAlwaysItemExists_2 {
-            get {
-                return ResourceManager.GetString("FUTD_CopyAlwaysItemExists_2", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0} item with CopyToOutputDirectory=&quot;Always&quot; source (&apos;{1}&apos; {2}, {3} bytes) differs from destination (&apos;{4}&apos; {5}, {6} bytes), not up-to-date..
         /// </summary>
         internal static string FUTD_CopyAlwaysItemsDiffer_7 {
@@ -516,15 +507,6 @@ namespace Microsoft.VisualStudio {
         internal static string FUTD_NoOutputMarkerExists_1 {
             get {
                 return ResourceManager.GetString("FUTD_NoOutputMarkerExists_1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Optimizing CopyToOutputDirectory=&quot;Always&quot; item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to &quot;true&quot;..
-        /// </summary>
-        internal static string FUTD_OptimizingCopyAlwaysItem {
-            get {
-                return ResourceManager.GetString("FUTD_OptimizingCopyAlwaysItem", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -213,10 +213,6 @@ This project was loaded using the wrong project type, likely as a result of rena
   <data name="FUTD_FirstRun" xml:space="preserve">
     <value>The up-to-date check has not yet run for this project. Not up-to-date.</value>
   </data>
-  <data name="FUTD_CopyAlwaysItemExists_2" xml:space="preserve">
-    <value>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</value>
-    <comment>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</comment>
-  </data>
   <data name="FUTD_ComparingInputOutputTimestamps_1" xml:space="preserve">
     <value>Comparing timestamps of inputs and outputs in Set="{0}":</value>
     <comment>Do not translate 'Set' as this name is used in code. {0} is the name of the set.</comment>
@@ -360,10 +356,6 @@ This project was loaded using the wrong project type, likely as a result of rena
   </data>
   <data name="FUTD_CheckingCopiedOutputFileSourceNewer" xml:space="preserve">
     <value>Source is newer than build output destination, not up-to-date.</value>
-  </data>
-  <data name="FUTD_OptimizingCopyAlwaysItem" xml:space="preserve">
-    <value>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</value>
-    <comment>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</comment>
   </data>
   <data name="FUTD_CheckingCopyToOutputDirectoryItem_3" xml:space="preserve">
     <value>Checking {0} item with CopyToOutputDirectory="{1}" '{2}':</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Kontrola aktuálnosti dokončena za {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">Položka {0} z {1} má CopyToOutputDirectory nastaveno na hodnotu Always a projekt má DisableFastUpToDateCopyAlwaysOptimization nastaveno na hodnotu true, není aktuální.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">Položka {0} se zdrojem CopyToOutputDirectory=Always ({1} {2}, počet bajtů: {3}) se liší od cíle ({4} {5}, počet bajtů: {6}), není aktuální.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">Vstupní položka {1} {0} neexistuje, i když je povinná.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Optimalizuje se položka CopyToOutputDirectory=Always. Tuto možnost zakažte nastavením možnosti DisableFastUpToDateCopyAlwaysOptimization na hodnotu true.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Die aktuelle Überprüfung wurde in {0:N1} ms abgeschlossen.</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">Für {0}-Element „{1}“ ist „CopyToOutputDirectory“ auf „Always“ festgelegt, und für das Projekt ist „DisableFastUpToDateCopyAlwaysOptimization“ auf „true“ festgelegt, nicht aktuell.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">{0}-Element mit der Quelle CopyToOutputDirectory=„Always“ („{1}“ {2}, {3} Byte) unterscheidet sich vom Ziel („{4}“ {5}, {6} Byte), nicht aktuell.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">Die Eingabe {1}-Element "{0}" ist nicht vorhanden, aber nicht erforderlich.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Das Element CopyToOutputDirectory=„Always“ wird optimiert. Deaktivieren Sie dies, indem Sie „DisableFastUpToDateCopyAlwaysOptimization“ auf „true“ festlegen.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Comprobación actualizada completada en {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} elemento “{1}” tiene CopyToOutputDirectory establecido en “Always” y el proyecto tiene DisableFastUpToDateCopyAlwaysOptimization establecido en “true”, no actualizado.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">{0} elemento con el origen CopyToOutputDirectory="Always" ('{1}' {2}, {3} bytes) difiere del destino ('{4}' {5}, {6} bytes), no actualizado.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">El elemento {1} de entrada "{0}" no existe, pero no es necesario.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Optimizando el elemento CopyToOutputDirectory="Always". Para deshabilitarlo, establezca DisableFastUpToDateCopyAlwaysOptimization en "true".</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Vérification à jour effectuée en {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} 'élément '{1}' a CopyToOutputDirectory défini sur 'Always', et le projet a DisableFastUpToDateCopyAlwaysOptimization défini sur 'true', et non à jour.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">{0} élément avec CopyToOutputDirectory="Always" source ('{1}' {2}, {3} octets) diffère de la destination ('{4}' {5}, {6} octets), pas à jour.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">L''{0}' d’élément de {1} d’entrée n’existe pas, mais n’est pas obligatoire.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Optimisation de l’élément CopyToOutputDirectory=="Always". Désactivez cette option en définissant DisableFastUpToDateCopyAlwaysOptimization sur « true ».</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Controllo aggiornato completato in {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">Elemento {0} '{1}' ha CopyToOutputDirectory impostato su 'Always' e il progetto ha DisableFastUpToDateCopyAlwaysOptimization impostato su 'true', non aggiornato.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">Elemento {0} con origine CopyToOutputDirectory="Always" ('{1}' {2}, {3} byte) differisce dalla destinazione ('{4}' {5}, {6} byte), non aggiornato.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">L'input {1} 'elemento '{0}' non esiste, ma non è obbligatorio.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Ottimizzazione dell'elemento CopyToOutputDirectory="Always". Disabilitare questa impostazione impostando DisableFastUpToDateCopyAlwaysOptimization su "true".</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -122,11 +122,6 @@
         <target state="translated">{0:N1} ミリ秒で最新チェックが完了しました</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} 項目 '{1}' は CopyToOutputDirectory が 'Always' に設定され、プロジェクトの DisableFastUpToDateCopyAlwaysOptimization が 'true' に設定され、それは最新の状態ではありません。</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">CopyToOutputDirectory="Always" ソース ('{1}' {2}, {3} バイト) を持つ{0}項目は、宛先 ('{4}' {5}, {6} バイト) と異なり、最新ではありません。</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">入力 {1} の項目 '{0}' は存在しませんが、必須ではありません。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">CopyToOutputDirectory="Always" である項目を最適化しています。DisableFastUpToDateCopyAlwaysOptimization を "true" に設定します。</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -122,11 +122,6 @@
         <target state="translated">{0:N1}ms 후에 최신 확인 완료</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} 항목 '{1}'에는 CopyToOutputDirectory가 'Always'로 설정되어 있고 프로젝트에는 DisableFastUpToDateCopyAlwaysOptimization이 최신 상태가 아닌 'true'로 설정되어 있습니다.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">CopyToOutputDirectory="Always" 소스('{1}' {2}, {3}바이트)가 있는 {0} 항목이 대상('{4}' {5}, {6}바이트)과 다릅니다. 최신 상태가 아닙니다.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">입력 {1} 항목 '{0}'이(가) 존재하지 않지만 필수는 아닙니다.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">CopyToOutputDirectory="항상" 항목 최적화. DisableFastUpToDateCopyAlwaysOptimization을 "true"로 설정하여 이 기능을 비활성화합니다.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Sprawdzanie aktualności zostało ukończone w {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} element „{1}” ma właściwość CopyToOutputDirectory ustawioną na wartość „Always”, a projekt ma wartość DisableFastUpToDateCopyAlwaysOptimization ustawioną na wartość „true”, a nie aktualną.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">{0} element z poleceniem CopyToOutputDirectory=„ Zawsze” źródło ('{1}' {2} {3} B) różni się od lokalizacji docelowej („{4}” {5} {6} bajty), nieaktualne.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">Wejściowy {1} element „{0}” nie istnieje, ale nie jest wymagany.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Optymalizowanie elementu CopyToOutputDirectory= element „Zawsze”. Wyłącz tę opcję, ustawiając wartość DisableFastUpToDateCopyAlwaysOptimization na wartość „true”.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Verificação de atualização concluída em {0:N1} ms</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} item '{1}' tem o CopyToOutputDirectory definido como 'Always', e o projeto tem DisableFastUpToDateCopyAlwaysOptimization definido como 'true', não atualizado.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">{0} item com a origem CopyToOutputDirectory="Always" ('{1}' {2}, {3} bytes) difere do destino ('{4}' {5}, {6} bytes), não atualizado.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">O item '{0}' de entrada {1} não existe, mas não é necessário.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Otimizando o item CopyToOutputDirectory="Always". Desabilite isso definindo DisableFastUpToDateCopyAlwaysOptimization como “true”.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Проверка актуальности завершена за {0:N1} мс</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">Параметр CopyToOutputDirectory для элемента {0} '{1}' имеет значение \"Always\", а параметр DisableFastUpToDateCopyAlwaysOptimization для проекта имеет значение \"true\", обновление не выполнено.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">Элемент {0} с источником CopyToOutputDirectory="Always" ('{1}' {2}, {3} байт) отличается от места назначения ('{4}' {5}, {6} байт), обновление не выполнено.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">Элемент "{0}" входных данных {1} не существует и не является обязательным.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">Оптимизация элемента CopyToOutputDirectory="Always". Отключите этот параметр, установив значение "true" для параметра DisableFastUpToDateCopyAlwaysOptimization.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -122,11 +122,6 @@
         <target state="translated">Güncel denetim {0:N1} ms içinde tamamlandı</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} '{1}' öğesinde copyToOutputDirectory seçeneği 'Always' olarak ayarlandı ve projede DisableFastUpToDateCopyAlwaysOptimization seçeneği 'true' olarak ayarlandı, güncel değil.</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">CopyToOutputDirectory="Always" kaynağına ('{1}' {2}, {3} bayt) sahip {0} öğesi hedeften ('{4}' {5}, {6} bayt) farklı, güncel değil.</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">{1} girişinin '{0}' öğesi yok ancak gerekli değil.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">CopyToOutputDirectory="Always" öğesi iyileştiriliyor. DisableFastUpToDateCopyAlwaysOptimization seçeneğini "true" olarak ayarlayarak bunu devre dışı bırakın.</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -122,11 +122,6 @@
         <target state="translated">最新检查已在 {0:N1} 毫秒内完成</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} 项'{1}'将 CopyToOutputDirectory 设置为“Always”，并且项目已将 DisableFastUpToDateCopyAlwaysOptimization 设置为“true”，不是最新版本。</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">具有 CopyToOutputDirectory="Always" 源的 {0} 项('{1}' {2}，{3} 字节)不同于目标('{4}' {5}，{6} 字节)，不是最新版本。</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">输入{1}项'{0}'不存在，但不需要。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">正在优化 CopyToOutputDirectory="Always"项。通过将 DisableFastUpToDateCopyAlwaysOptimization 设置为"true"来禁用此功能。</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -122,11 +122,6 @@
         <target state="translated">已在 {0:N1} 毫秒内完成最新的檢查</target>
         <note>{0} is a duration in milliseconds. "ms" refers to "milliseconds". Leave the "{0:N1}" string as-is, for correct formatting of the number.</note>
       </trans-unit>
-      <trans-unit id="FUTD_CopyAlwaysItemExists_2">
-        <source>{0} item '{1}' has CopyToOutputDirectory set to 'Always', and the project has DisableFastUpToDateCopyAlwaysOptimization set to 'true', not up-to-date.</source>
-        <target state="translated">{0} 項目 '{1}' CopyToOutputDirectory 已設定為 'Always'，且專案已將 DisableFastUpToDateCopyAlwaysOptimization 設定為 'true'，而非最新。</target>
-        <note>Do not translate 'CopyToOutputDirectory' or 'Always' or 'DisableFastUpToDateCopyAlwaysOptimization' or 'true'. {0} is an MSBuild item type. {1} is a file path.</note>
-      </trans-unit>
       <trans-unit id="FUTD_CopyAlwaysItemsDiffer_7">
         <source>{0} item with CopyToOutputDirectory="Always" source ('{1}' {2}, {3} bytes) differs from destination ('{4}' {5}, {6} bytes), not up-to-date.</source>
         <target state="translated">{0} 項目與 CopyToOutputDirectory="Always" 來源 ('{1}' {2}, {3} bytes) 不同於目的地 ('{4}' {5}, {6} bytes)，不是最新的。</target>
@@ -226,11 +221,6 @@
         <source>Input {1} item '{0}' does not exist, but is not required.</source>
         <target state="translated">輸入 {1} 項目 '{0}' 不存在，但並非必要項目。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
-      </trans-unit>
-      <trans-unit id="FUTD_OptimizingCopyAlwaysItem">
-        <source>Optimizing CopyToOutputDirectory="Always" item. Disable this by setting DisableFastUpToDateCopyAlwaysOptimization to "true".</source>
-        <target state="translated">正在最佳化 CopyToOutputDirectory="Always" 項目。將 DisableFastUpToDateCopyAlwaysOptimization 設定為 "true" 以停用此設定。</target>
-        <note>Do not translate "CopyToOutputDirectory", "Always", "DisableFastUpToDateCopyAlwaysOptimization" or "true".</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>


### PR DESCRIPTION
In 17.2 we added an optimisation for the handling of "CopyAlways" items, so that they would no longer automatically trigger the project to be built regardless of whether the file in question had changed.

Out of caution, we added support for an option to disable this behaviour.

We have had no negative feedback about this feature. Telemetry shows zero usage of this option over the last seven days. This commit removes the option, making the new behaviour non-optional, and simplifying the code a little.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8694)