### PR TITLE
Removing the FormatException thrown for the empty case in the NameValueListPairEncoding

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/NameQuotedValuePairListEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/NameQuotedValuePairListEncoding.cs
@@ -11,12 +11,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         public IEnumerable<(string Name, string Value)> Parse(string value)
         {
-            Requires.NotNullOrWhiteSpace(value, nameof(value));
-
             foreach (var entry in ReadEntries(value))
             {
                 var (entryKey, entryValue) = SplitEntry(entry);
-                yield return (DecodeCharacters(entryKey), StripQuotes(DecodeCharacters(entryValue)));
+                if (!string.IsNullOrEmpty(entryKey))
+                {
+                    yield return (DecodeCharacters(entryKey), StripQuotes(DecodeCharacters(entryValue)));
+                }
             }
 
             static IEnumerable<string> ReadEntries(string rawText)
@@ -46,6 +47,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             static (string EncodedKey, string EncodedValue) SplitEntry(string entry)
             {
+                if (string.IsNullOrEmpty(entry))
+                {
+                    return (string.Empty, string.Empty);
+                }
                 bool escaped = false;
                 for (int i = 0; i < entry.Length; i++)
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/NameQuotedValuePairListEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/NameQuotedValuePairListEncoding.cs
@@ -11,13 +11,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         public IEnumerable<(string Name, string Value)> Parse(string value)
         {
+            Requires.NotNull(value, nameof(value));
+            if (string.IsNullOrEmpty(value))
+            {
+                yield break;
+            }
             foreach (var entry in ReadEntries(value))
             {
                 var (entryKey, entryValue) = SplitEntry(entry);
-                if (!string.IsNullOrEmpty(entryKey))
-                {
-                    yield return (DecodeCharacters(entryKey), StripQuotes(DecodeCharacters(entryValue)));
-                }
+                yield return (DecodeCharacters(entryKey), StripQuotes(DecodeCharacters(entryValue)));
             }
 
             static IEnumerable<string> ReadEntries(string rawText)
@@ -47,10 +49,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             static (string EncodedKey, string EncodedValue) SplitEntry(string entry)
             {
-                if (string.IsNullOrEmpty(entry))
-                {
-                    return (string.Empty, string.Empty);
-                }
                 bool escaped = false;
                 for (int i = 0; i < entry.Length; i++)
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/BuildPropertyPage/NameQuotedValuePairListEncodingTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/BuildPropertyPage/NameQuotedValuePairListEncodingTests.cs
@@ -36,6 +36,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
         [InlineData("\"\"ab\"\"cd=     value1     ", "/\"/\"ab/\"/\"cd=\"     value1     \"")]
         [InlineData("\"\"ab\"\"cd=value1     ", "/\"/\"ab/\"/\"cd=\"value1     \"")]
         [InlineData("\"\"ab\"\"cd=     value1", "/\"/\"ab/\"/\"cd=\"     value1\"")]
+        [InlineData("", "")]
+        [InlineData(",", "")]
+        [InlineData(",,,", "")]
         public void ValidNameQuotedValuePairListEncoding(string input, string expectedOutput)
         {
             NameQuotedValuePairListEncoding _encoding = new();
@@ -90,9 +93,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
                 }
             }
         }
-
+        
         [Theory]
-        [InlineData("=key1=")]
         [InlineData("=key1")]
         [InlineData(",key1")]
         [InlineData(",,,key1")]
@@ -102,8 +104,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
         [InlineData("=")]
         [InlineData("==")]
         [InlineData("===")]
-        [InlineData(",")]
-        [InlineData(",,,")]
         [InlineData("\"")]
         [InlineData("key1,=abcd")]
         [InlineData("key1,=,abcd")]
@@ -114,5 +114,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
             FormatException exception = Assert.Throws<FormatException>(() => (_encoding.Format(_encoding.Parse(input))));
             Assert.Equal("Expected valid name value pair.", exception.Message);
         }
+       
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/BuildPropertyPage/NameQuotedValuePairListEncodingTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/BuildPropertyPage/NameQuotedValuePairListEncodingTests.cs
@@ -37,8 +37,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
         [InlineData("\"\"ab\"\"cd=value1     ", "/\"/\"ab/\"/\"cd=\"value1     \"")]
         [InlineData("\"\"ab\"\"cd=     value1", "/\"/\"ab/\"/\"cd=\"     value1\"")]
         [InlineData("", "")]
-        [InlineData(",", "")]
-        [InlineData(",,,", "")]
         public void ValidNameQuotedValuePairListEncoding(string input, string expectedOutput)
         {
             NameQuotedValuePairListEncoding _encoding = new();
@@ -73,6 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
         [InlineData("/\"/\"ab/\"/\"cd/\"/\"ef=\"value1\"", new[] { "\"\"ab\"\"cd\"\"ef", "value1" })]
         [InlineData("/\"/\"ab/\"/\"cd=\"value1\"", new[] { "\"\"ab\"\"cd", "value1" })]
         [InlineData("a//bc=\"value1\"", new[] { "a/bc", "value1" })]
+        [InlineData("", new string[0])]
         public void VerifyNameQuotedValuePairListEncoding(string encodedPairs, string[] pairs)
         {
             NameQuotedValuePairListEncoding _encoding = new();
@@ -95,6 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
         }
         
         [Theory]
+        [InlineData("=key1=")]
         [InlineData("=key1")]
         [InlineData(",key1")]
         [InlineData(",,,key1")]
@@ -108,6 +108,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.InterceptingProjectPro
         [InlineData("key1,=abcd")]
         [InlineData("key1,=,abcd")]
         [InlineData("=\"\"")]
+        [InlineData(",")]
+        [InlineData(",,,")]
+        [InlineData("    ")]
         public void InvalidNameQuotedValuePairListEncoding(string input)
         {
             NameQuotedValuePairListEncoding _encoding = new();


### PR DESCRIPTION
Fixes [AB#1706419](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1706419)

Removing the Format Exception thrown in the NameValueListPairEncoding as the user cannot enter an input in which this error will be thrown as the intermediate steps feed in such a format where it will not be encountered by a user.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8726)