### PR TITLE
Fix exception in FUTDC dataflow when DisableFastUpToDateCheck is true

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
@@ -14,6 +14,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
     public void SetProjectData(ProjectCopyData projectCopyData)
     {
         System.Diagnostics.Debug.Assert(Path.IsPathRooted(projectCopyData.TargetPath));
+        Requires.Argument(!projectCopyData.IsDefault, nameof(projectCopyData), "Must not be default.");
 
         lock (_projectData)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Diagnostics;
 using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate;
@@ -13,22 +12,10 @@ internal class CopyItemAggregator : ICopyItemAggregator
 
     public void SetProjectData(ProjectCopyData projectCopyData)
     {
-        System.Diagnostics.Debug.Assert(Path.IsPathRooted(projectCopyData.TargetPath));
         Requires.Argument(!projectCopyData.IsDefault, nameof(projectCopyData), "Must not be default.");
 
         lock (_projectData)
         {
-            // TODO remove this debug output, or log elsewhere
-            Trace.WriteLine($"*********************** CopyItem data for {projectCopyData.TargetPath}:");
-            foreach (CopyItem copyItem in projectCopyData.CopyItems)
-            {
-                Trace.WriteLine($"  {copyItem.AbsoluteSourcePath} -> {copyItem.RelativeTargetPath} ({copyItem.CopyType})");
-            }
-            foreach (string referencePath in projectCopyData.ReferencedProjectTargetPaths)
-            {
-                Trace.WriteLine($"  References: {referencePath}");
-            }
-
             _projectData[projectCopyData.TargetPath] = projectCopyData;
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
@@ -48,4 +48,7 @@ internal record struct ProjectCopyData(
     string? ProjectFullPath,
     string TargetPath,
     ImmutableArray<CopyItem> CopyItems,
-    ImmutableArray<string> ReferencedProjectTargetPaths);
+    ImmutableArray<string> ReferencedProjectTargetPaths)
+{
+    public bool IsDefault => CopyItems.IsDefault;
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInputDataSource.cs
@@ -122,7 +122,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (priorCopyData != state.ProjectCopyData)
                 {
-                    _copyItemAggregator.SetProjectData(state.ProjectCopyData);
+                    // If the FUTDC is disabled, we won't have valid copy items in the snapshot.
+                    if (!state.IsDisabled)
+                    {
+                        _copyItemAggregator.SetProjectData(state.ProjectCopyData);
+                    }
                 }
 
                 if (state.ItemHash is not null && _persistentState is not null && (priorItemHash != state.ItemHash || priorLastItemsChangedAtUtc != state.LastItemsChangedAtUtc))


### PR DESCRIPTION
Fixes #8721

When the FUTDC is disabled, we don't produce snapshot data for the project therefore we don't have copy items to give to the copy item aggregator.

The previous code had some diagnostic code that would enumerate the copy items. When disabled, this would have the value of `default(ImmutableArray<CopyItem>)` which is not valid for enumeration, leading to a `NullReferenceException`.

This commit removes the diagnostic code, which was intended for removal prior to release. However that diagnostic code actually helped locate the error in this case, as otherwise the enumeration would have occurred quite a bit later, making it harder to identify the root cause.

To ensure this error doesn't occur again, we add some more focussed validation of the argument.

The actual fix is to not call this method when the FUTDC is disabled.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8724)