### PR TITLE
Add documentation link to verbose log output

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This project appears to be a candidate for build acceleration. To opt in, set the &apos;AccelerateBuildsInVisualStudio&apos; MSBuild property to &apos;true&apos;..
+        ///   Looks up a localized string similar to This project appears to be a candidate for build acceleration. To opt in, set the &apos;AccelerateBuildsInVisualStudio&apos; MSBuild property to &apos;true&apos;. See https://aka.ms/vs-build-acceleration..
         /// </summary>
         internal static string FUTD_AccelerationCandidate {
             get {
@@ -169,7 +169,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Build acceleration is disabled for this project via the &apos;AccelerateBuildsInVisualStudio&apos; MSBuild property..
+        ///   Looks up a localized string similar to Build acceleration is disabled for this project via the &apos;AccelerateBuildsInVisualStudio&apos; MSBuild property. See https://aka.ms/vs-build-acceleration..
         /// </summary>
         internal static string FUTD_AccelerationDisabledForProject {
             get {
@@ -412,7 +412,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copying {0} files to accelerate build:.
+        ///   Looks up a localized string similar to Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):.
         /// </summary>
         internal static string FUTD_CopyingFilesToAccelerateBuild_1 {
             get {
@@ -745,7 +745,7 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Build acceleration data is unavailable for project with target &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Build acceleration data is unavailable for project with target &apos;{0}&apos;. See https://aka.ms/vs-build-acceleration..
         /// </summary>
         internal static string FUTDC_AccelerationDataMissingForProject_1 {
             get {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -423,7 +423,7 @@ This project was loaded using the wrong project type, likely as a result of rena
     <comment>{0} and {1} are file paths.</comment>
   </data>
   <data name="FUTD_CopyingFilesToAccelerateBuild_1" xml:space="preserve">
-    <value>Copying {0} files to accelerate build:</value>
+    <value>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</value>
     <comment>{0} is an integer.</comment>
   </data>
   <data name="FUTD_FromTo_2" xml:space="preserve">
@@ -442,18 +442,18 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>Input marker does not exist.</value>
   </data>
   <data name="FUTD_AccelerationDisabledForProject" xml:space="preserve">
-    <value>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</value>
+    <value>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</value>
     <comment>Do not translate AccelerateBuildsInVisualStudio.</comment>
   </data>
   <data name="FUTD_AccelerationCandidate" xml:space="preserve">
-    <value>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</value>
+    <value>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</value>
     <comment>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</comment>
   </data>
   <data name="FUTD_AccelerationDisabledCopyItemsIncomplete" xml:space="preserve">
     <value>Build acceleration is not available for this project because not all transitively referenced projects have provided acceleration data.</value>
   </data>
   <data name="FUTDC_AccelerationDataMissingForProject_1" xml:space="preserve">
-    <value>Build acceleration data is unavailable for project with target '{0}'.</value>
+    <value>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</value>
     <comment>{0} is a file path.</comment>
   </data>
   <data name="DiagnosticLevel_None" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Data akcelerace sestavení nejsou pro projekt s cílem {0} k dispozici.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Data akcelerace sestavení nejsou pro projekt s cílem {0} k dispozici.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Zdá se, že tento projekt je kandidátem na akceleraci sestavení. Pro přihlášení nastavte vlastnost MSBuild AccelerateBuildsInVisualStudio na hodnotu true.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Zdá se, že tento projekt je kandidátem na akceleraci sestavení. Pro přihlášení nastavte vlastnost MSBuild AccelerateBuildsInVisualStudio na hodnotu true.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">Akcelerace sestavení je pro tento projekt zakázaná prostřednictvím vlastnosti MSBuild AccelerateBuildsInVisualStudio.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Akcelerace sestavení je pro tento projekt zakázaná prostřednictvím vlastnosti MSBuild AccelerateBuildsInVisualStudio.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Kopírování {0} souborů pro zrychlení sestavení:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Kopírování {0} souborů pro zrychlení sestavení:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Buildbeschleunigungsdaten sind für das Projekt mit dem Ziel "{0}" nicht verfügbar.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Buildbeschleunigungsdaten sind für das Projekt mit dem Ziel "{0}" nicht verfügbar.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Dieses Projekt scheint ein Kandidat für die Buildbeschleunigung zu sein. Um sich zu entscheiden, legen Sie die MSBuild-Eigenschaft "AccelerateBuildsInVisualStudio" auf "true" fest.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Dieses Projekt scheint ein Kandidat für die Buildbeschleunigung zu sein. Um sich zu entscheiden, legen Sie die MSBuild-Eigenschaft "AccelerateBuildsInVisualStudio" auf "true" fest.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">Die Buildbeschleunigung ist für dieses Projekt über die MSBuild-Eigenschaft "AccelerateBuildsInVisualStudio" deaktiviert.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Die Buildbeschleunigung ist für dieses Projekt über die MSBuild-Eigenschaft "AccelerateBuildsInVisualStudio" deaktiviert.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">{0} Dateien werden kopiert, um den Buildvorgang zu beschleunigen:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">{0} Dateien werden kopiert, um den Buildvorgang zu beschleunigen:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Los datos de aceleración de compilación no están disponibles para el proyecto con el destino '{0}'.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Los datos de aceleración de compilación no están disponibles para el proyecto con el destino '{0}'.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Este proyecto parece ser candidato para la aceleración de compilación. Para participar, establezca la propiedad 'AccelerateBuildsInVisualStudio' de MSBuild en 'true'.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Este proyecto parece ser candidato para la aceleración de compilación. Para participar, establezca la propiedad 'AccelerateBuildsInVisualStudio' de MSBuild en 'true'.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">La aceleración de compilación está deshabilitada para este proyecto a través de la propiedad 'AccelerateBuildsInVisualStudio' de MSBuild.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">La aceleración de compilación está deshabilitada para este proyecto a través de la propiedad 'AccelerateBuildsInVisualStudio' de MSBuild.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Copiando {0} archivos para acelerar la compilación:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Copiando {0} archivos para acelerar la compilación:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Les données d’accélération de build ne sont pas disponibles pour le projet avec la cible « {0} ».</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Les données d’accélération de build ne sont pas disponibles pour le projet avec la cible « {0} ».</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Ce projet semble être un candidat pour l’accélération de build. Pour y participer, définissez la propriété MSBuild « AccelerateBuildsInVisualStudio » sur « true ».</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Ce projet semble être un candidat pour l’accélération de build. Pour y participer, définissez la propriété MSBuild « AccelerateBuildsInVisualStudio » sur « true ».</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">L’accélération de build est désactivée pour ce projet via la propriété MSBuilds « AccelerateBuildsInVisualStudio ».</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">L’accélération de build est désactivée pour ce projet via la propriété MSBuilds « AccelerateBuildsInVisualStudio ».</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Copie des fichiers {0} pour accélérer la génération :</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Copie des fichiers {0} pour accélérer la génération :</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">I dati di accelerazione della compilazione non sono disponibili per il progetto con destinazione '{0}'.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">I dati di accelerazione della compilazione non sono disponibili per il progetto con destinazione '{0}'.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Questo progetto sembra un candidato per l'accelerazione della compilazione. Per acconsentire esplicitamente, impostare la proprietà 'AccelerateBuildsInVisualStudio' di MSBuild su 'true'.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Questo progetto sembra un candidato per l'accelerazione della compilazione. Per acconsentire esplicitamente, impostare la proprietà 'AccelerateBuildsInVisualStudio' di MSBuild su 'true'.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">L'accelerazione della compilazione è disabilitata per questo progetto tramite la proprietà MSBuild 'AccelerateBuildsInVisualStudio'.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">L'accelerazione della compilazione è disabilitata per questo progetto tramite la proprietà MSBuild 'AccelerateBuildsInVisualStudio'.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Copia dei file {0} per accelerare la compilazione:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Copia dei file {0} per accelerare la compilazione:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">ビルド アクセラレーション データは、ターゲット '{0}' のプロジェクトでは利用できません。</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">ビルド アクセラレーション データは、ターゲット '{0}' のプロジェクトでは利用できません。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">このプロジェクトは、ビルド アクセラレーションの候補のようです。オプトインするには、'AccelerateBuildsInVisualStudio' MSBuild プロパティを 'true' に設定します。</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">このプロジェクトは、ビルド アクセラレーションの候補のようです。オプトインするには、'AccelerateBuildsInVisualStudio' MSBuild プロパティを 'true' に設定します。</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">'AccelerateBuildsInVisualStudio' MSBuild プロパティを介して、このプロジェクトのビルド アクセラレーションが無効になっています。</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">'AccelerateBuildsInVisualStudio' MSBuild プロパティを介して、このプロジェクトのビルド アクセラレーションが無効になっています。</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">ビルドを高速化するために {0} 個のファイルをコピーしています:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">ビルドを高速化するために {0} 個のファイルをコピーしています:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">대상이 '{0}'인 프로젝트에는 빌드 가속 데이터를 사용할 수 없습니다.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">대상이 '{0}'인 프로젝트에는 빌드 가속 데이터를 사용할 수 없습니다.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">이 프로젝트는 빌드 가속을 위한 후보인 것 같습니다. 옵트인하려면 'AccelerateBuildsInVisualStudio' MSBuild 속성을 'true'로 설정하세요.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">이 프로젝트는 빌드 가속을 위한 후보인 것 같습니다. 옵트인하려면 'AccelerateBuildsInVisualStudio' MSBuild 속성을 'true'로 설정하세요.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">'AccelerateBuildsInVisualStudio' MSBuild 속성을 사용하는 이 프로젝트에 빌드 가속을 사용할 수 없습니다.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">'AccelerateBuildsInVisualStudio' MSBuild 속성을 사용하는 이 프로젝트에 빌드 가속을 사용할 수 없습니다.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">빌드 가속을 위해 {0}개의 파일을 복사하는 중:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">빌드 가속을 위해 {0}개의 파일을 복사하는 중:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Dane przyspieszenia kompilacji są niedostępne dla projektu z elementem docelowym „{0}”.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Dane przyspieszenia kompilacji są niedostępne dla projektu z elementem docelowym „{0}”.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Ten projekt wydaje się być kandydatem do przyspieszenia kompilacji. Aby wyrazić zgodę, ustaw właściwość MSBuild „AccelerateBuildsInVisualStudio” na wartość „true”.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Ten projekt wydaje się być kandydatem do przyspieszenia kompilacji. Aby wyrazić zgodę, ustaw właściwość MSBuild „AccelerateBuildsInVisualStudio” na wartość „true”.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">Przyspieszanie kompilacji jest wyłączone dla tego projektu za pomocą właściwości MSBuild „AccelerateBuildsInVisualStudio”.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Przyspieszanie kompilacji jest wyłączone dla tego projektu za pomocą właściwości MSBuild „AccelerateBuildsInVisualStudio”.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Kopiowanie {0} plików, aby przyspieszyć kompilację:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Kopiowanie {0} plików, aby przyspieszyć kompilację:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Os dados de aceleração de compilação não estão disponíveis para o projeto com destino '{0}'.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Os dados de aceleração de compilação não estão disponíveis para o projeto com destino '{0}'.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Este projeto parece ser um candidato para aceleração de construção. Para aceitar, defina a propriedade MSBuild 'AccelerateBuildsInVisualStudio' como 'verdadeiro'.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Este projeto parece ser um candidato para aceleração de construção. Para aceitar, defina a propriedade MSBuild 'AccelerateBuildsInVisualStudio' como 'verdadeiro'.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">A aceleração de compilação está desabilitada para este projeto por meio da propriedade MSBuild 'AccelerateBuildsInVisualStudio'.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">A aceleração de compilação está desabilitada para este projeto por meio da propriedade MSBuild 'AccelerateBuildsInVisualStudio'.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Copiando arquivos {0} para acelerar a compilação:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Copiando arquivos {0} para acelerar a compilação:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Данные ускорения построения недоступны для проекта с целевым объектом "{0}".</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Данные ускорения построения недоступны для проекта с целевым объектом "{0}".</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Этот проект является кандидатом на ускорение построения. Чтобы согласиться, задайте для свойства MSBuild "AccelerateBuildsInVisualStudio" значение "true".</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Этот проект является кандидатом на ускорение построения. Чтобы согласиться, задайте для свойства MSBuild "AccelerateBuildsInVisualStudio" значение "true".</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">Ускорение построения отключено для этого проекта с помощью свойства MSBuild "AccelerateBuildsInVisualStudio".</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Ускорение построения отключено для этого проекта с помощью свойства MSBuild "AccelerateBuildsInVisualStudio".</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Копирование файлов ({0}) для ускорения построения:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Копирование файлов ({0}) для ускорения построения:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">Derleme hızlandırma verileri, '{0}' hedefi olan proje için kullanılamıyor.</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Derleme hızlandırma verileri, '{0}' hedefi olan proje için kullanılamıyor.</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">Bu proje, derleme hızlandırma için bir aday gibi görünüyor. Kabul etmek için 'AccelerateBuildsInVisualStudio' MSBuild özelliğini “true” olarak ayarlayın.</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Bu proje, derleme hızlandırma için bir aday gibi görünüyor. Kabul etmek için 'AccelerateBuildsInVisualStudio' MSBuild özelliğini “true” olarak ayarlayın.</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">Derleme hızlandırma, 'AccelerateBuildsInVisualStudio' MSBuild özelliği aracılığıyla bu proje için devre dışı bırakıldı.</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">Derleme hızlandırma, 'AccelerateBuildsInVisualStudio' MSBuild özelliği aracılığıyla bu proje için devre dışı bırakıldı.</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">Derlemeyi hızlandırmak için {0} dosya kopyalanıyor:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">Derlemeyi hızlandırmak için {0} dosya kopyalanıyor:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">对于目标为“{0}”的项目，生成加速数据不可用。</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">对于目标为“{0}”的项目，生成加速数据不可用。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">此项目似乎是生成加速的候选项。若要选择加入，请将“AccelerateBuildsInVisualStudio”MSBuild 属性设置为“true”。</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">此项目似乎是生成加速的候选项。若要选择加入，请将“AccelerateBuildsInVisualStudio”MSBuild 属性设置为“true”。</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">通过“AccelerateBuildsInVisualStudio”MSBuild 属性禁用此项目的生成加速。</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">通过“AccelerateBuildsInVisualStudio”MSBuild 属性禁用此项目的生成加速。</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">正在复制 {0} 文件以加速生成:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">正在复制 {0} 文件以加速生成:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -23,8 +23,8 @@
         <note>Indicates that a diagnostic (i.e. a compiler warning) should be kept as a warning rather than disabled or promoted to an error.</note>
       </trans-unit>
       <trans-unit id="FUTDC_AccelerationDataMissingForProject_1">
-        <source>Build acceleration data is unavailable for project with target '{0}'.</source>
-        <target state="translated">具有目標 '{0}' 的專案無法使用建置加速資料。</target>
+        <source>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">具有目標 '{0}' 的專案無法使用建置加速資料。</target>
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTDC_CheckingCopyItemsForProject_1">
@@ -33,8 +33,8 @@
         <note>{0} is a file path.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationCandidate">
-        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.</source>
-        <target state="translated">此專案似乎是建置加速的候選項目。若要加入，請將 'AccelerateBuildsInVisualStudio' MSBuild 屬性設定為 'true'。</target>
+        <source>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">此專案似乎是建置加速的候選項目。若要加入，請將 'AccelerateBuildsInVisualStudio' MSBuild 屬性設定為 'true'。</target>
         <note>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledCopyItemsIncomplete">
@@ -43,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="FUTD_AccelerationDisabledForProject">
-        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.</source>
-        <target state="translated">已透過 'AccelerateBuildsInVisualStudio' MSBuild 屬性停用此專案的建置加速。</target>
+        <source>Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="needs-review-translation">已透過 'AccelerateBuildsInVisualStudio' MSBuild 屬性停用此專案的建置加速。</target>
         <note>Do not translate AccelerateBuildsInVisualStudio.</note>
       </trans-unit>
       <trans-unit id="FUTD_AddingInputReferenceCopyMarkers">
@@ -178,8 +178,8 @@
         <note>Do not translate CopyToOutputDirectory="Always". {0} and {3} are file paths. {1} and {4} are date times. {2} and {5} are byte counts.</note>
       </trans-unit>
       <trans-unit id="FUTD_CopyingFilesToAccelerateBuild_1">
-        <source>Copying {0} files to accelerate build:</source>
-        <target state="translated">正在複製 {0} 個檔案以加速建置:</target>
+        <source>Copying {0} files to accelerate build (https://aka.ms/vs-build-acceleration):</source>
+        <target state="needs-review-translation">正在複製 {0} 個檔案以加速建置:</target>
         <note>{0} is an integer.</note>
       </trans-unit>
       <trans-unit id="FUTD_CriticalBuildTasksRunning">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -754,7 +754,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertUpToDateAsync(
                     $"""
-                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.
+                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Comparing timestamps of copy marker inputs and outputs:
@@ -825,7 +825,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                    $"""
-                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.
+                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Comparing timestamps of copy marker inputs and outputs:
@@ -847,7 +847,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         Adding input reference copy markers:
                             Reference1OriginalPath
                     Input marker 'Reference1OriginalPath' is newer ({ToLocalTime(originalTime)}) than output marker 'C:\Dev\Solution\Project\OutputMarker' ({ToLocalTime(outputTime)}), not up-to-date.
-                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.
+                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.
                     """,
                     "InputMarkerNewerThanOutputMarker");
             }
@@ -1601,7 +1601,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath2}'
                                 Destination {ToLocalTime(destinationTime)}: '{destinationPath2}'
                                 Remembering the need to copy file '{sourcePath2}' to '{destinationPath2}'.
-                    Copying 2 files to accelerate build:
+                    Copying 2 files to accelerate build (https://aka.ms/vs-build-acceleration):
                         From '{sourcePath1}' to '{destinationPath1}'.
                         From '{sourcePath2}' to '{destinationPath2}'.
                     Build acceleration copied 2 files.
@@ -1612,7 +1612,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
-                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.
+                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1636,7 +1636,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath1}'
                                 Destination {ToLocalTime(destinationTime)}: '{destinationPath1}'
                     Item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath1}' is newer than destination '{destinationPath1}', not up-to-date.
-                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.
+                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.
                     """,
                     "CopyToOutputDirectorySourceNewer");
             }
@@ -1687,7 +1687,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath2}'
                                 Destination {ToLocalTime(destinationTime)}: '{destinationPath2}'
                                 Remembering the need to copy file '{sourcePath2}' to '{destinationPath2}'.
-                    Copying 2 files to accelerate build:
+                    Copying 2 files to accelerate build (https://aka.ms/vs-build-acceleration):
                         From '{sourcePath1}' to '{destinationPath1}'.
                         From '{sourcePath2}' to '{destinationPath2}'.
                     Build acceleration copied 2 files.
@@ -1698,7 +1698,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
-                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.
+                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1722,7 +1722,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath1}'
                                 Destination {ToLocalTime(destinationTime)}: '{destinationPath1}'
                     Item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath1}' is newer than destination '{destinationPath1}', not up-to-date.
-                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.
+                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.
                     """,
                     "CopyToOutputDirectorySourceNewer");
             }
@@ -1776,7 +1776,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath2}'
                                 Destination {ToLocalTime(destinationTime)}: '{destinationPath2}'
                                 Remembering the need to copy file '{sourcePath2}' to '{destinationPath2}'.
-                    Copying 2 files to accelerate build:
+                    Copying 2 files to accelerate build (https://aka.ms/vs-build-acceleration):
                         From '{sourcePath1}' to '{destinationPath1}'.
                         From '{sourcePath2}' to '{destinationPath2}'.
                     Build acceleration copied 2 files.
@@ -1787,7 +1787,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
-                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.
+                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1811,7 +1811,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath1}'
                                 Destination {ToLocalTime(destinationTime)}: '{destinationPath1}'
                     Item with CopyToOutputDirectory="PreserveNewest" source '{sourcePath1}' is newer than destination '{destinationPath1}', not up-to-date.
-                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.
+                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.
                     """,
                     "CopyToOutputDirectorySourceNewer");
             }
@@ -1892,7 +1892,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath2}'
                                 Destination '{destinationPath2}' does not exist.
                                 Remembering the need to copy file '{sourcePath2}' to '{destinationPath2}'.
-                    Copying 2 files to accelerate build:
+                    Copying 2 files to accelerate build (https://aka.ms/vs-build-acceleration):
                         From '{sourcePath1}' to '{destinationPath1}'.
                         From '{sourcePath2}' to '{destinationPath2}'.
                     Build acceleration copied 2 files.
@@ -1903,7 +1903,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
-                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property.
+                    Build acceleration is disabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1927,7 +1927,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                                 Source      {ToLocalTime(sourceTime)}: '{sourcePath1}'
                                 Destination '{destinationPath1}' does not exist.
                     Destination '{destinationPath1}' does not exist, not up-to-date.
-                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'.
+                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.
                     """,
                     "CopyToOutputDirectoryDestinationNotFound");
             }


### PR DESCRIPTION
Fixes #8799

These URLs guide users towards documentation for the Build Acceleration feature.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8806)