### PR TITLE
Improve Build Acceleration logging

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -1101,10 +1101,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
                 finally
                 {
-                    if (fileSystemOperations.IsAccelerationCandidate)
+                    if (fileSystemOperations.IsAccelerationCandidate && fileSystemOperations.IsAccelerationEnabled is null)
                     {
-                        // We didn't copy anything, but we did find a candidate for build acceleration.
-                        // Log this fact, to help users discover the build acceleration feature.
+                        // We didn't copy anything, but we did find a candidate for build acceleration,
+                        // and the project does not specify AccelerateBuildsInVisualStudio. Log a message to
+                        // let the user know that their project might benefit from Build Acceleration.
                         logger.Minimal(nameof(Resources.FUTD_AccelerationCandidate));
                     }
 


### PR DESCRIPTION
In order to aid discovery of the Build Acceleration feature, we log a message to the console when we believe that a project might be a candidate for acceleration.

This change ensures we only log the message when the project doesn't specify the AccelerateBuildsInVisualStudio property at all. This ensures that we don't suggest the feature for projects that have explicitly opted out of the feature.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8765)