### PR TITLE
Fix namespace update setting based on prompt selection

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -181,6 +181,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
                 await settings.SetValueAsync(VsToolsOptions.OptionPromptNamespaceUpdate, !promptNamespaceUpdate, true);
 
+                // If the user checked the "Don't show again" checkbox, we need to set the namespace enable state based on their selection of Yes/No in the dialog.
+                if (promptNamespaceUpdate)
+                {
+                    await settings.SetValueAsync(VsToolsOptions.OptionEnableNamespaceUpdate, confirmation, isMachineLocal: true);
+                }
+
                 return confirmation;
             }
 


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1515450/

The prompt for "Sync namespace to folder structure?" allowed you to also select the "Don't show again" checkbox. However, the selection of `Yes` or `No` on this dialog did not correspond to the actual enability of the namespace update feature. Here, I check to see if the user has ticked that checkbox and set the setting (Tools -> Options -> Projects and Solutions -> General) to enable/disable it based on them selecting Yes/No.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8777)