### PR TITLE
Remove stray space

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CompilerCommandLineArgs.xaml
@@ -5,7 +5,7 @@
       xmlns="http://schemas.microsoft.com/build/2009/properties">
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
-                ItemType="CompilerCommandLineArgs "
+                ItemType="CompilerCommandLineArgs"
                 MSBuildTarget="CompileDesignTime"
                 Persistence="ProjectFile"
                 SourceOfDefaultValue="AfterContext"


### PR DESCRIPTION
This doesn't seem to be causing any problems, but I can imagine it might surface a hard-to-diagnose bug one day.

Searching other `ItemType` attributes shows this is the only one with white space.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8780)