### PR TITLE
Add Build Acceleration telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -35,6 +35,47 @@ internal sealed partial class BuildUpToDateCheck
         /// </summary>
         public bool IsAccelerationCandidate { get; internal set; }
 
+        /// <summary>
+        /// Gets whether build acceleration was enabled in any configuration or not.
+        /// </summary>
+        /// <remarks>
+        ///   <para>
+        ///   <list type="bullet">
+        ///     <item><see langword="null"/> when no value was specified in any configuration.</item>
+        ///     <item><see langword="false"/> if all configurations had it disabled.</item>
+        ///     <item><see langword="true"/> if any configuration had it enabled.</item>
+        ///   </list>
+        ///   </para>
+        ///   <para>
+        ///     When no value is specified (value <see langword="null"/>), build acceleration should
+        ///     be considered disabled (the default behavior). Projects must opt in to this feature.
+        ///   </para>
+        ///   <para>
+        ///     This value is set at the configured level, though We expect all configurations
+        ///     to share the same value, so expose it at this top level.
+        ///   </para>
+        /// </remarks>
+        public bool? IsAccelerationEnabled { get; internal set; }
+
+        public BuildAccelerationResult AccelerationResult
+        {
+            get
+            {
+                if (IsAccelerationEnabled is true)
+                {
+                    if (_pendingCopies is not null)
+                        return BuildAccelerationResult.EnabledAccelerated;
+
+                    return BuildAccelerationResult.EnabledNotAccelerated;
+                }
+
+                if (IsAccelerationCandidate)
+                    return BuildAccelerationResult.DisabledCandidate;
+
+                return BuildAccelerationResult.DisabledNotCandidate;
+            }
+        }
+
         public FileSystemOperationAggregator(IFileSystem fileSystem, Log logger)
         {
             _fileSystem = fileSystem;
@@ -151,6 +192,17 @@ internal sealed partial class BuildUpToDateCheck
         {
             _parent = parent;
             _isBuildAccelerationEnabled = isBuildAccelerationEnabled;
+
+            if (isBuildAccelerationEnabled is true)
+            {
+                // True if any configuration is enabled
+                _parent.IsAccelerationEnabled = true;
+            }
+            else if (_parent.IsAccelerationEnabled is null && isBuildAccelerationEnabled is false)
+            {
+                // Note an explicit disable
+                _parent.IsAccelerationEnabled = false;
+            }
         }
 
         public bool AddCopy(string source, string destination)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             private readonly TimestampCache _timestampCache;
             private readonly Guid _projectGuid;
             private readonly string _fileName;
-            private readonly ITelemetryService? _telemetryService;
+            private readonly ITelemetryService? _telemetryService; // null for validation runs
             private readonly UpToDateCheckConfiguredInput _upToDateCheckConfiguredInput;
             private readonly string? _ignoreKinds;
             private readonly int _checkNumber;
@@ -192,7 +192,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return false;
             }
 
-            public void UpToDate()
+            /// <summary>
+            /// Publishes that the project is up-to-date via telemetry and the output window.
+            /// </summary>
+            public void UpToDate(BuildAccelerationResult buildAccelerationResult, int copyCount)
             {
                 Assumes.Null(FailureReason);
                 Assumes.Null(FailureDescription);
@@ -208,11 +211,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     (TelemetryPropertyName.UpToDateCheck.LogLevel, Level),
                     (TelemetryPropertyName.UpToDateCheck.Project, _projectGuid),
                     (TelemetryPropertyName.UpToDateCheck.CheckNumber, _checkNumber),
-                    (TelemetryPropertyName.UpToDateCheck.IgnoreKinds, _ignoreKinds ?? "")
+                    (TelemetryPropertyName.UpToDateCheck.IgnoreKinds, _ignoreKinds ?? ""),
+                    (TelemetryPropertyName.UpToDateCheck.AccelerationResult, buildAccelerationResult),
+                    (TelemetryPropertyName.UpToDateCheck.AcceleratedCopyCount, copyCount)
                 });
 
                 Info(nameof(Resources.FUTD_UpToDate));
             }
+        }
+
+        public enum BuildAccelerationResult
+        {
+            // Disabled, not candidate
+            DisabledNotCandidate,
+            // Disabled, candidate
+            DisabledCandidate,
+            // Enabled, not accelerated
+            EnabledNotAccelerated,
+            // Enabled, accelerated
+            EnabledAccelerated
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -1078,9 +1078,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         {
                             logger.Info(nameof(Resources.FUTD_BuildAccelerationSummary_1), copyCount);
                         }
-                    }
 
-                    logger.UpToDate();
+                        logger.UpToDate(fileSystemOperations.AccelerationResult, copyCount);
+                    }
 
                     return (true, checkedConfigurations);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -59,6 +59,17 @@ namespace Microsoft.VisualStudio.Telemetry
             ///     This number resets when the project is reloaded.
             /// </summary>
             public const string CheckNumber = "vs.projectsystem.managed.uptodatecheck.checknumber";
+
+            /// <summary>
+            ///     The outcome of the FUTDC's Build Acceleration evaluation.
+            /// </summary>
+            public const string AccelerationResult = "vs.projectsystem.managed.uptodatecheck.accelerationresult";
+
+            /// <summary>
+            ///     The number of files copied as part of Build Acceleration. Zero if disabled or no files were copied.
+            ///     See <see cref="AccelerationResult"/> to understand why the value may be zero.
+            /// </summary>
+            public const string AcceleratedCopyCount = "vs.projectsystem.managed.uptodatecheck.acceleratedcopycount";
         }
 
         public static class TreeUpdated

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -2082,7 +2082,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, telemetryEvent.EventName);
 
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(7, telemetryEvent.Properties.Count);
+            Assert.Equal(9, telemetryEvent.Properties.Count);
 
             var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.DurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
@@ -2106,6 +2106,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.Project));
             Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.CheckNumber));
+            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.AcceleratedCopyCount));
+            Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.AccelerationResult));
 
             _telemetryEvents.Clear();
         }


### PR DESCRIPTION
Captures the status of the Build Acceleration (BA) feature any time the build is up-to-date. May be one of:

- Disabled, not candidate
- Disabled, candidate
- Enabled, not accelerated
- Enabled, accelerated

Builds that are not up-to-date log the reason, some of which could be helped by BA. We don't know for sure in this case however, as the check works differently when it encounters a copyable file depending upon whether BA is enabled or not.

- When enabled and we hit a copyable file, we remember the file and continue checking, then if we get to the end of the file and only have files to copy, we copy them.
- When disabled and we hit a copyable file, we return immediately on the first failure, even if the file was copyable. For that reason, we don't know for sure whether there were other reasons the project might have been built. The results of current telemetry give a bound for the impact BA would have if enabled.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8738)