### PR TITLE
Reduce allocations during verbose FUTDC logging

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -47,6 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     0 => "FastUpToDate: ",
                     1 => "FastUpToDate:     ",
                     2 => "FastUpToDate:         ",
+                    3 => "FastUpToDate:             ",
                     _ => "FastUpToDate: " + new string(' ', Indent * 4)
                 };
             }


### PR DESCRIPTION
Recent changes to the FUTDC logging made having a third level of nesting common. We provide special-case prefixes for nesting depths of zero, one or two. This change adds a case for three.

I have no observed any instances of nesting levels of four or below.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8730)