### PR TITLE
Ensure continuation runs asynchronously

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     {
         private readonly IVsUIService<IVsSolution> _solution;
 
-        private TaskCompletionSource _loadedInHost = new();
+        private TaskCompletionSource _loadedInHost = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private IAsyncDisposable? _solutionEventsSubscription;
 
         [ImportingConstructor]


### PR DESCRIPTION
This prevents code from unintentionally running on the UI thread when waiting on the `TaskCompletionSource`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8779)