### PR TITLE
Ensure dataflow faults don't hang the language service during initialisation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/Workspace.cs
@@ -582,6 +582,17 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     }
 
     /// <summary>
+    /// Called when the dataflow that provides project data to <see cref="OnWorkspaceUpdateAsync(IProjectVersionedValue{WorkspaceUpdate})"/>
+    /// faults for some reason. This allows the workspace to know that no further updates are coming.
+    /// </summary>
+    /// <param name="exception"></param>
+    internal void Fault(Exception exception)
+    {
+        // Ensure we unblock any code waiting for initialization, and surface the error to the caller.
+        _contextCreated.TrySetException(exception);
+    }
+
+    /// <summary>
     /// Maps from our property data snapshot to Roslyn's API for accessing the project's
     /// evaluation data.
     /// </summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/WorkspaceFactory.cs
@@ -90,6 +90,14 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 severity: ProjectFaultSeverity.LimitedFunctionality,
                 nameFormat: "Workspace update handler {0}");
 
+        // Notify the workspace if the dataflow faults, to avoid hanging during initialization
+        // while waiting for data that won't ever arrive due to the fault.
+        _ = actionBlock.Completion.ContinueWith(
+            task => workspace.Fault(task.Exception),
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+
         #region Ordering evaluation before first build
 
         IPropagatorBlock<IProjectVersionedValue<WorkspaceUpdate>, IProjectVersionedValue<WorkspaceUpdate>> orderingBlock

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/LanguageServices/WorkspaceTests.cs
@@ -10,6 +10,7 @@ using Task = System.Threading.Tasks.Task;
 using Moq.Language.Flow;
 
 #pragma warning disable CA1068 // CancellationToken parameters must come last
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 #pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
@@ -652,6 +653,46 @@ public class WorkspaceTests
 
         // CreateProjectContextAsync throws
         await EvaluationUpdateThrowsAndDisposesAsync(createProjectContext => createProjectContext.Throws(ex), ex);
+    }
+
+    [Fact]
+    public async Task Fault_BeforeInitialisation()
+    {
+        var workspace = await CreateInstanceAsync(applyEvaluation: false);
+
+        Task task = workspace.WriteAsync(_ => throw new Exception(), CancellationToken.None);
+
+        Assert.Equal(TaskStatus.WaitingForActivation, task.Status);
+
+        var exception = new Exception();
+
+        workspace.Fault(exception);
+
+        var actualException = await Assert.ThrowsAsync<Exception>(() => task);
+
+        Assert.Same(exception, actualException);
+    }
+
+    [Fact]
+    public async Task Fault_AfterInitialisation()
+    {
+        // Initialised after this call (as we apply evaluation data)
+        var workspace = await CreateInstanceAsync(applyEvaluation: true);
+
+        int count = 0;
+
+        await workspace.WriteAsync(async _ => count++, CancellationToken.None);
+
+        Assert.Equal(1, count);
+
+        // Faulting once initialised won't stop callers from using the workspace.
+        // It only means we won't keep the workspace up to date over time as the project
+        // changes.
+        workspace.Fault(new Exception());
+
+        await workspace.WriteAsync(async _ => count++, CancellationToken.None);
+
+        Assert.Equal(2, count);
     }
 
     /// <summary>


### PR DESCRIPTION
[AB#1644056](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1644056)

In 17.4 we saw an exception in the dataflow chain that would result in a hang. The cause of that exception has been addressed, however it highlighted a potential hang in the workspace if such an exception occurred during workspace initialisation.

This change hooks dataflow faults and passes those exceptions on to any code waiting for initialisation to complete, preventing a hang and allowing those callers to observe the fault.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8715)