### PR TITLE
Optimize copy item checking when build acceleration is disabled

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -481,13 +481,16 @@
     Returns="@(_CollectedCopyToOutputDirectoryItem)">
     <ItemGroup>
 
-      <_CollectedCopyToOutputDirectoryItem Include="@(_ThisProjectItemsToCopyToOutputDirectory)" />
+      <_CollectedCopyToOutputDirectoryItem Include="@(_ThisProjectItemsToCopyToOutputDirectory)">
+        <BuildAccelerationOnly>false</BuildAccelerationOnly>
+      </_CollectedCopyToOutputDirectoryItem>
 
       <!-- Output assembly -->
 
       <_CollectedCopyToOutputDirectoryItem Include="$(TargetPath)">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>$([System.IO.Path]::GetFileName('$(TargetPath)'))</TargetPath>
+        <BuildAccelerationOnly>true</BuildAccelerationOnly>
       </_CollectedCopyToOutputDirectoryItem>
 
       <!-- Debug symbols -->
@@ -495,6 +498,7 @@
       <_CollectedCopyToOutputDirectoryItem Include="@(_DebugSymbolsOutputPath->'%(FullPath)')" Condition="'$(_DebugSymbolsProduced)' == 'true' and '$(SkipCopyingSymbolsToOutputDirectory)' != 'true' and '$(CopyOutputSymbolsToOutputDirectory)' != 'false'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>$([System.IO.Path]::GetFileName('%(Identity)'))</TargetPath>
+        <BuildAccelerationOnly>true</BuildAccelerationOnly>
       </_CollectedCopyToOutputDirectoryItem>
 
       <!-- ReferenceCopyLocalPaths
@@ -508,11 +512,13 @@
       <_CollectedCopyToOutputDirectoryItem Include="@(ReferenceCopyLocalPaths->'%(Identity)')" Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' != 'ProjectReference' AND '%(ReferenceCopyLocalPaths.DestinationSubPath)' != ''">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>%(ReferenceCopyLocalPaths.DestinationSubPath)</TargetPath>
+        <BuildAccelerationOnly>true</BuildAccelerationOnly>
       </_CollectedCopyToOutputDirectoryItem>
 
       <_CollectedCopyToOutputDirectoryItem Include="@(ReferenceCopyLocalPaths->'%(Identity)')" Condition="'%(ReferenceCopyLocalPaths.ReferenceSourceTarget)' != 'ProjectReference' AND '%(ReferenceCopyLocalPaths.DestinationSubPath)' == ''">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>$([System.IO.Path]::GetFileName('%(Identity)'))</TargetPath>
+        <BuildAccelerationOnly>true</BuildAccelerationOnly>
       </_CollectedCopyToOutputDirectoryItem>
 
       <!-- Documentation file -->
@@ -520,6 +526,7 @@
       <_CollectedCopyToOutputDirectoryItem Include="@(FinalDocFile->'%(FullPath)')" Condition="'$(_DocumentationFileProduced)' == 'true'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>$([System.IO.Path]::GetFileName('%(Identity)'))</TargetPath>
+        <BuildAccelerationOnly>true</BuildAccelerationOnly>
       </_CollectedCopyToOutputDirectoryItem>
 
       <!-- Satellite assemblies -->
@@ -527,6 +534,7 @@
       <_CollectedCopyToOutputDirectoryItem Include="@(IntermediateSatelliteAssembliesWithTargetPath->'$(TargetDir)%(Culture)\$(TargetName).resources.dll')" Condition="'@(IntermediateSatelliteAssembliesWithTargetPath)' != ''">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         <TargetPath>%(IntermediateSatelliteAssembliesWithTargetPath.Culture)\$(TargetName).resources.dll</TargetPath>
+        <BuildAccelerationOnly>true</BuildAccelerationOnly>
       </_CollectedCopyToOutputDirectoryItem>
 
     </ItemGroup>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyToOutputDirectoryItem.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CopyToOutputDirectoryItem.xaml
@@ -18,6 +18,9 @@
     <EnumValue Name="PreserveNewest" />
   </EnumProperty>
 
+  <BoolProperty Name="BuildAccelerationOnly"
+                Visible="False" />
+
   <StringProperty Name="TargetPath"
                   Visible="False" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -78,7 +78,8 @@ internal sealed partial class BuildUpToDateCheck
                 // we have some copies to perform
 
                 _logger.Info(nameof(Resources.FUTD_CopyingFilesToAccelerateBuild_1), _pendingCopies.Count);
-                _logger.Indent++;
+
+                using Log.Scope _ = _logger.IndentScope();
 
                 foreach ((string source, string destination) in _pendingCopies)
                 {
@@ -126,8 +127,6 @@ internal sealed partial class BuildUpToDateCheck
                         return (Success: false, CopyCount: copyCount);
                     }
                 }
-
-                _logger.Indent--;
             }
 
             return (Success: true, CopyCount: copyCount);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -37,14 +37,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _upToDateCheckConfiguredInput = upToDateCheckConfiguredInput;
                 _ignoreKinds = ignoreKinds;
                 _checkNumber = checkNumber;
+
                 _fileName = Path.GetFileNameWithoutExtension(projectPath);
             }
+
+            public Scope IndentScope() => new(this);
 
             private string Preamble()
             {
                 return Indent switch
                 {
-                    0 => "FastUpToDate: ",
+                    <= 0 => "FastUpToDate: ",
                     1 => "FastUpToDate:     ",
                     2 => "FastUpToDate:         ",
                     3 => "FastUpToDate:             ",
@@ -68,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (level <= Level)
                 {
-                    // These are user visible, so we want them in local times so that 
+                    // These are user visible, so we want them in local times so that
                     // they correspond with dates/times that Explorer, etc shows
                     ConvertToLocalTime(ref arg0);
 
@@ -82,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (level <= Level)
                 {
-                    // These are user visible, so we want them in local times so that 
+                    // These are user visible, so we want them in local times so that
                     // they correspond with dates/times that Explorer, etc shows
                     ConvertToLocalTime(ref arg0);
                     ConvertToLocalTime(ref arg1);
@@ -97,7 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 if (level <= Level)
                 {
-                    // These are user visible, so we want them in local times so that 
+                    // These are user visible, so we want them in local times so that
                     // they correspond with dates/times that Explorer, etc shows
                     ConvertToLocalTimes(values);
 
@@ -212,6 +215,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 });
 
                 Info(nameof(Resources.FUTD_UpToDate));
+            }
+
+            public readonly struct Scope : IDisposable
+            {
+                private readonly Log _log;
+
+                public Scope(Log log)
+                {
+                    _log = log;
+                    _log.Indent++;
+                }
+
+                public void Dispose()
+                {
+                    _log.Indent--;
+                }
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (log.Level >= LogLevel.Info)
                 {
-                    log.Indent++;
+                    using Log.Scope _ = log.IndentScope();
 
                     if (state.LastItemChanges.Length == 0)
                     {
@@ -159,8 +159,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             log.Info(isAdd ? nameof(Resources.FUTD_ChangedItemsAddition_2) : nameof(Resources.FUTD_ChangedItemsRemoval_2), itemType, item);
                         }
                     }
-
-                    log.Indent--;
                 }
 
                 return false;
@@ -176,15 +174,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // which also includes other items such as project files, compilation items, analyzer references, etc.
 
             log.Info(nameof(Resources.FUTD_ComparingInputOutputTimestamps));
-            log.Indent++;
 
-            // First, validate the relationship between inputs and outputs within the default set.
-            if (!CheckInputsAndOutputs(CollectDefaultInputs(), CollectDefaultOutputs(), timestampCache, DefaultSetName))
+            using (log.IndentScope())
             {
-                return false;
+                // First, validate the relationship between inputs and outputs within the default set.
+                if (!CheckInputsAndOutputs(CollectDefaultInputs(), CollectDefaultOutputs(), timestampCache, DefaultSetName))
+                {
+                    return false;
+                }
             }
-
-            log.Indent--;
 
             // Second, validate the relationships between inputs and outputs in specific sets, if any.
             foreach (string setName in state.SetNames)
@@ -305,25 +303,28 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (state.MSBuildProjectFullPath is not null)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingProjectFileInputs));
-                    log.Indent++;
-                    log.VerboseLiteral(state.MSBuildProjectFullPath);
-                    log.Indent--;
+                    using (log.IndentScope())
+                    {
+                        log.VerboseLiteral(state.MSBuildProjectFullPath);
+                    }
                     yield return (Path: state.MSBuildProjectFullPath, ItemType: null, IsRequired: true);
                 }
 
                 if (state.NewestImportInput is not null)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingNewestImportInput));
-                    log.Indent++;
-                    log.VerboseLiteral(state.NewestImportInput);
-                    log.Indent--;
+                    using (log.IndentScope())
+                    {
+                        log.VerboseLiteral(state.NewestImportInput);
+                    }
                     yield return (Path: state.NewestImportInput, ItemType: null, IsRequired: true);
                 }
 
                 foreach ((string itemType, ImmutableArray<string> items) in state.InputSourceItemsByItemType)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), itemType);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string item in items)
                     {
@@ -331,14 +332,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         log.VerboseLiteral(absolutePath);
                         yield return (Path: absolutePath, itemType, IsRequired: true);
                     }
-
-                    log.Indent--;
                 }
 
                 if (!state.ResolvedAnalyzerReferencePaths.IsEmpty)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), ResolvedAnalyzerReference.SchemaName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string path in state.ResolvedAnalyzerReferencePaths)
                     {
@@ -346,14 +346,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         log.VerboseLiteral(absolutePath);
                         yield return (Path: absolutePath, ItemType: ResolvedAnalyzerReference.SchemaName, IsRequired: true);
                     }
-
-                    log.Indent--;
                 }
 
                 if (!state.ResolvedCompilationReferencePaths.IsEmpty)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), ResolvedCompilationReference.SchemaName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string path in state.ResolvedCompilationReferencePaths)
                     {
@@ -361,14 +360,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         log.VerboseLiteral(path);
                         yield return (Path: path, ItemType: ResolvedCompilationReference.SchemaName, IsRequired: true);
                     }
-
-                    log.Indent--;
                 }
 
                 if (state.UpToDateCheckInputItemsByKindBySetName.TryGetValue(DefaultSetName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckInputItems))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputs_1), UpToDateCheckInput.SchemaName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string kind in state.KindNames)
                     {
@@ -387,8 +385,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             }
                         }
                     }
-
-                    log.Indent--;
                 }
             }
 
@@ -397,7 +393,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (state.UpToDateCheckOutputItemsByKindBySetName.TryGetValue(DefaultSetName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckOutputItems))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputs_1), UpToDateCheckOutput.SchemaName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string kind in state.KindNames)
                     {
@@ -416,14 +413,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             }
                         }
                     }
-
-                    log.Indent--;
                 }
 
                 if (state.UpToDateCheckBuiltItemsByKindBySetName.TryGetValue(DefaultSetName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckBuiltItems))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputs_1), UpToDateCheckBuilt.SchemaName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string kind in state.KindNames)
                     {
@@ -442,8 +438,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             }
                         }
                     }
-
-                    log.Indent--;
                 }
             }
 
@@ -452,7 +446,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (state.UpToDateCheckInputItemsByKindBySetName.TryGetValue(setName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckInputItems))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedInputsInSet_2), UpToDateCheckInput.SchemaName, setName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string kind in state.KindNames)
                     {
@@ -471,8 +466,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             }
                         }
                     }
-
-                    log.Indent--;
                 }
             }
 
@@ -481,7 +474,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 if (state.UpToDateCheckOutputItemsByKindBySetName.TryGetValue(setName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckOutputItems))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputsInSet_2), UpToDateCheckOutput.SchemaName, setName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string kind in state.KindNames)
                     {
@@ -500,14 +494,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             }
                         }
                     }
-
-                    log.Indent--;
                 }
 
                 if (state.UpToDateCheckBuiltItemsByKindBySetName.TryGetValue(setName, out ImmutableDictionary<string, ImmutableArray<string>>? upToDateCheckBuiltItems))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingTypedOutputsInSet_2), UpToDateCheckBuilt.SchemaName, setName);
-                    log.Indent++;
+
+                    using Log.Scope _ = log.IndentScope();
 
                     foreach (string kind in state.KindNames)
                     {
@@ -526,8 +519,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             }
                         }
                     }
-
-                    log.Indent--;
                 }
             }
 
@@ -625,7 +616,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             log.Info(nameof(Resources.FUTD_ComparingCopyMarkerTimestamps));
 
-            log.Indent++;
+            using Log.Scope _ = log.IndentScope();
 
             string outputMarkerFile = _configuredProject.UnconfiguredProject.MakeRooted(state.CopyUpToDateMarkerItem);
 
@@ -644,30 +635,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             bool inputMarkerExists = false;
 
-            foreach (string inputMarker in state.CopyReferenceInputs)
+            using (log.IndentScope())
             {
-                log.Indent++;
-                log.VerboseLiteral(inputMarker);
-                log.Indent--;
-
-                DateTime? inputMarkerTime = timestampCache.GetTimestampUtc(inputMarker);
-
-                if (inputMarkerTime is null)
+                foreach (string inputMarker in state.CopyReferenceInputs)
                 {
-                    log.Indent += 2;
-                    log.Verbose(nameof(Resources.FUTD_InputMarkerDoesNotExist));
-                    log.Indent -= 2;
-                    continue;
-                }
+                    log.VerboseLiteral(inputMarker);
 
-                inputMarkerExists = true;
+                    DateTime? inputMarkerTime = timestampCache.GetTimestampUtc(inputMarker);
 
-                // See if input marker is newer than output marker
-                if (outputMarkerTime < inputMarkerTime)
-                {
-                    fileSystemOperations.IsAccelerationCandidate = true;
+                    if (inputMarkerTime is null)
+                    {
+                        using (log.IndentScope())
+                        {
+                            log.Verbose(nameof(Resources.FUTD_InputMarkerDoesNotExist));
+                            continue;
+                        }
+                    }
 
-                    return log.Fail("InputMarkerNewerThanOutputMarker", nameof(Resources.FUTD_InputMarkerNewerThanOutputMarker_4), inputMarker, inputMarkerTime, outputMarkerFile, outputMarkerTime);
+                    inputMarkerExists = true;
+
+                    // See if input marker is newer than output marker
+                    if (outputMarkerTime < inputMarkerTime)
+                    {
+                        fileSystemOperations.IsAccelerationCandidate = true;
+
+                        return log.Fail("InputMarkerNewerThanOutputMarker", nameof(Resources.FUTD_InputMarkerNewerThanOutputMarker_4), inputMarker, inputMarkerTime, outputMarkerFile, outputMarkerTime);
+                    }
                 }
             }
 
@@ -675,8 +668,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 log.Info(nameof(Resources.FUTD_NoInputMarkersExist));
             }
-
-            log.Indent--;
 
             return true;
         }
@@ -696,6 +687,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 log.Info(nameof(Resources.FUTD_CheckingBuiltOutputFile), sourcePath);
 
+                using Log.Scope _ = log.IndentScope();
+
                 DateTime? sourceTime = timestampCache.GetTimestampUtc(sourcePath);
 
                 if (sourceTime is null)
@@ -705,9 +698,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return log.Fail("CopySourceNotFound", nameof(Resources.FUTD_CheckingBuiltOutputFileSourceNotFound_2), sourcePath, destinationPath);
                 }
 
-                log.Indent++;
                 log.Info(nameof(Resources.FUTD_SourceFileTimeAndPath_2), sourceTime, sourcePath);
-                log.Indent--;
 
                 DateTime? destinationTime = timestampCache.GetTimestampUtc(destinationPath);
 
@@ -716,9 +707,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     return log.Fail("CopyDestinationNotFound", nameof(Resources.FUTD_CheckingBuiltOutputFileDestinationNotFound_2), destinationPath, sourcePath);
                 }
 
-                log.Indent++;
                 log.Info(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destinationPath);
-                log.Indent--;
 
                 if (destinationTime < sourceTime)
                 {
@@ -729,7 +718,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             return true;
         }
 
-        private bool CheckCopyToOutputDirectoryItems(Log log, UpToDateCheckImplicitConfiguredInput state, IEnumerable<CopyItem> copyItems, ConfiguredFileSystemOperationAggregator fileSystemAggregator, CancellationToken token)
+        private bool CheckCopyToOutputDirectoryItems(Log log, UpToDateCheckImplicitConfiguredInput state, IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> copyItemsByProject, ConfiguredFileSystemOperationAggregator fileSystemAggregator, bool? isBuildAccelerationEnabled, CancellationToken token)
         {
             ITimestampCache? timestampCache = _context.CopyItemTimestamps;
 
@@ -742,110 +731,124 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             string outputFullPath = Path.Combine(state.MSBuildProjectDirectory, state.OutputRelativeOrFullPath);
 
-            bool hasItem = false;
+            Log.Scope? scope1 = null;
 
-            foreach ((string sourcePath, string targetPath, CopyType copyType) in copyItems)
+            foreach ((string project, ImmutableArray<CopyItem> copyItems) in copyItemsByProject)
             {
-                if (!hasItem)
+                Log.Scope? scope2 = null;
+
+                foreach ((string sourcePath, string targetPath, CopyType copyType, bool isBuildAccelerationOnly) in copyItems)
                 {
-                    log.Verbose(nameof(Resources.FUTD_CheckingCopyToOutputDirectoryItems));
-                    log.Indent++;
-                    hasItem = true;
-                }
+                    token.ThrowIfCancellationRequested();
 
-                string destinationPath = Path.Combine(outputFullPath, targetPath);
-
-                if (StringComparers.Paths.Equals(sourcePath, destinationPath))
-                {
-                    // This can occur when a project is checking its own items, and the item already
-                    // exists in the output directory.
-                    continue;
-                }
-
-                token.ThrowIfCancellationRequested();
-
-                log.Verbose(nameof(Resources.FUTD_CheckingCopyToOutputDirectoryItem_1), copyType.ToString());
-
-                DateTime? sourceTime = timestampCache.GetTimestampUtc(sourcePath);
-
-                if (sourceTime is null)
-                {
-                    // We don't generally expect the source to be unavailable.
-                    // If this occurs, schedule a build to be on the safe side.
-                    return log.Fail("CopyToOutputDirectorySourceNotFound", nameof(Resources.FUTD_CheckingCopyToOutputDirectorySourceNotFound_1), sourcePath);
-                }
-
-                log.Indent++;
-                log.Verbose(nameof(Resources.FUTD_SourceFileTimeAndPath_2), sourceTime, sourcePath);
-                log.Indent--;
-                DateTime? destinationTime = timestampCache.GetTimestampUtc(destinationPath);
-
-                if (destinationTime is null)
-                {
-                    log.Indent++;
-                    log.Verbose(nameof(Resources.FUTD_DestinationDoesNotExist_1), destinationPath);
-                    log.Indent--;
-
-                    if (!fileSystemAggregator.AddCopy(sourcePath, destinationPath))
+                    if (isBuildAccelerationEnabled is not true && isBuildAccelerationOnly)
                     {
-                        return log.Fail("CopyToOutputDirectoryDestinationNotFound", nameof(Resources.FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1), destinationPath);
+                        // This item should only be checked when build acceleration is enabled.
+                        // For example, we only check referenced output assemblies when enabled.
+                        // When not accelerating builds, checking these is unnecessary overhead.
+                        continue;
                     }
 
-                    continue;
-                }
+                    string destinationPath = Path.Combine(outputFullPath, targetPath);
 
-                log.Indent++;
-                log.Verbose(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destinationPath);
-                log.Indent--;
-
-                switch (copyType)
-                {
-                    case CopyType.Always:
+                    if (StringComparers.Paths.Equals(sourcePath, destinationPath))
                     {
-                        // We have already validated the presence of these files, so we don't expect these to return
-                        // false. If one of them does, the corresponding size would be zero, so we would schedule a build.
-                        // The odds of both source and destination disappearing between the gathering of the timestamps
-                        // above and these following statements is vanishingly small, and would suggest bigger problems
-                        // such as the entire project directory having been deleted.
-                        _fileSystem.TryGetFileSizeBytes(sourcePath, out long sourceSizeBytes);
-                        _fileSystem.TryGetFileSizeBytes(destinationPath, out long destinationSizeBytes);
+                        // This can occur when a project is checking its own items, and the item already
+                        // exists in the output directory.
+                        continue;
+                    }
 
-                        if (sourceTime != destinationTime || sourceSizeBytes != destinationSizeBytes)
+                    if (scope1 is null)
+                    {
+                        log.Verbose(nameof(Resources.FUTD_CheckingCopyToOutputDirectoryItems));
+                        scope1 = log.IndentScope();
+                    }
+
+                    if (scope2 is null)
+                    {
+                        log.Verbose(nameof(Resources.FUTDC_CheckingCopyItemsForProject_1), project);
+                        scope2 = log.IndentScope();
+                    }
+
+                    log.Verbose(nameof(Resources.FUTD_CheckingCopyToOutputDirectoryItem_1), copyType.ToString());
+
+                    DateTime? sourceTime = timestampCache.GetTimestampUtc(sourcePath);
+
+                    if (sourceTime is null)
+                    {
+                        // We don't generally expect the source to be unavailable.
+                        // If this occurs, schedule a build to be on the safe side.
+                        return log.Fail("CopyToOutputDirectorySourceNotFound", nameof(Resources.FUTD_CheckingCopyToOutputDirectorySourceNotFound_1), sourcePath);
+                    }
+
+                    using Log.Scope _ = log.IndentScope();
+
+                    log.Verbose(nameof(Resources.FUTD_SourceFileTimeAndPath_2), sourceTime, sourcePath);
+
+                    DateTime? destinationTime = timestampCache.GetTimestampUtc(destinationPath);
+
+                    if (destinationTime is null)
+                    {
+                        log.Verbose(nameof(Resources.FUTD_DestinationDoesNotExist_1), destinationPath);
+
+                        if (!fileSystemAggregator.AddCopy(sourcePath, destinationPath))
                         {
-                            if (!fileSystemAggregator.AddCopy(sourcePath, destinationPath))
-                            {
-                                return log.Fail("CopyAlwaysItemDiffers", nameof(Resources.FUTD_CopyAlwaysItemsDiffer_6), sourcePath, sourceTime, sourceSizeBytes, destinationPath, destinationTime, destinationSizeBytes);
-                            }
+                            return log.Fail("CopyToOutputDirectoryDestinationNotFound", nameof(Resources.FUTD_CheckingCopyToOutputDirectoryItemDestinationNotFound_1), destinationPath);
                         }
 
-                        break;
+                        continue;
                     }
 
-                    case CopyType.PreserveNewest:
+                    log.Verbose(nameof(Resources.FUTD_DestinationFileTimeAndPath_2), destinationTime, destinationPath);
+
+                    switch (copyType)
                     {
-                        if (destinationTime < sourceTime)
+                        case CopyType.Always:
                         {
-                            if (!fileSystemAggregator.AddCopy(sourcePath, destinationPath))
+                            // We have already validated the presence of these files, so we don't expect these to return
+                            // false. If one of them does, the corresponding size would be zero, so we would schedule a build.
+                            // The odds of both source and destination disappearing between the gathering of the timestamps
+                            // above and these following statements is vanishingly small, and would suggest bigger problems
+                            // such as the entire project directory having been deleted.
+                            _fileSystem.TryGetFileSizeBytes(sourcePath, out long sourceSizeBytes);
+                            _fileSystem.TryGetFileSizeBytes(destinationPath, out long destinationSizeBytes);
+
+                            if (sourceTime != destinationTime || sourceSizeBytes != destinationSizeBytes)
                             {
-                                return log.Fail("CopyToOutputDirectorySourceNewer", nameof(Resources.FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_3), CopyType.PreserveNewest.ToString(), sourcePath, destinationPath);
+                                if (!fileSystemAggregator.AddCopy(sourcePath, destinationPath))
+                                {
+                                    return log.Fail("CopyAlwaysItemDiffers", nameof(Resources.FUTD_CopyAlwaysItemsDiffer_6), sourcePath, sourceTime, sourceSizeBytes, destinationPath, destinationTime, destinationSizeBytes);
+                                }
                             }
+
+                            break;
                         }
 
-                        break;
-                    }
+                        case CopyType.PreserveNewest:
+                        {
+                            if (destinationTime < sourceTime)
+                            {
+                                if (!fileSystemAggregator.AddCopy(sourcePath, destinationPath))
+                                {
+                                    return log.Fail("CopyToOutputDirectorySourceNewer", nameof(Resources.FUTD_CheckingCopyToOutputDirectorySourceNewerThanDestination_3), CopyType.PreserveNewest.ToString(), sourcePath, destinationPath);
+                                }
+                            }
 
-                    default:
-                    {
-                        System.Diagnostics.Debug.Fail("Project copy items should only contain copyable items.");
-                        break;
+                            break;
+                        }
+
+                        default:
+                        {
+                            System.Diagnostics.Debug.Fail("Project copy items should only contain copyable items.");
+                            break;
+                        }
                     }
                 }
+
+                scope2?.Dispose();
             }
 
-            if (hasItem)
-            {
-                log.Indent--;
-            }
+            scope1?.Dispose();
 
             return true;
         }
@@ -1039,7 +1042,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                         // We may have an incomplete set of copy items.
                         // We check timestamps of whatever items we can find, but only perform acceleration when the full set is available.
-                        (IEnumerable<CopyItem> copyItems, bool isCopyItemsComplete) = _copyItemAggregator.TryGatherCopyItemsForProject(implicitState.ProjectTargetPath, logger);
+                        (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> copyItemsByProject, bool isCopyItemsComplete) = _copyItemAggregator.TryGatherCopyItemsForProject(implicitState.ProjectTargetPath, logger);
 
                         bool? isBuildAccelerationEnabled = IsBuildAccelerationEnabled(isCopyItemsComplete, implicitState);
 
@@ -1053,7 +1056,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             !CheckInputsAndOutputs(logger, lastSuccessfulBuildStartTimeUtc, timestampCache, implicitState, ignoreKinds, token) ||
                             !CheckBuiltFromInputFiles(logger, timestampCache, implicitState, token) ||
                             !CheckMarkers(logger, timestampCache, implicitState, isBuildAccelerationEnabled, fileSystemOperations) ||
-                            !CheckCopyToOutputDirectoryItems(logger, implicitState, copyItems, configuredFileSystemOperations, token))
+                            !CheckCopyToOutputDirectoryItems(logger, implicitState, copyItemsByProject, configuredFileSystemOperations, isBuildAccelerationEnabled, token))
                         {
                             return (false, checkedConfigurations);
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
@@ -30,11 +30,11 @@ internal interface ICopyItemAggregator
     /// <returns>
     /// A tuple comprising:
     /// <list type="number">
-    ///   <item><c>Items</c> a sequence of items that are reachable from the current project.</item>
+    ///   <item><c>Items</c> a sequence of items by project, that are reachable from the current project.</item>
     ///   <item><c>IsComplete</c> indicating whether we have items from all reachable projects.</item>
     /// </list>
     /// </returns>
-    (IEnumerable<CopyItem> Items, bool IsComplete) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger);
+    (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger);
 }
 
 /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -754,20 +754,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Checking copy items from project &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Checking copy items from project &apos;{0}&apos;:.
         /// </summary>
         internal static string FUTDC_CheckingCopyItemsForProject_1 {
             get {
                 return ResourceManager.GetString("FUTDC_CheckingCopyItemsForProject_1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Skipping duplicate copy item &apos;{0}&apos; to &apos;{1}&apos;.
-        /// </summary>
-        internal static string FUTDC_SkippingDuplicateCopyItem_2 {
-            get {
-                return ResourceManager.GetString("FUTDC_SkippingDuplicateCopyItem_2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -375,12 +375,8 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>Checking items to copy to the output directory:</value>
   </data>
   <data name="FUTDC_CheckingCopyItemsForProject_1" xml:space="preserve">
-    <value>Checking copy items from project '{0}'.</value>
+    <value>Checking copy items from project '{0}':</value>
     <comment>{0} is a file path.</comment>
-  </data>
-  <data name="FUTDC_SkippingDuplicateCopyItem_2" xml:space="preserve">
-    <value>Skipping duplicate copy item '{0}' to '{1}'</value>
-    <comment>{0} and {1} are file paths.</comment>
   </data>
   <data name="FUTD_CheckingCopyToOutputDirectoryItem_1" xml:space="preserve">
     <value>Checking {0} item</value>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Probíhá kontrola kopírování položek z projektu {0}.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Probíhá kontrola kopírování položek z projektu {0}.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Přeskakování duplicitní kopie položky {0} do {1}</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Das Kopieren von Elementen aus dem Projekt "{0}" wird überprüft.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Das Kopieren von Elementen aus dem Projekt "{0}" wird überprüft.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Doppeltes Kopierelement "{0}" wird in "{1}" übersprungen.</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Comprobando elementos de copia del proyecto '{0}'.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Comprobando elementos de copia del proyecto '{0}'.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Omitiendo el elemento de copia duplicado '{0}' a '{1}'</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Vérification des éléments de copie à partir du projet « {0} ».</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Vérification des éléments de copie à partir du projet « {0} ».</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Ignorer la copie en double de l’élément « {0} » vers « {1} ».</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">È in corso il controllo della copia degli elementi dal progetto '{0}'.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">È in corso il controllo della copia degli elementi dal progetto '{0}'.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">La copia duplicata dell'elemento '{0}' in '{1}' verrà ignorata</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">プロジェクト '{0}' からのコピー項目を確認しています。</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">プロジェクト '{0}' からのコピー項目を確認しています。</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">重複コピー項目 '{0}' を '{1}' にスキップしています</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">프로젝트 '{0}'에서 항목 복사를 확인하는 중입니다.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">프로젝트 '{0}'에서 항목 복사를 확인하는 중입니다.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">'{1}'에 중복된 복사 항목 '{0}'을(를) 건너뛰는 중</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Sprawdzanie elementów kopii z projektu „{0}”.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Sprawdzanie elementów kopii z projektu „{0}”.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Pomijanie zduplikowanego elementu kopii „{0}” do „{1}”</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Verificando itens de cópia do projeto '{0}'.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Verificando itens de cópia do projeto '{0}'.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Ignorando item de cópia duplicado '{0}' para '{1}'</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">Проверка копирования элементов из проекта "{0}".</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">Проверка копирования элементов из проекта "{0}".</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Пропуск копирования элемента "{0}" в "{1}"</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">'{0}' projesindeki kopya öğeleri kontrol ediliyor.</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">'{0}' projesindeki kopya öğeleri kontrol ediliyor.</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">Yinelenen kopya öğesi '{0}' yolundan '{1}' yoluna atlanıyor</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">正在检查项目“{0}”中的复制项。</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">正在检查项目“{0}”中的复制项。</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">正在跳过复制项 '{0}' 到 '{1}' 的重复项</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -28,14 +28,9 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
-        <source>Checking copy items from project '{0}'.</source>
-        <target state="translated">正在檢查從專案 '{0}' 複製項目。</target>
+        <source>Checking copy items from project '{0}':</source>
+        <target state="needs-review-translation">正在檢查從專案 '{0}' 複製項目。</target>
         <note>{0} is a file path.</note>
-      </trans-unit>
-      <trans-unit id="FUTDC_SkippingDuplicateCopyItem_2">
-        <source>Skipping duplicate copy item '{0}' to '{1}'</source>
-        <target state="translated">正在略過複製項目 '{0}' 到 '{1}'</target>
-        <note>{0} and {1} are file paths.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
         <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>


### PR DESCRIPTION
Contributes to #8733

Build Acceleration is a new feature that requires opt in.

When adding that feature, we started checking a larger number of potential inputs to projects. This included files like the output assemblies of referenced projects, along with their debug symbols and documentation files.

We need to check such files for the Build Acceleration feature, but when it is disabled there is no need to check them and doing so creates additional overhead that makes the FUTDC slower.

This change adds new metadata to those items, `BuildAccelerationOnly`, so the FUTDC can decide whether to check them or not.

That change filters all items from many projects during builds, leading to confusing messages being logged. Quite a bit of the diff here relates to moving logging code around to produce better quality log messages. In doing so, a more robust approach to controlling nesting of log messages was introduced. The diff is easier to read if white space changes are ignored.

We also remove the duplicate item checking that we saw previously as I never saw this being hit in practice, and tracking these items has a cost that I no longer believe is worth it.

Unit tests were extended to include items both with and without `BuildAccelerationOnly` metadata to validate behaviour. Note that the logging changes also created some diff in the unit tests of unrelated methods, however those changes mean that the tests now reflect the output that is actually seen when running the FUTDC in VS.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8735)