### PR TITLE
Update documented DTB targets

### DIFF
--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -48,10 +48,10 @@ Targets that dynamically change references, source files or compilation options 
 
 If you've determined that your target needs to run in a design-time build, using the above table set `BeforeTargets` to the normal target equivalent of what you are contributing to the build. For example, if a target changes `<Reference>` items, then it should indicate that it runs _before_ `ResolveAssemblyReferences` target:
 
-``` XML
-  <Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">
-     ...
-  </Target>
+```xml
+<Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">
+    ...
+</Target>
 ```
 The `AddAdditionalReferences` target will run in both normal builds _and_ design-time builds, leading to consistent results between them.
 
@@ -59,13 +59,13 @@ The `AddAdditionalReferences` target will run in both normal builds _and_ design
 
 Use both the `DesignTimeBuild` (CPS-based projects) and `BuildingProject` (legacy project system) properties to determine whether a target is running in a design-time build or a normal build. This can be used to avoid expensive calculations or work that is only needed for a normal build, helping to keep the IDE responsive.
 
-``` XML
-  <Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">
-     <PropertyGroup Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">
-         <_AvoidExpensiveCalculation>true</_AvoidExpensiveCalculation>
-     </PropertyGroup>
-     ...
-  </Target>
+```xml
+<Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">
+    <PropertyGroup Condition="'$(DesignTimeBuild)' == 'true' OR '$(BuildingProject)' != 'true'">
+        <_AvoidExpensiveCalculation>true</_AvoidExpensiveCalculation>
+    </PropertyGroup>
+    ...
+</Target>
 ```
 
 __NOTE:__ The `DesignTimeBuild` property is typically empty (`''`) in normal builds, so avoid comparisons to `'false'`.
@@ -115,6 +115,7 @@ This will cause design-time builds to show up in the build logging tool window. 
 After following the above instructions, open the resulting build log file or Output window (for the new project system).
 
 #### Failing design-time build
+
 For a failing build, look for errors at the end of the log:
 
 ```
@@ -127,8 +128,8 @@ c:\Projects\MyProject\MyProject.csproj(17,5): error : An error occurred!
 
 These errors indicate that a target failed, typically this is due to targets that have not correctly specified their dependencies.
 
-
 #### Slow design-time build
+
 For a slow design-time, look for the target performance summary at end of the log which can indicate long running tasks and targets:
 
 ```

--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -15,16 +15,30 @@ For performance reasons, and unlike normal builds which call the _Build_ target,
 
 The following design-time targets are called, including any dependencies, during design-time builds in the C#/VB project systems. Other project systems, such as C++ or JavaScript will call different targets. 
 
-Design-Time Target                            | Normal Target                      | Description
-----------------------------------------------|------------------------------------|------------------
-ResolveAssemblyReferencesDesignTime           | ResolveAssemblyReferences          | Resolves `<Reference>` items to their paths.
-ResolveProjectReferencesDesignTime            | ResolveProjectReferences           | Resolves `<ProjectReference>` items to their output paths.
-ResolveComReferencesDesignTime                | ResolveComReferences               | Resolves `<COMReference>` items to their primary interop assemblies (PIA) paths.
-ResolveFrameworkReferencesDesignTime          | ResolveFrameworkReferences         | Resolves `<FrameworkReference>` items to their paths.
-ResolvePackageDependenciesDesignTime          | ResolvePackageDependencies         | Resolves `<PackageReference>` items to their paths.
-CompileDesignTime (new project system)/Compile| Compile                            | Passes command-line arguments, `<Compile>` items and `<Analyzer>` items to the compiler in normal builds, or to the language service in design-time builds.
+Design-Time Target                             | Defined by | Description
+-----------------------------------------------|------------|------------------
+BuiltProjectOutputGroup                        | MSBuild    | 
+CollectAnalyzersDesignTime                     | DNPS       | Returns `Analyzer` items.
+CollectCentralPackageVersions                  | NuGet      | Returns `PackageVersion` items.
+CollectCopyToOutputDirectoryItemDesignTime     | DNPS       | Identifies items the project contributes to the output directory during build. Supports the Fast Up-to-date Check and Build Acceleration.
+CollectFrameworkReferences                     | NuGet      | Returns non-transitive `FrameworkReference` items. Supports package restore.
+CollectPackageDownloads                        | NuGet      | Returns `PackageDownload` items. Supports package restore.
+CollectPackageReferences                       | NuGet      | Returns `PackageReference` items. Supports package restore.
+CollectResolvedCompilationReferencesDesignTime | DNPS       |
+CollectResolvedSDKReferencesDesignTime         | SDK        |
+CollectSuggestedWorkloads                      | DNPS       |
+CollectUpToDateCheckBuiltDesignTime            | DNPS       | Supports the Fast Up-to-date Check.
+CollectUpToDateCheckInputDesignTime            | DNPS       | Supports the Fast Up-to-date Check.
+CollectUpToDateCheckOutputDesignTime           | DNPS       | Supports the Fast Up-to-date Check.
+CompileDesignTime                              | MSBuild    | Passes command-line arguments, `<Compile>` items and `<Analyzer>` items to the compiler in normal builds, or to the language service in design-time builds.
+GenerateSupportedTargetFrameworkAlias          | SDK        | Returns `SupportedTargetFrameworkAlias` items. Supports the Project Properties UI.
+ResolveAssemblyReferencesDesignTime            | MSBuild    | Resolves `Reference` items to their paths. Supports the Dependencies Node.
+ResolveComReferencesDesignTime                 | MSBuild    | Resolves `COMReference` items to their primary interop assemblies (PIA) paths. Supports the Dependencies Node.
+ResolveFrameworkReferencesDesignTime           | MSBuild    | Resolves `FrameworkReference` items to their paths. Supports the Dependencies Node.
+ResolvePackageDependenciesDesignTime           | MSBuild    | Resolves `PackageReference` items to their paths. Supports the Dependencies Node.
+ResolveProjectReferencesDesignTime2            | DNPS       | Resolves `ProjectReference` items to their output paths. Overrides `ResolveProjectReferencesDesignTime` from MSBuild's common targets. Supports the Dependencies Node.
 
-The design-time targets are typically simple wrappers around their normal target equivalents, with customized behavior for design-time builds. 
+Where DNPS is the .NET Project System (this repository).
 
 ## Designing targets for use in design-time builds
 


### PR DESCRIPTION
The table of targets that run during design-time builds was quite out of date. This change updates it and adds some more information.

None of the new entries have a "Normal target" equivalent, so I've removed that detail from the table.

Instead, I've added which component defines the target.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8751)