### PR TITLE
Remove explicit build acceleration overrides

### DIFF
--- a/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.csproj
+++ b/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.csproj
@@ -8,11 +8,6 @@
 
   <Import Project="..\..\eng\imports\VisualStudio.props" />
 
-  <PropertyGroup>
-    <!-- This VSSDK project has custom build steps and should not be accelerated. -->
-    <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
-  </PropertyGroup>
-
   <ItemGroup>
     <!-- Depend on projects producing XAML rules included in this Willow package -->
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />

--- a/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -15,9 +15,6 @@
     <ExtensionInstallationFolder>Microsoft\ManagedProjectSystem</ExtensionInstallationFolder>
     <TargetVsixContainerName>$(AssemblyName).vsix</TargetVsixContainerName>
     <TargetVsixContainer>$(VisualStudioSetupInsertionPath)$(TargetVsixContainerName)</TargetVsixContainer>
-
-    <!-- This VSSDK project has custom build steps and should not be accelerated. -->
-    <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <!-- Local properties -->

--- a/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -13,9 +13,6 @@
     <ExtensionInstallationFolder>Microsoft\VisualStudio\Editors</ExtensionInstallationFolder>
     <TargetVsixContainerName>$(AssemblyName).vsix</TargetVsixContainerName>
     <TargetVsixContainer>$(VisualStudioSetupInsertionPath)$(TargetVsixContainerName)</TargetVsixContainer>
-
-    <!-- This VSSDK project has custom build steps and should not be accelerated. -->
-    <AccelerateBuildsInVisualStudio>false</AccelerateBuildsInVisualStudio>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Our common targets now specify these for all builds within Visual Studio. We don't need to opt-out explicitly here anymore.

https://github.com/dotnet/project-system/blob/d03b401d72a79f3d970cfe33e51a0adf41e03132/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L28-L29

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8800)