### PR TITLE
Identify FUTDC time spent waiting for project data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Log.cs
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             private readonly TextWriter _writer;
             private readonly Stopwatch _stopwatch;
+            private readonly TimeSpan _waitTime;
             private readonly TimestampCache _timestampCache;
             private readonly Guid _projectGuid;
             private readonly string _fileName;
@@ -27,11 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             public string? FailureDescription { get; private set; }
             public FileSystemOperationAggregator? FileSystemOperations { get; set; }
 
-            public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimestampCache timestampCache, string projectPath, Guid projectGuid, ITelemetryService? telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput, string? ignoreKinds, int checkNumber)
+            public Log(TextWriter writer, LogLevel requestedLogLevel, Stopwatch stopwatch, TimeSpan waitTime, TimestampCache timestampCache, string projectPath, Guid projectGuid, ITelemetryService? telemetryService, UpToDateCheckConfiguredInput upToDateCheckConfiguredInput, string? ignoreKinds, int checkNumber)
             {
                 _writer = writer;
                 Level = requestedLogLevel;
                 _stopwatch = stopwatch;
+                _waitTime = waitTime;
                 _timestampCache = timestampCache;
                 _projectGuid = projectGuid;
                 _telemetryService = telemetryService;
@@ -183,6 +185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     (TelemetryPropertyName.UpToDateCheck.FailReason, (object)reason),
                     (TelemetryPropertyName.UpToDateCheck.DurationMillis, _stopwatch.Elapsed.TotalMilliseconds),
+                    (TelemetryPropertyName.UpToDateCheck.WaitDurationMillis, _waitTime.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheck.FileCount, _timestampCache.Count),
                     (TelemetryPropertyName.UpToDateCheck.ConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
                     (TelemetryPropertyName.UpToDateCheck.LogLevel, Level),
@@ -214,6 +217,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 _telemetryService?.PostProperties(TelemetryEventName.UpToDateCheckSuccess, new[]
                 {
                     (TelemetryPropertyName.UpToDateCheck.DurationMillis, (object)_stopwatch.Elapsed.TotalMilliseconds),
+                    (TelemetryPropertyName.UpToDateCheck.WaitDurationMillis, _waitTime.TotalMilliseconds),
                     (TelemetryPropertyName.UpToDateCheck.FileCount, _timestampCache.Count),
                     (TelemetryPropertyName.UpToDateCheck.ConfigurationCount, _upToDateCheckConfiguredInput.ImplicitInputs.Length),
                     (TelemetryPropertyName.UpToDateCheck.LogLevel, Level),

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -951,6 +951,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             async Task<(bool, ImmutableArray<ProjectConfiguration>)> CheckAsync(UpToDateCheckConfiguredInput state, IUpToDateCheckStatePersistence persistence, CancellationToken token)
             {
+                // The subscription object calls GetLatestVersionAsync for project data, which can take a while.
+                // We separate out the wait time from the overall time, so we can more easily identify when the
+                // wait is long, versus the check's actual execution time.
+                var waitTime = sw.Elapsed;
+
                 token.ThrowIfCancellationRequested();
 
                 // Short-lived cache of timestamp by path
@@ -966,6 +971,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     logWriter,
                     requestedLogLevel,
                     sw,
+                    waitTime,
                     timestampCache,
                     _configuredProject.UnconfiguredProject.FullPath ?? "",
                     projectGuid,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryPropertyName.cs
@@ -19,9 +19,23 @@ namespace Microsoft.VisualStudio.Telemetry
             public const string FailReason = "vs.projectsystem.managed.uptodatecheck.fail.reason2";
 
             /// <summary>
-            ///     Indicates the duration of the up-to-date check, in milliseconds.
+            ///     Indicates the duration of the up-to-date check, in milliseconds. Includes wait time and execution time.
             /// </summary>
             public const string DurationMillis = "vs.projectsystem.managed.uptodatecheck.durationmillis";
+
+            /// <summary>
+            ///     Indicates the duration of time between when the check was requested, and when we actually
+            ///     start execution.
+            /// </summary>
+            /// <remarks>
+            ///     During this time we await the latest project data, which can take quite some time.
+            ///     We also acquire a lock, and query the host for the status of the up-to-date check.
+            ///     We report this wait time separately via telemetry in order to properly attribute the source
+            ///     of delays in the up-to-date check. This time is also included in <see cref="DurationMillis"/>
+            ///     for historical reasons. Ideally they would not overlap, but changing that now would
+            ///     make analysis of historical data difficult.
+            /// </remarks>
+            public const string WaitDurationMillis = "vs.projectsystem.managed.uptodatecheck.waitdurationmillis";
 
             /// <summary>
             ///     Indicates the number of file system timestamps that were queried during the up-to-date check.

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -2110,7 +2110,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             Assert.Equal(TelemetryEventName.UpToDateCheckFail, telemetryEvent.EventName);
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(9, telemetryEvent.Properties.Count);
+            Assert.Equal(10, telemetryEvent.Properties.Count);
 
             var reasonProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.FailReason));
             Assert.Equal(reason, reasonProp.propertyValue);
@@ -2118,6 +2118,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.DurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
             Assert.True(duration > 0.0);
+
+            var waitDurationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.WaitDurationMillis));
+            var waitDuration = Assert.IsType<double>(waitDurationProp.propertyValue);
+            Assert.True(waitDuration > 0.0);
 
             var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.FileCount));
             var fileCount = Assert.IsType<int>(fileCountProp.propertyValue);
@@ -2149,11 +2153,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             Assert.Equal(TelemetryEventName.UpToDateCheckSuccess, telemetryEvent.EventName);
 
             Assert.NotNull(telemetryEvent.Properties);
-            Assert.Equal(9, telemetryEvent.Properties.Count);
+            Assert.Equal(10, telemetryEvent.Properties.Count);
 
             var durationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.DurationMillis));
             var duration = Assert.IsType<double>(durationProp.propertyValue);
             Assert.True(duration > 0.0);
+
+            var waitDurationProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.WaitDurationMillis));
+            var waitDuration = Assert.IsType<double>(waitDurationProp.propertyValue);
+            Assert.True(waitDuration > 0.0);
 
             var fileCountProp = Assert.Single(telemetryEvent.Properties.Where(p => p.propertyName == TelemetryPropertyName.UpToDateCheck.FileCount));
             var fileCount = Assert.IsType<int>(fileCountProp.propertyValue);


### PR DESCRIPTION
In current telemetry we report a single duration for the FUTDC. In practice, there are two interesting components to this number:

1. Time spent waiting for project data. The subscription object calls GetLatestVersionAsync for project data, which can take a while.
2. Time spent executing the check itself, iterating over files and so forth.

With this change, we add another measure to our telemetry that captures only the wait time. This will allow us to subtract this from the previously reported number (which we continue to report unchanged) so we can more easily identify wait time versus the check's actual execution time.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8744)