### PR TITLE
Ensure all JoinableTaskCollections have a DisplayName value

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreSharedJoinableTaskCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreSharedJoinableTaskCollection.cs
@@ -10,9 +10,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
     internal class PackageRestoreSharedJoinableTaskCollection : IJoinableTaskScope
     {
         [ImportingConstructor]
-        public PackageRestoreSharedJoinableTaskCollection(IProjectThreadingService threadingService) 
+        public PackageRestoreSharedJoinableTaskCollection(IProjectThreadingService threadingService)
         {
             JoinableTaskCollection = threadingService.JoinableTaskContext.CreateCollection();
+            JoinableTaskCollection.DisplayName = nameof(PackageRestoreSharedJoinableTaskCollection);
             JoinableTaskFactory = threadingService.JoinableTaskContext.CreateFactory(JoinableTaskCollection);
         }
 


### PR DESCRIPTION
This satisfies the threading guideline: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/24027/Threading?anchor=%E2%9C%94%EF%B8%8F-**do**-set-%60joinabletaskcollection.displayname%60-to-speed-up-dump-and-hang-analysis

There was only one call to JTC.CreateCollection in our repo that didn't specify a display name. This commit gives it one to assist in future debugging.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8771)