### PR TITLE
Replace deprecated uses of RenameDocumentAsync/RenameSymbolAsync

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -17,6 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
     internal class FileMoveNotificationListener : IFileMoveNotificationListener
     {
+        private static readonly DocumentRenameOptions s_renameOptions = new();
+
         private readonly UnconfiguredProject _unconfiguredProject;
         private readonly IUserNotificationServices _userNotificationServices;
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
@@ -136,10 +138,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                     }
 
                     // This is a file item to another directory, it should only detect this a Update Namespace action.
-                    // TODO Upgrade this api to get rid of the exclamation sign
-#pragma warning disable CS0618 // Type or member is obsolete https://github.com/dotnet/project-system/issues/8591
-                    Renamer.RenameDocumentActionSet documentAction = await Renamer.RenameDocumentAsync(oldDocument, null!, documentFolders);
-#pragma warning restore CS0618 // Type or member is obsolete
+                    Renamer.RenameDocumentActionSet documentAction = await Renamer.RenameDocumentAsync(oldDocument, s_renameOptions, null, documentFolders);
 
                     if (documentAction.ApplicableActions.IsEmpty ||
                         documentAction.ApplicableActions.Any(a => !a.GetErrors().IsEmpty))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -20,6 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
     [AppliesTo(ProjectCapability.CSharpOrVisualBasicLanguageService)]
     internal partial class RenamerProjectTreeActionHandler : ProjectTreeActionHandlerBase
     {
+        private static readonly DocumentRenameOptions s_renameOptions = new();
+
         private readonly IEnvironmentOptions _environmentOptions;
         private readonly IUnconfiguredProjectVsServices _projectVsServices;
         private readonly IProjectThreadingService _threadingService;
@@ -166,9 +168,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             }
 
             // Get the list of possible actions to execute
-#pragma warning disable CS0618 // Type or member is obsolete https://github.com/dotnet/project-system/issues/8591
-            Renamer.RenameDocumentActionSet documentRenameResult = await Renamer.RenameDocumentAsync(oldDocument, newFileWithExtension);
-#pragma warning restore CS0618 // Type or member is obsolete
+            Renamer.RenameDocumentActionSet documentRenameResult = await Renamer.RenameDocumentAsync(oldDocument, s_renameOptions, newFileWithExtension);
 
             // Check if there are any symbols that need to be renamed
             if (documentRenameResult.ApplicableActions.IsEmpty)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/RoslynServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/RoslynServices.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Rename;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 
-using RoslynRenamer = Microsoft.CodeAnalysis.Rename;
 using Workspace = Microsoft.CodeAnalysis.Workspace;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
@@ -11,6 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     [Export(typeof(IRoslynServices))]
     internal class RoslynServices : IRoslynServices
     {
+        private static readonly SymbolRenameOptions s_renameOptions = new();
         private readonly IProjectThreadingService _threadingService;
 
         [ImportingConstructor]
@@ -25,19 +26,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [ImportMany]
         protected OrderPrecedenceImportCollection<ISyntaxFactsService> SyntaxFactsServicesImpl { get; }
 
-        private ISyntaxFactsService? SyntaxFactsService
-        {
-            get
-            {
-                return SyntaxFactsServicesImpl.FirstOrDefault()?.Value;
-            }
-        }
+        private ISyntaxFactsService? SyntaxFactsService => SyntaxFactsServicesImpl.FirstOrDefault()?.Value;
 
         public Task<Solution> RenameSymbolAsync(Solution solution, ISymbol symbol, string newName, CancellationToken token = default)
         {
-#pragma warning disable CS0618 // Type or member is obsolete https://github.com/dotnet/project-system/issues/8591
-            return RoslynRenamer.Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Workspace.Options, token);
-#pragma warning restore CS0618 // Type or member is obsolete
+            return Renamer.RenameSymbolAsync(solution, symbol, s_renameOptions, newName, token);
         }
 
         public bool ApplyChangesToSolution(Workspace ws, Solution renamedSolution)


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/8591

Replaces the use of the deprecated overload for `RenameDocumentAsync`/`RenameSymbolAsync`. The new overload takes in a `DocumentRenameOptions`/`SymbolRenameOptions`. I looked at the code in Roslyn and these options are simply defaulted (new instance with no parameters) in our current use of the deprecated overload. Given that, for each of our classes, I simply made a static default field for the class to use.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8784)