### PR TITLE
Fix a property name

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -32,7 +32,7 @@
                 HasConfigurationCondition="True" />
   </Rule.DataSource>
 
-  <StringProperty Name="Output path"
+  <StringProperty Name="OutputPath"
                   DisplayName="Build output path"
                   Category="General"
                   Subtype="directory" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Vlastní konstanty</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Cesta k výstupu sestavení</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Benutzerdefinierte Konstanten</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Buildausgabepfad</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Constantes personalizadas</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Ruta de acceso de salida de la compilación</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Constantes personnalisées</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Créer un chemin de sortie</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Costanti personalizzate</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Percorso dell’output di compilazione</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -387,9 +387,9 @@
         <target state="translated">カスタム定数</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">ビルド出力パス</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -387,9 +387,9 @@
         <target state="translated">사용자 지정 상수</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">빌드 출력 경로</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Stałe niestandardowe</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Ścieżka wyjściowa kompilacji</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Constantes personalizadas</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Construir caminho de saída</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Пользовательские константы</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Выходной путь сборки</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -387,9 +387,9 @@
         <target state="translated">Özel sabitler</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">Derleme çıkış yolu</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -387,9 +387,9 @@
         <target state="translated">自定义常量</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">生成输出路径</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -387,9 +387,9 @@
         <target state="translated">自訂常數</target>
         <note />
       </trans-unit>
-      <trans-unit id="StringProperty|Output path|DisplayName">
+      <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
-        <target state="translated">建置輸出路徑</target>
+        <target state="new">Build output path</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|PostBuildEvent|Description">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Rules/MiscellaneousRuleTests.cs
@@ -39,7 +39,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
 
             XElement rule = LoadXamlRule(fullPath);
 
-            foreach (var property in GetProperties(rule))
+            foreach (var property in 
+                GetProperties(rule))
             {
                 Assert.False(
                     IsVisible(property),
@@ -214,6 +215,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             }
         }
 
+        [Theory]
+        [MemberData(nameof(GetAllRules))]
+        public void PropertyNamesMustNotContainSpaces(string ruleName, string fullPath)
+        {
+            // While MSBuild properties may not contain spaces in their names this restriction doesn't necessarily
+            // apply when the property in the Rule connects to a non-MSBuild DataSource. Currently none of our
+            // properties have names with spaces, so for the moment we'll just keep this test simple.
+            
+            var root = LoadXamlRule(fullPath);
+
+            foreach (var property in GetProperties(root))
+            {
+                var name = property.Attribute("Name")?.Value;
+
+                Assert.NotNull(name);
+                Assert.False(name.Contains(" "), $"Property name '{name}' in rule '{ruleName}' contains a space. This is likely to lead to a runtime exception when accessing the property");
+            }
+        }
+    
         public static IEnumerable<object[]> GetMiscellaneousRules()
         {
             return Project(GetRules(""));


### PR DESCRIPTION
Fixes #8793.

On the VB "Build" property page we have a property named "Output path". Note that is not the text displayed to the user, but the actual ID of the property on the page. When the user attempts to set this property they'll get exceptions from MSBuild complaining that MSBuild property names cannot include spaces; this is because the property name on the page is used as-is for the property name in the underlying MSBuild file.

Here we fix the property name on the .xaml file, and add a unit test that scans all our .xaml files and verify that none of the property names contain spaces.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8795)