### PR TITLE
Fix insertion description script for escaping backslashes

### DIFF
--- a/eng/scripts/GetInsertionPRDescription.ps1
+++ b/eng/scripts/GetInsertionPRDescription.ps1
@@ -82,6 +82,9 @@ $commitsString = "[ $($commits | Out-String) ]"
 # Replace the non-commit entry newline with a space.
 # This situation occurs when the commit body contains newlines in it (multiple paragraphs).
 $commitsClean = $commitsString -replace '(?<!\})\r\n',' '
+# Any remaining backslashes need to be escaped as they are part of the commit body/subject.
+# This ignores the natural newlines for the commit entries.
+$commitsClean = $commitsClean -replace '(?!\r\n)\\','\\'
 # Replace any double quotes with a backslash double quote.
 # This situation occurs when commit bodies or commit subjects contain double quotes in them.
 $commitsClean = $commitsClean -replace '"','\"'


### PR DESCRIPTION
Our current insertion failed because it couldn't parse the JSON from the insertion description script.
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7154640&view=results

That happened because this commit had backslashes in the commit description.
https://github.com/dotnet/project-system/commit/e259c18f9b5ccdaed5cd50c496fbcde9dd0e9b92

I've added a step to escape backslashes in commit entries. This ignores the correct newlines (\r\n) in the JSON text.

## Successful Insertion build
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7156938&view=logs&j=d58a6a34-8c26-597b-aa5c-b9a7e66e5056&t=9f7ffec7-f238-54a1-42ea-53b7cfb882d6

## Insertion Description
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/444149?_a=overview

![image](https://user-images.githubusercontent.com/17788297/210895607-a2c7e58a-b867-4d7b-b85d-0c90424641f1.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8769)