### PR TITLE
Fix some build warnings

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -261,6 +261,9 @@ stages:
     - ${{ if eq(parameters.SkipCompliance, false) }}:
       - Compliance
     variables:
+      # Only used for tracking purposes in MicroBuild tasks.
+      # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
+      TeamName: DotNet-Project-System
       # Gets the PackageVersion variable produced by the Build pipeline.
       PackageVersion: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetPackageVersion.PackageVersion'] ]
       # Gets the AssemblyVersion variable produced by the Build pipeline.

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -261,9 +261,6 @@ stages:
     - ${{ if eq(parameters.SkipCompliance, false) }}:
       - Compliance
     variables:
-      # Only used for tracking purposes in MicroBuild tasks.
-      # See: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/650/MicroBuild-Signing?anchor=high-level-steps-to-enable-signing
-      TeamName: DotNet-Project-System
       # Gets the PackageVersion variable produced by the Build pipeline.
       PackageVersion: $[ stageDependencies.Build.BuildOfficialRelease.outputs['SetPackageVersion.PackageVersion'] ]
       # Gets the AssemblyVersion variable produced by the Build pipeline.

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -45,6 +45,7 @@ jobs:
 
   # Sets the Products drop for permanent retention. This is the drop that contains the VS insertion data (.vsman files).
   # Overview: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/635/Overview
+  # YAML reference: https://dev.azure.com/devdiv/Engineering/_git/MicroBuild?path=/src/Tasks/RetainDrops/task.json
   - task: MicroBuildRetainVstsDrops@1
     displayName: Retain Products Drop
     inputs:

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -97,17 +97,6 @@ jobs:
       # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/634/Link-Work-Items-to-PR
       LinkWorkItemsToPR: false
 
-  - powershell: |
-      Set-Location '$(Pipeline.Workspace)/project-system/VS'
-      Write-Host '$(Pipeline.Workspace)/project-system/VS contents:'
-      Get-ChildItem
-    displayName: Check Directory Files
-
-  - task: MicroBuildCleanup@1
-    displayName: MicroBuild Cleanup
-
-  - powershell: |
-      Set-Location '$(Pipeline.Workspace)/project-system/VS'
-      Write-Host '$(Pipeline.Workspace)/project-system/VS contents:'
-      Get-ChildItem
-    displayName: Check Directory Files
+  # The MicroBuildInsertVsPayload clones the VS repo. This removes the cloned repo after use.
+  - powershell: Remove-Item -Path '$(Pipeline.Workspace)/project-system/VS' -Recurse -Force -ErrorAction Ignore
+    displayName: Clean VS Directory

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -32,8 +32,13 @@ jobs:
       git init
       git remote add origin https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS
       git fetch --depth $(PriorInsertionCommitDepth) origin $(InsertionVSBranch)
-      Get-ChildItem
     displayName: Fetch VS Repo
+
+  - powershell: |
+      Set-Location '$(Pipeline.Workspace)/VS'
+      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Get-ChildItem
+    displayName: Check Directory Files
 
   ###################################################################################################################################################################
   # GENERATE VS INSERTION
@@ -56,10 +61,22 @@ jobs:
       # When this isn't provided, the tool sets the --AadAuth flag instead of using --PatAuthEnvVar. The AadAuth doesn't seem to work for this situation.
       AccessToken: $(System.AccessToken)
 
+  - powershell: |
+      Set-Location '$(Pipeline.Workspace)/VS'
+      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Get-ChildItem
+    displayName: Check Directory Files
+
   # Creates the description for the VS Insertion PR and sets it to the InsertionDescription variable. Also sets the ShortCommitId variable based on currentSha.
   - powershell: . '$(Build.SourcesDirectory)/eng/scripts/GetInsertionPRDescription.ps1' -vsDirectory '$(Pipeline.Workspace)/VS/' -currentSha '$(Build.SourceVersion)' -repoUrl '$(Build.Repository.Uri)' -projectName '$(Build.DefinitionName)'
     displayName: Create VS Insertion Description
     failOnStderr: true
+
+  - powershell: |
+      Set-Location '$(Pipeline.Workspace)/VS'
+      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Get-ChildItem
+    displayName: Check Directory Files
 
   # Creates a VS insertion PR using the Products drop containing the .vsman files.
   # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/635/Overview?anchor=**build-pipeline**
@@ -97,3 +114,18 @@ jobs:
       # ##[warning]WARNING: Cannot copy work items from vstfs:///Build/Build/6574299: ArgumentException : 'https://github.com/dotnet/project-system' does not look like an Azure DevOps url
       # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/634/Link-Work-Items-to-PR
       LinkWorkItemsToPR: false
+
+  - powershell: |
+      Set-Location '$(Pipeline.Workspace)/VS'
+      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Get-ChildItem
+    displayName: Check Directory Files
+
+  - task: MicroBuildCleanup@1
+    displayName: MicroBuild Cleanup
+
+  - powershell: |
+      Set-Location '$(Pipeline.Workspace)/VS'
+      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Get-ChildItem
+    displayName: Check Directory Files

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -32,6 +32,7 @@ jobs:
       git init
       git remote add origin https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS
       git fetch --depth $(PriorInsertionCommitDepth) origin $(InsertionVSBranch)
+      Get-ChildItem
     displayName: Fetch VS Repo
 
   ###################################################################################################################################################################

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -43,19 +43,6 @@ jobs:
     displayName: === Generate VS Insertion ===
     condition: false
 
-  # Sets the Products drop for permanent retention. This is the drop that contains the VS insertion data (.vsman files).
-  # Overview: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/635/Overview
-  # YAML reference: https://dev.azure.com/devdiv/Engineering/_git/MicroBuild?path=/src/Tasks/RetainDrops/task.json
-  - task: MicroBuildRetainVstsDrops@1
-    displayName: Retain Products Drop
-    inputs:
-      # If the drop name is changed in the Publish job, this name also needs changed.
-      # TODO: Consider making this a pipeline variable.
-      DropNames: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
-      DropServiceUri: https://devdiv.artifacts.visualstudio.com/DefaultCollection
-      # When this isn't provided, the tool sets the --AadAuth flag instead of using --PatAuthEnvVar. The AadAuth doesn't seem to work for this situation.
-      AccessToken: $(System.AccessToken)
-
   # Creates the description for the VS Insertion PR and sets it to the InsertionDescription variable. Also sets the ShortCommitId variable based on currentSha.
   - powershell: . '$(Build.SourcesDirectory)/eng/scripts/GetInsertionPRDescription.ps1' -vsDirectory '$(Pipeline.Workspace)/VS/' -currentSha '$(Build.SourceVersion)' -repoUrl '$(Build.Repository.Uri)' -projectName '$(Build.DefinitionName)'
     displayName: Create VS Insertion Description

--- a/eng/pipelines/templates/generate-insertion.yml
+++ b/eng/pipelines/templates/generate-insertion.yml
@@ -34,12 +34,6 @@ jobs:
       git fetch --depth $(PriorInsertionCommitDepth) origin $(InsertionVSBranch)
     displayName: Fetch VS Repo
 
-  - powershell: |
-      Set-Location '$(Pipeline.Workspace)/VS'
-      Write-Host '$(Pipeline.Workspace)/VS contents:'
-      Get-ChildItem
-    displayName: Check Directory Files
-
   ###################################################################################################################################################################
   # GENERATE VS INSERTION
   ###################################################################################################################################################################
@@ -61,22 +55,10 @@ jobs:
       # When this isn't provided, the tool sets the --AadAuth flag instead of using --PatAuthEnvVar. The AadAuth doesn't seem to work for this situation.
       AccessToken: $(System.AccessToken)
 
-  - powershell: |
-      Set-Location '$(Pipeline.Workspace)/VS'
-      Write-Host '$(Pipeline.Workspace)/VS contents:'
-      Get-ChildItem
-    displayName: Check Directory Files
-
   # Creates the description for the VS Insertion PR and sets it to the InsertionDescription variable. Also sets the ShortCommitId variable based on currentSha.
   - powershell: . '$(Build.SourcesDirectory)/eng/scripts/GetInsertionPRDescription.ps1' -vsDirectory '$(Pipeline.Workspace)/VS/' -currentSha '$(Build.SourceVersion)' -repoUrl '$(Build.Repository.Uri)' -projectName '$(Build.DefinitionName)'
     displayName: Create VS Insertion Description
     failOnStderr: true
-
-  - powershell: |
-      Set-Location '$(Pipeline.Workspace)/VS'
-      Write-Host '$(Pipeline.Workspace)/VS contents:'
-      Get-ChildItem
-    displayName: Check Directory Files
 
   # Creates a VS insertion PR using the Products drop containing the .vsman files.
   # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/635/Overview?anchor=**build-pipeline**
@@ -116,8 +98,8 @@ jobs:
       LinkWorkItemsToPR: false
 
   - powershell: |
-      Set-Location '$(Pipeline.Workspace)/VS'
-      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Set-Location '$(Pipeline.Workspace)/project-system/VS'
+      Write-Host '$(Pipeline.Workspace)/project-system/VS contents:'
       Get-ChildItem
     displayName: Check Directory Files
 
@@ -125,7 +107,7 @@ jobs:
     displayName: MicroBuild Cleanup
 
   - powershell: |
-      Set-Location '$(Pipeline.Workspace)/VS'
-      Write-Host '$(Pipeline.Workspace)/VS contents:'
+      Set-Location '$(Pipeline.Workspace)/project-system/VS'
+      Write-Host '$(Pipeline.Workspace)/project-system/VS contents:'
       Get-ChildItem
     displayName: Check Directory Files

--- a/eng/pipelines/templates/publish-assets-and-packages.yml
+++ b/eng/pipelines/templates/publish-assets-and-packages.yml
@@ -55,6 +55,7 @@ jobs:
       # Issue: https://github.com/dotnet/project-system/issues/8431
       # Example of current path: 'Products/[DevDiv]/[dotnet/project-system]/[main]/[x.x]'
       DropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
+      DropRetentionDays: 30
       # When this isn't provided, the tool sets the --AadAuth flag instead of using --PatAuthEnvVar. The AadAuth doesn't seem to work for this situation.
       AccessToken: $(System.AccessToken)
 

--- a/eng/pipelines/templates/publish-assets-and-packages.yml
+++ b/eng/pipelines/templates/publish-assets-and-packages.yml
@@ -44,6 +44,7 @@ jobs:
 
   # This creates the Products drop location and uploads the insertion data (.vsman files) for VS insertion.
   # This also includes the bootstrapper files (.exe and .vsman) necessary for OptProf.
+  # YAML reference: https://dev.azure.com/devdiv/Engineering/_git/MicroBuild?path=/src/Tasks/UploadDrop/task.json
   - task: MicroBuildUploadVstsDropFolder@2
     displayName: Publish Insertion Data
     inputs:

--- a/eng/pipelines/templates/publish-assets-and-packages.yml
+++ b/eng/pipelines/templates/publish-assets-and-packages.yml
@@ -55,7 +55,7 @@ jobs:
       # Issue: https://github.com/dotnet/project-system/issues/8431
       # Example of current path: 'Products/[DevDiv]/[dotnet/project-system]/[main]/[x.x]'
       DropName: Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
-      DropRetentionDays: 30
+      DropRetentionDays: 60
       # When this isn't provided, the tool sets the --AadAuth flag instead of using --PatAuthEnvVar. The AadAuth doesn't seem to work for this situation.
       AccessToken: $(System.AccessToken)
 


### PR DESCRIPTION
## Description

We have a few warnings to deal with in our official build.

- After doing an insertion (via `MicroBuildInsertVsPayload`), we need to clear the VS repo files from the build machine prior to the job finishing.
- I've confirmed with VS engineering that we do not need to indefinitely retain our drops we provide via insertion. They modify the retention policy on drops depending on the build the component is inserted into. I've set this duration to ~~30~~ 60 days, which is the recommended duration (from VSEng).

## Test Build
- https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7066598
  - Insertion: https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/440450?_a=overview

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8714)