### PR TITLE
Disable Build Acceleration for VSIX projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -24,6 +24,9 @@
 
     <!-- Tells CPS which target to run for the Package solution build type -->
     <PackageAction Condition="'$(PackageAction)' == ''">Pack</PackageAction>
+
+    <!-- Disable Build Acceleration for VSIX projects -->
+    <AccelerateBuildsInVisualStudio Condition="'$(IsVsixProject)' == 'true'">false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(AssemblyReferenceTabs)' == '' And '$(UsingMicrosoftNETSdk)' == 'true'">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <!--
-    Locate the approriate localized xaml resources based on the language ID or name.
+    Locate the appropriate localized xaml resources based on the language ID or name.
 
     The logic here matches the resource manager sufficiently to handle the fixed set of 
     possible VS languages and directories on disk.


### PR DESCRIPTION
VSIX projects are not eligible for Build Acceleration, as their build steps cannot be satisfied by simply copying files to the output directory.

Ideally the VSSDK would set this property in their props/targets, however users of older versions of the VSSDK would not pick up this behaviour. By setting it here, we ensure these projects work correctly when Build Acceleration is enabled at the solution level.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8742)