### PR TITLE
FUTDC learns some new metadata on ProjectReference items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -669,14 +669,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 static bool IncludeProjectReference(IImmutableDictionary<string, string> metadata)
                 {
-                    // Exclude any project references for which we do not reference the output assembly.
+                    // TODO this filtering is overzealous. In each of these cases, there are subtleties to how
+                    // builds handle the output assembly vs. CopyToOutputDirectory items both of the directly
+                    // referenced project, and of transitively referenced projects. To improve this we need
+                    // more information on the edges of our project reference graph.
+
+                    // Exclude any project reference for which we do not reference the output assembly.
                     if (metadata.GetBoolProperty(ResolvedProjectReference.ReferenceOutputAssemblyProperty) == false)
                     {
                         return false;
                     }
 
-                    // Exclude any project references having Private="false" (aka CopyLocal="No").
+                    // Exclude any project reference having Private="false" (aka CopyLocal="No").
                     if (metadata.GetBoolProperty(ResolvedProjectReference.PrivateProperty) == false)
+                    {
+                        return false;
+                    }
+
+                    // Exclude any project reference having EmbedInteropTypes="true".
+                    if (metadata.GetBoolProperty(ResolvedProjectReference.EmbedInteropTypesProperty) == true)
                     {
                         return false;
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -659,15 +659,30 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             .Select(pair => new CopyItem(path: pair.Key, metadata: pair.Value))
                             .ToImmutableArray();
 
-                        // Exclude any project references for which we do not reference the output assembly.
-                        // This avoids following references to certain "private" project references, such as PrivateP2PCaching.proj in NBGV.
-                        ImmutableArray<string> referenceItems = change2.After.Items.Where(pair => pair.Value.GetBoolProperty(ResolvedProjectReference.ReferenceOutputAssemblyProperty) == true).Select(item => item.Key).ToImmutableArray();
+                        ImmutableArray<string> referenceItems = change2.After.Items.Where(pair => IncludeProjectReference(pair.Value)).Select(item => item.Key).ToImmutableArray();
 
                         return new ProjectCopyData(msBuildProjectFullPath, targetPath, copyItems, referenceItems);
                     }
                 }
 
                 return ProjectCopyData;
+
+                static bool IncludeProjectReference(IImmutableDictionary<string, string> metadata)
+                {
+                    // Exclude any project references for which we do not reference the output assembly.
+                    if (metadata.GetBoolProperty(ResolvedProjectReference.ReferenceOutputAssemblyProperty) == false)
+                    {
+                        return false;
+                    }
+
+                    // Exclude any project references having Private="false" (aka CopyLocal="No").
+                    if (metadata.GetBoolProperty(ResolvedProjectReference.PrivateProperty) == false)
+                    {
+                        return false;
+                    }
+
+                    return true;
+                }
             }
 
             ProjectFileClassifier BuildClassifier()


### PR DESCRIPTION
Fixes #8719
Fixes #8716

`ProjectReference` items can be modified with metadata that modifies how items the project produces are copied to the referencing project's output directory.

This PR improves handling of such metadata, to avoid two problems:

1. Incorrectly expecting certain items in the output directory and scheduling builds (overbuild)
2. Copying too many files to the output directory when using Build Acceleration

Three kinds of metadata are covered here:

1. `Private="False"`
2. `EmbedInteropTypes="True"`
3. `ReferenceOutputAssembly="False"`

Here we filter such projects from the graph.

In reality, the situation is more subtle, as mentioned in the code comment. We will make some additional changes here to improve fidelity in the near future.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8720)