### PR TITLE
Reduce exception message size

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FaultExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FaultExtensions.cs
@@ -200,13 +200,22 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
             return block.Completion.ContinueWith(_ =>
             {
+                Exception exception = block.Completion.Exception;
+
+                // If the exception is an aggregate over a single inner exception, take the inner message
+                string innerMessage = exception switch
+                {
+                    AggregateException { InnerExceptions: { Count: 1 } inner } => inner[0].Message,
+                    _ => exception.Message
+                };
+
                 var dataSourceException = new AggregateException(
                     string.Format(
                         CultureInfo.CurrentCulture,
                         Resources.DataFlowFaults,
                         block.ToString(),
-                        block.Completion.Exception),
-                    block.Completion.Exception);
+                        innerMessage),
+                    exception);
 
                 try
                 {


### PR DESCRIPTION
Our fault handling logic wraps exceptions raised on Dataflow blocks and reports them via `IProjectFaultHandlerService`.

The previous implementation was constructing that wrapper exception such that its `Message` contained the full `ToString()` of the inner exception. That inner string can be enormous for deep stacks, or deeply nested chains of exceptions (or both).

Lifeng observed instances of this exception string crowding the Large Object Heap, and this fix should address that by simplifying the message of the wrapper exception.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8797)