### PR TITLE
Up-to-date check doesn't require ordered snapshot data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -507,11 +507,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 var itemsByKindBySet = new Dictionary<string, Dictionary<string, HashSet<string>>>(BuildUpToDateCheck.SetNameComparer);
 
-                var after = projectChangeDescription.After.Items as IDataWithOriginalSource<KeyValuePair<string, IImmutableDictionary<string, string>>>;
-
-                Assumes.NotNull(after);
-
-                foreach ((string item, IImmutableDictionary<string, string> metadata) in after.SourceData)
+                foreach ((string item, IImmutableDictionary<string, string> metadata) in TryGetOrderedData(projectChangeDescription.After.Items))
                 {
                     if (metadataPredicate is not null && !metadataPredicate(metadata))
                     {
@@ -540,6 +536,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         pair => pair.Key,
                         pair => pair.Value.ToImmutableArray()),
                     BuildUpToDateCheck.SetNameComparer);
+
+                static IEnumerable<KeyValuePair<string, IImmutableDictionary<string, string>>> TryGetOrderedData(IImmutableDictionary<string, IImmutableDictionary<string, string>> items)
+                {
+                    if (items is IDataWithOriginalSource<KeyValuePair<string, IImmutableDictionary<string, string>>> dataWithOriginalSource)
+                        return dataWithOriginalSource.SourceData;
+
+                    // We couldn't obtain ordered items for some reason.
+                    // This is not a big problem, so just return the items in whatever order
+                    // the backing collection from CPS models them in.
+                    return items;
+                }
 
                 void AddItem(string setName, string kindName, string item)
                 {


### PR DESCRIPTION
Fixes [AB#1680186](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1680186)
Fixes [AB#1712009](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1712009)

CPS uses immutable dictionaries to model snapshot data. The default implementations of these reorder their items (by hash code, which is essentially random).

Snapshot data that comes from CPS builds is backed by interface `IDataWithOriginalSource<>` which allows access to data in the original order.

It turns out this interface is not available on data sourced from evaluation.

Because the FUTDC uses the `JointRuleSource` it receives a mix of both evaluation and build data. Therefore in a given snapshot we cannot guarantee item ordering.

This change attempts to use ordered data when available, but falls back to the random order when it needs to. The order of items here is not important. The original reason for adding ordered data here was to make unit tests stable across runs, where we check the logged output of data. Those tests will continue to run, as we stage mock data that always implements this interface.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8781)