### PR TITLE
Clarify CPS vs. legacy project system

### DIFF
--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -43,7 +43,11 @@ The `AddAdditionalReferences` target will run in both normal builds _and_ design
 
 ### Determining whether a target is running in a design-time build
 
-Use both the `DesignTimeBuild` (CPS-based projects) and `BuildingProject` (legacy project system) properties to determine whether a target is running in a design-time build or a normal build. This can be used to avoid expensive calculations or work that is only needed for a normal build, helping to keep the IDE responsive.
+Checking if a target is running in a design-time build can be used to avoid expensive calculations or work that is only needed for a normal build, helping to keep the IDE responsive.
+
+Different project systems use different properties to distinguish between design-time builds and normal builds. For example, the .NET Project System in this repo builds on top of the Common Project System (CPS) components, and CPS-based project systems set the `DesignTimeBuild` property. However, non-SDK-style C# and VB projects generally use what we call the "legacy" project system, and it uses the `BuildingProject` property.
+
+As such, you should make use of both the `DesignTimeBuild` and `BuildingProject` properties to determine whether a target is running in a design-time build or a normal build: 
 
 ``` XML
   <Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">


### PR DESCRIPTION
This change updates our documentation on design-time builds to clarify what is meant by "CPS" and "legacy project system". An internal user was using this document for guidance on how to check for a design-time build and was confused by these terms as they aren't defined or explained.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8747)