### PR TITLE
Use CallerArgumentExpression to simplify validation 

### DIFF
--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -46,7 +46,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Threading"                                       Version="17.4.16-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.4.16-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.4.0-preview-3-32908-042" />
-    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.0.64" />
+    <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.6.4-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
     <PackageReference Update="System.Threading.Tasks.Dataflow"                                        Version="6.0.0" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabRenderer.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/ProjectDesignerTabRenderer.vb
@@ -121,7 +121,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' </summary>
         ''' <param name="owner">The ProjectDesignerTabControl control which owns and contains this control.</param>
         Public Sub New(owner As ProjectDesignerTabControl)
-            Requires.NotNull(owner, NameOf(owner))
+            Requires.NotNull(owner)
 
             _owner = owner
 

--- a/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/ApplicationDesigner/SpecialFileCustomViewProvider.vb
@@ -144,7 +144,7 @@ Namespace Microsoft.VisualStudio.Editors.ApplicationDesigner
         ''' <param name="SpecialFileId">The special file ID for IVsProjectSpecialFiles that will be used to
         '''   obtain the document filename</param>
         Public Sub New(DesignerView As ApplicationDesignerView, SpecialFileId As Integer)
-            Requires.NotNull(DesignerView, NameOf(DesignerView))
+            Requires.NotNull(DesignerView)
 
             _specialFileId = SpecialFileId
             _designerView = DesignerView

--- a/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/Common/Utils.vb
@@ -699,8 +699,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             Private Shared ReadOnly s_knownTypes As Type() = {GetType(Size)}
 
             Public Shared Sub Serialize(stream As Stream, value As Object)
-                Requires.NotNull(stream, NameOf(stream))
-                Requires.NotNull(value, NameOf(value))
+                Requires.NotNull(stream)
+                Requires.NotNull(value)
                 Using writer As New BinaryWriter(stream, Encoding.UTF8, leaveOpen:=True)
                     Dim valueType = value.GetType()
                     writer.Write(valueType.AssemblyQualifiedName)
@@ -710,7 +710,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesCommon
             End Sub
 
             Public Shared Function Deserialize(stream As Stream) As Object
-                Requires.NotNull(stream, NameOf(stream))
+                Requires.NotNull(stream)
                 If stream.Length = 0 Then
                     Throw New SerializationException("The stream contains no content.")
                 End If

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseDialog.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/BaseDialog.vb
@@ -56,7 +56,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         '**************************************************************************
         Public Sub New(ServiceProvider As IServiceProvider)
             Debug.Assert(ServiceProvider IsNot Nothing, "ServiceProvider is NULL.")
-            Requires.NotNull(ServiceProvider, NameOf(ServiceProvider))
+            Requires.NotNull(ServiceProvider)
 
             _serviceProvider = ServiceProvider
 

--- a/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/DesignerFramework/SourceCodeControlManager.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' </summary>
         ''' <param name="sp"></param>
         Public Sub New(sp As IServiceProvider, Hierarchy As IVsHierarchy)
-            Requires.NotNull(sp, NameOf(sp))
+            Requires.NotNull(sp)
 
             _serviceProvider = sp
         End Sub
@@ -132,8 +132,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="fileReloaded">Out: Set to true if one or more files were reloaded...</param>
         ''' <remarks>Disallows in memory edits for IVsQueryEditQuerySave2</remarks>
         Public Shared Function QueryEditableFiles(sp As IServiceProvider, files As List(Of String), throwOnFailure As Boolean, checkOnly As Boolean, ByRef fileReloaded As Boolean, Optional allowInMemoryEdits As Boolean = True, Optional allowFileReload As Boolean = True) As Boolean
-            Requires.NotNull(sp, NameOf(sp))
-            Requires.NotNull(files, NameOf(files))
+            Requires.NotNull(sp)
+            Requires.NotNull(files)
 
             If files.Count = 0 Then
                 Return True
@@ -243,8 +243,8 @@ Namespace Microsoft.VisualStudio.Editors.AppDesDesignerFramework
         ''' <param name="files">The set of files to check</param>
         ''' <param name="throwOnFailure">Should we throw if the save fails?</param>
         Public Shared Function QuerySave(sp As IServiceProvider, files As List(Of String), throwOnFailure As Boolean) As Boolean
-            Requires.NotNull(sp, NameOf(sp))
-            Requires.NotNull(files, NameOf(files))
+            Requires.NotNull(sp)
+            Requires.NotNull(files)
 
             If files.Count = 0 Then
                 Return True

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/MultipleValuesStore.vb
@@ -31,8 +31,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="SelectedConfigName">The selected configuration in the drop-down combobox.  Empty string indicates "All Configurations".</param>
         ''' <param name="SelectedPlatformName">The selected platform in the drop-down combobox.  Empty string indicates "All Platforms".</param>
         Public Sub New(VsCfgProvider As IVsCfgProvider2, Objects() As Object, Values() As Object, SelectedConfigName As String, SelectedPlatformName As String)
-            Requires.NotNull(Values, NameOf(Values))
-            Requires.NotNull(Objects, NameOf(Objects))
+            Requires.NotNull(Values)
+            Requires.NotNull(Objects)
 
             If Values.Length <> Objects.Length Then
                 Debug.Fail("Bad array length returned from GetPropertyMultipleValues()")

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Stream">The stream to load from.</param>
         ''' <returns>The loaded store for resources.</returns>
         Public Overrides Function LoadStore(Stream As Stream) As SerializationStore
-            Requires.NotNull(Stream, NameOf(Stream))
+            Requires.NotNull(Stream)
 
             Return PropertyPageSerializationStore.Load(Stream)
         End Function
@@ -70,8 +70,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Value">The object (must be a Resource instance) to serialize into the store.</param>
         Public Overrides Sub Serialize(Store As SerializationStore, Value As Object)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Value, NameOf(Value))
+            Requires.NotNull(Store)
+            Requires.NotNull(Value)
 
             If TypeOf Value IsNot PropPageDesignerRootComponent Then
                 Throw AppDesCommon.CreateArgumentException(NameOf(Value))
@@ -100,9 +100,9 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="OwningObject">The object (must be a Resource instance) whose property (member) you are trying to serialize into the store.</param>
         ''' <param name="Member">The property whose value needs to be serialized into the store.</param>
         Public Overrides Sub SerializeMember(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(OwningObject, NameOf(OwningObject))
-            Requires.NotNull(Member, NameOf(Member))
+            Requires.NotNull(Store)
+            Requires.NotNull(OwningObject)
+            Requires.NotNull(Member)
 
             Dim OwningResource As PropPageDesignerRootComponent = TryCast(OwningObject, PropPageDesignerRootComponent)
             If OwningObject Is Nothing Then
@@ -145,7 +145,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Store">The store to serialize into.</param>
         ''' <returns>The set of components that were deserialized.</returns>
         Public Overrides Function Deserialize(Store As SerializationStore) As ICollection
-            Requires.NotNull(Store, NameOf(Store))
+            Requires.NotNull(Store)
 
             Dim RFStore As PropertyPageSerializationStore = TryCast(Store, PropertyPageSerializationStore)
             If RFStore Is Nothing Then
@@ -164,8 +164,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
         Public Overrides Function Deserialize(Store As SerializationStore, Container As IContainer) As ICollection
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Container, NameOf(Container))
+            Requires.NotNull(Store)
+            Requires.NotNull(Container)
 
             Dim RFStore As PropertyPageSerializationStore = TryCast(Store, PropertyPageSerializationStore)
             If RFStore Is Nothing Then
@@ -190,8 +190,8 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         Public Overrides Sub DeserializeTo(Store As SerializationStore, Container As IContainer, ValidateRecycledTypes As Boolean, applyDefaults As Boolean)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Container, NameOf(Container))
+            Requires.NotNull(Store)
+            Requires.NotNull(Container)
 
             Dim RFStore As PropertyPageSerializationStore = TryCast(Store, PropertyPageSerializationStore)
             If RFStore Is Nothing Then

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropertyPageSerializationService_Store.vb
@@ -400,7 +400,7 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
                 ''' </summary>
                 ''' <param name="Member">The property (must be a PropertyDescriptor) to be serialized.</param>
                 Public Sub AddPropertyToSerialize(Member As MemberDescriptor)
-                    Requires.NotNull(Member, NameOf(Member))
+                    Requires.NotNull(Member)
 
                     If TypeOf Member Is PropertyDescriptor Then
                         Dim Prop As PropertyDescriptor = DirectCast(Member, PropertyDescriptor)

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropPage.vb
@@ -327,7 +327,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         End Sub
 
         Private Sub GetPageInfo(pPageInfo() As PROPPAGEINFO) Implements IPropertyPage2.GetPageInfo, IPropertyPage.GetPageInfo
-            Requires.NotNull(pPageInfo, NameOf(pPageInfo))
+            Requires.NotNull(pPageInfo)
 
             pPageInfo(0).cb = 4 + 4 + 8 + 4 + 4 + 4
             pPageInfo(0).dwHelpContext = HelpContext

--- a/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPages/PropertyControlData.vb
@@ -641,7 +641,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' </summary>
         ''' <param name="AllInitialValues"></param>
         Public Sub SetInitialValues(AllInitialValues As Object())
-            Requires.NotNull(AllInitialValues, NameOf(AllInitialValues))
+            Requires.NotNull(AllInitialValues)
 
             If AllInitialValues.Length = 0 Then
                 Throw Common.CreateArgumentException(NameOf(AllInitialValues))
@@ -1320,7 +1320,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         '''   PropertyControlData.MissingProperty is returned.
         ''' </param>
         Public Shared Sub GetAllPropertyValuesNative(Descriptor As PropertyDescriptor, Extenders As Object(), ByRef Values As Object(), ByRef ValueOrIndeterminate As Object)
-            Requires.NotNull(Extenders, NameOf(Extenders))
+            Requires.NotNull(Extenders)
 
             Dim ReturnValues As Object() = New Object(Extenders.Length - 1) {}
 
@@ -1353,7 +1353,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         ''' <param name="Values"></param>
         Public Shared Function GetValueOrIndeterminateFromArray(Values() As Object) As Object
             'Determine if all the values are the same or not
-            Requires.NotNull(Values, NameOf(Values))
+            Requires.NotNull(Values)
 
             If Values.Length = 0 Then
                 Debug.Fail("Bad Values array")

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportDialogBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportDialogBase.vb
@@ -16,7 +16,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
         Private ReadOnly _serviceProvider As IServiceProvider
 
         Public Sub New(serviceProvider As IServiceProvider)
-            Requires.NotNull(serviceProvider, NameOf(serviceProvider))
+            Requires.NotNull(serviceProvider)
             _serviceProvider = serviceProvider
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
+++ b/src/Microsoft.VisualStudio.Editors/AddImportsDialogs/AddImportsDialogService.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.VisualStudio.Editors.AddImports
         ''' </summary>
         ''' <param name="packageServiceProvider"></param>
         Friend Sub New(packageServiceProvider As IServiceProvider)
-            Requires.NotNull(packageServiceProvider, NameOf(packageServiceProvider))
+            Requires.NotNull(packageServiceProvider)
             _serviceProvider = packageServiceProvider
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/ShellUtil.vb
@@ -341,8 +341,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="editLocks">OUT: Number of edit locks on the document</param>
         ''' <param name="docCookie">OUT: A cookie for the doc, 0 if the doc isn't found in the RDT</param>
         Friend Shared Sub GetDocumentInfo(fileName As String, rdt As IVsRunningDocumentTable, ByRef hierarchy As IVsHierarchy, ByRef readLocks As UInteger, ByRef editLocks As UInteger, ByRef itemid As UInteger, ByRef docCookie As UInteger)
-            Requires.NotNull(fileName, NameOf(fileName))
-            Requires.NotNull(rdt, NameOf(rdt))
+            Requires.NotNull(fileName)
+            Requires.NotNull(rdt)
 
             '
             ' Initialize out parameters...
@@ -625,8 +625,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' <param name="customToolName">Name of custom tool to look for</param>
         ''' <returns>True if registered, false otherwise</returns>
         Friend Shared Function IsCustomToolRegistered(hierarchy As IVsHierarchy, customToolName As String) As Boolean
-            Requires.NotNull(hierarchy, NameOf(hierarchy))
-            Requires.NotNull(customToolName, NameOf(customToolName))
+            Requires.NotNull(hierarchy)
+            Requires.NotNull(customToolName)
 
             ' All project systems support empty string (= no custom tool)
             If customToolName.Length = 0 Then Return True

--- a/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
+++ b/src/Microsoft.VisualStudio.Editors/Common/Utils.vb
@@ -1246,7 +1246,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         Private Function IsWCFReferenceValidInProject(Hierarchy As IVsHierarchy) As Boolean
-            Requires.NotNull(Hierarchy, NameOf(Hierarchy))
+            Requires.NotNull(Hierarchy)
 
             If TryCast(Hierarchy, WCFReference.Interop.IVsWCFMetadataStorageProvider) IsNot Nothing Then
                 Dim objIsServiceReferenceSupported As Object = Nothing
@@ -1273,7 +1273,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         Friend Function IsWebReferenceSupportedByDefaultInProject(Hierarchy As IVsHierarchy) As Boolean
-            Requires.NotNull(Hierarchy, NameOf(Hierarchy))
+            Requires.NotNull(Hierarchy)
 
             Dim objIsReferenceSupported As Object = Nothing
             Try
@@ -1298,7 +1298,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         ''' </summary>
         ''' <param name="Hierarchy"></param>
         Friend Function IsVbProject(Hierarchy As IVsHierarchy) As Boolean
-            Requires.NotNull(Hierarchy, NameOf(Hierarchy))
+            Requires.NotNull(Hierarchy)
 
             Dim langService As Guid = Guid.Empty
             Try
@@ -1565,7 +1565,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
         End Function
 
         Friend Function GetSecurityZoneOfFile(path As String, serviceProvider As ServiceProvider) As Security.SecurityZone
-            Requires.NotNull(path, NameOf(path))
+            Requires.NotNull(path)
 
             If Not IO.Path.IsPathRooted(path) Then
                 Throw CreateArgumentException(NameOf(path))
@@ -1658,8 +1658,8 @@ Namespace Microsoft.VisualStudio.Editors.Common
             Private Shared ReadOnly s_knownTypes As Type() = {GetType(Size)}
 
             Public Shared Sub Serialize(stream As Stream, value As Object)
-                Requires.NotNull(stream, NameOf(stream))
-                Requires.NotNull(value, NameOf(value))
+                Requires.NotNull(stream)
+                Requires.NotNull(value)
                 Using writer As New BinaryWriter(stream, Encoding.UTF8, leaveOpen:=True)
                     Dim valueType = value.GetType()
                     writer.Write(valueType.AssemblyQualifiedName)
@@ -1669,7 +1669,7 @@ Namespace Microsoft.VisualStudio.Editors.Common
             End Sub
 
             Public Shared Function Deserialize(stream As Stream) As Object
-                Requires.NotNull(stream, NameOf(stream))
+                Requires.NotNull(stream)
                 If stream.Length = 0 Then
                     Throw New SerializationException("The stream contains no content.")
                 End If

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Private ReadOnly _customToolValue As String
 
             Public Sub New(customToolValue As String)
-                Requires.NotNull(customToolValue, NameOf(customToolValue))
+                Requires.NotNull(customToolValue)
                 _customToolValue = customToolValue
             End Sub
 
@@ -108,7 +108,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Public Sub New(displayName As String, customToolValue As String)
                 MyBase.New(customToolValue)
 
-                Requires.NotNull(displayName, NameOf(displayName))
+                Requires.NotNull(displayName)
                 _displayName = displayName
             End Sub
 
@@ -128,7 +128,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Public Sub New(accessibility As AccessModifierType, serviceProvider As IServiceProvider, customToolValue As String)
                 MyBase.New(customToolValue)
 
-                Requires.NotNull(serviceProvider, NameOf(serviceProvider))
+                Requires.NotNull(serviceProvider)
 
                 _accessibility = accessibility
                 _serviceProvider = serviceProvider
@@ -294,9 +294,9 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   default for VB (My.Resources).
         ''' </param>
         Public Sub New(rootDesigner As BaseRootDesigner, serviceProvider As IServiceProvider, projectItem As EnvDTE.ProjectItem, namespaceToOverrideIfCustomToolIsEmpty As String)
-            Requires.NotNull(rootDesigner, NameOf(rootDesigner))
-            Requires.NotNull(projectItem, NameOf(projectItem))
-            Requires.NotNull(serviceProvider, NameOf(serviceProvider))
+            Requires.NotNull(rootDesigner)
+            Requires.NotNull(projectItem)
+            Requires.NotNull(serviceProvider)
 
             _rootDesigner = rootDesigner
             _resxFileProjectItem = projectItem

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -713,7 +713,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="filename">The name of the document</param>
         ''' <returns>The document's cookie, or 0 if it's not in the RDT</returns>
         Private Function GetDocCookie(filename As String) As UInteger
-            Requires.NotNull(filename, NameOf(filename))
+            Requires.NotNull(filename)
 
             Dim docCookie As UInteger = 0
             Dim rdt4 As IVsRunningDocumentTable4 = TryCast(_rdt, IVsRunningDocumentTable4)

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDialog.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDialog.vb
@@ -53,7 +53,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '**************************************************************************
         Public Sub New(ServiceProvider As IServiceProvider)
             Debug.Assert(ServiceProvider IsNot Nothing, "ServiceProvider is NULL.")
-            Requires.NotNull(ServiceProvider, NameOf(ServiceProvider))
+            Requires.NotNull(ServiceProvider)
 
             _serviceProvider = ServiceProvider
 

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerTypeDiscoveryService.vb
@@ -23,8 +23,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="sp"></param>
         ''' <param name="hierarchy"></param>
         Public Sub New(sp As IServiceProvider, hierarchy As IVsHierarchy)
-            Requires.NotNull(sp, NameOf(sp))
-            Requires.NotNull(hierarchy, NameOf(hierarchy))
+            Requires.NotNull(sp)
+            Requires.NotNull(hierarchy)
 
             _serviceProvider = sp
             _hierarchy = hierarchy
@@ -134,7 +134,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="typeResolutionService"></param>
         ''' <param name="projectOutput"></param>
         Protected Overridable Function AssemblyFromProjectOutput(typeResolutionService As ComponentModel.Design.ITypeResolutionService, projectOutput As String) As System.Reflection.Assembly
-            Requires.NotNull(typeResolutionService, NameOf(typeResolutionService))
+            Requires.NotNull(typeResolutionService)
 
             If typeResolutionService IsNot Nothing Then
                 Try

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationService.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationService.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Stream">The stream to load from.</param>
         ''' <returns>The loaded store for objects.</returns>
         Public Overrides Function LoadStore(Stream As Stream) As SerializationStore
-            Requires.NotNull(Stream, NameOf(Stream))
+            Requires.NotNull(Stream)
 
             Return GenericComponentSerializationStore.Load(Stream)
         End Function
@@ -52,8 +52,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Value">The object to serialize into the store.</param>
         Public Overrides Sub Serialize(Store As SerializationStore, Value As Object)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Value, NameOf(Value))
+            Requires.NotNull(Store)
+            Requires.NotNull(Value)
 
             Dim RFStore As GenericComponentSerializationStore = TryCast(Store, GenericComponentSerializationStore)
             If RFStore Is Nothing Then
@@ -82,9 +82,9 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         '''   *want* to serialize it.  It will actually get serialized when the store is closed.
         ''' </remarks>
         Public Overrides Sub SerializeMember(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(OwningObject, NameOf(OwningObject))
-            Requires.NotNull(Member, NameOf(Member))
+            Requires.NotNull(Store)
+            Requires.NotNull(OwningObject)
+            Requires.NotNull(Member)
 
             Dim RFStore As GenericComponentSerializationStore = TryCast(Store, GenericComponentSerializationStore)
             If RFStore Is Nothing Then
@@ -124,7 +124,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Store">The store to serialize into.</param>
         ''' <returns>The set of components that were deserialized.</returns>
         Public Overrides Function Deserialize(Store As SerializationStore) As ICollection
-            Requires.NotNull(Store, NameOf(Store))
+            Requires.NotNull(Store)
 
             Dim RFStore As GenericComponentSerializationStore = TryCast(Store, GenericComponentSerializationStore)
             If RFStore Is Nothing Then
@@ -143,8 +143,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
         Public Overrides Function Deserialize(Store As SerializationStore, Container As IContainer) As ICollection
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Container, NameOf(Container))
+            Requires.NotNull(Store)
+            Requires.NotNull(Container)
 
             Dim RFStore As GenericComponentSerializationStore = TryCast(Store, GenericComponentSerializationStore)
             If RFStore Is Nothing Then
@@ -169,8 +169,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         Public Overrides Sub DeserializeTo(Store As SerializationStore, Container As IContainer, ValidateRecycledTypes As Boolean, applyDefaults As Boolean)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Container, NameOf(Container))
+            Requires.NotNull(Store)
+            Requires.NotNull(Container)
 
             Dim RFStore As GenericComponentSerializationStore = TryCast(Store, GenericComponentSerializationStore)
             If RFStore Is Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/GenericComponentSerializationStore.vb
@@ -331,7 +331,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="Value">The component from which we want to serialize stuff.</param>
             Public Sub New(Value As Object)
-                Requires.NotNull(Value, NameOf(Value))
+                Requires.NotNull(Value)
 
                 ' If it is an IComponent, we'll try to get its name from 
                 ' its site
@@ -420,7 +420,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="Value">The component from which we want to serialize stuff.</param>
             Friend Sub New(Value As ObjectData)
-                Requires.NotNull(Value, NameOf(Value))
+                Requires.NotNull(Value)
 
                 _objectName = Value.Name
                 _serializedValue = SerializeObject(Value.Value)
@@ -431,8 +431,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' </summary>
             ''' <param name="Value">The component from which we want to serialize stuff.</param>
             Public Sub New(Value As ObjectData, [Property] As PropertyDescriptor)
-                Requires.NotNull(Value, NameOf(Value))
-                Requires.NotNull([Property], NameOf([Property]))
+                Requires.NotNull(Value)
+                Requires.NotNull([Property])
 
                 _objectName = Value.Name
                 _propertyName = [Property].Name

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/SourceCodeControlManager.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' </summary>
         ''' <param name="sp"></param>
         Public Sub New(sp As IServiceProvider, Hierarchy As IVsHierarchy)
-            Requires.NotNull(sp, NameOf(sp))
+            Requires.NotNull(sp)
             _serviceProvider = sp
         End Sub
 #End Region
@@ -131,8 +131,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="fileReloaded">Out: Set to true if one or more files were reloaded...</param>
         ''' <remarks>Disallows in memory edits for IVsQueryEditQuerySave2</remarks>
         Public Shared Function QueryEditableFiles(sp As IServiceProvider, files As List(Of String), throwOnFailure As Boolean, checkOnly As Boolean, ByRef fileReloaded As Boolean, Optional allowInMemoryEdits As Boolean = True, Optional allowFileReload As Boolean = True) As Boolean
-            Requires.NotNull(sp, NameOf(sp))
-            Requires.NotNull(files, NameOf(files))
+            Requires.NotNull(sp)
+            Requires.NotNull(files)
 
             If files.Count = 0 Then
                 Return True
@@ -242,8 +242,8 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ''' <param name="files">The set of files to check</param>
         ''' <param name="throwOnFailure">Should we throw if the save fails?</param>
         Public Shared Function QuerySave(sp As IServiceProvider, files As List(Of String), throwOnFailure As Boolean) As Boolean
-            Requires.NotNull(sp, NameOf(sp))
-            Requires.NotNull(files, NameOf(files))
+            Requires.NotNull(sp)
+            Requires.NotNull(files)
 
             If files.Count = 0 Then
                 Return True

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -240,7 +240,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             Dim hr As Integer
             Dim obj As Object = Nothing
 
-            Requires.NotNull(ProjectHierarchy, NameOf(ProjectHierarchy))
+            Requires.NotNull(ProjectHierarchy)
 
             _projectHierarchy = ProjectHierarchy
 

--- a/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyExtensibility/TrackProjectDocumentsEventsHelper.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.VisualStudio.Editors.MyExtensibility
         End Sub
 
         Private Sub New(serviceProvider As IServiceProvider)
-            Requires.NotNull(serviceProvider, NameOf(serviceProvider))
+            Requires.NotNull(serviceProvider)
 
             _serviceProvider = serviceProvider
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/FrameworkMultiTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/FrameworkMultiTargetProvider.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As IReadOnlyList(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
 
-            Requires.NotNull(framework, NameOf(framework))
+            Requires.NotNull(framework)
 
             Dim frameworks = GetSupportedFrameworkNames(framework)
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/TypeConverterTargetProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/TargetFrameworks/TypeConverterTargetProvider.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Public Function GetSupportedTargetFrameworks(framework As FrameworkName) As IReadOnlyList(Of TargetFrameworkMoniker) Implements ISupportedTargetFrameworksProvider.GetSupportedTargetFrameworks
 
-            Requires.NotNull(framework, NameOf(framework))
+            Requires.NotNull(framework)
 
             ' CPS-based projects implement a enum property that ends up delegating onto
             ' SupportedTargetFrameworkAliasEnumProvider, which ends up reading from evaluation

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/AppDotXamlDocument.vb
@@ -108,8 +108,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Private ReadOnly _debugLockCheck As IDebugLockCheck 'Used by the document to verify BufferLock is used when it's needed
 
             Public Sub New(buffer As IVsTextLines, debugLockCheck As IDebugLockCheck)
-                Requires.NotNull(buffer, NameOf(buffer))
-                Requires.NotNull(debugLockCheck, NameOf(debugLockCheck))
+                Requires.NotNull(buffer)
+                Requires.NotNull(debugLockCheck)
 
                 _buffer = buffer
                 _debugLockCheck = debugLockCheck
@@ -167,9 +167,9 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Private ReadOnly _endLocationPlusOne As Location 'Points to the index *after* the last character in the range, just like IVsTextLines expects
 
             Public Sub New(vsTextLines As IVsTextLines, startLocation As Location, endLocation As Location, unescapedValue As String, definitionIncludesQuotes As Boolean)
-                Requires.NotNull(vsTextLines, NameOf(vsTextLines))
-                Requires.NotNull(startLocation, NameOf(startLocation))
-                Requires.NotNull(endLocation, NameOf(endLocation))
+                Requires.NotNull(vsTextLines)
+                Requires.NotNull(startLocation)
+                Requires.NotNull(endLocation)
 
                 If unescapedValue Is Nothing Then
                     unescapedValue = ""
@@ -289,7 +289,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Public Sub New(vsTextLines As IVsTextLines, fullyQualifiedPropertyName As String, elementStart As Location, elementEnd As Location)
                 MyBase.New(vsTextLines, elementStart, elementEnd, unescapedValue:="")
 
-                Requires.NotNull(fullyQualifiedPropertyName, NameOf(fullyQualifiedPropertyName))
+                Requires.NotNull(fullyQualifiedPropertyName)
 
                 _fullyQualifiedPropertyName = fullyQualifiedPropertyName
             End Sub
@@ -334,7 +334,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
 #Region "Constructor"
 
         Public Sub New(vsTextLines As IVsTextLines)
-            Requires.NotNull(vsTextLines, NameOf(vsTextLines))
+            Requires.NotNull(vsTextLines)
             _vsTextLines = vsTextLines
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/WPF/ApplicationPropPageVBWPF.vb
@@ -1318,8 +1318,8 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages.WPF
             Private ReadOnly _description As String
 
             Public Sub New(value As String, description As String)
-                Requires.NotNull(value, NameOf(value))
-                Requires.NotNull(description, NameOf(description))
+                Requires.NotNull(value)
+                Requires.NotNull(description)
 
                 _value = value
                 _description = description

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/FindReplace.vb
@@ -63,7 +63,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' </summary>
         ''' <param name="RootDesigner">Pointer to the root designer</param>
         Public Sub New(RootDesigner As ResourceEditorRootDesigner)
-            Requires.NotNull(RootDesigner, NameOf(RootDesigner))
+            Requires.NotNull(RootDesigner)
             _rootDesigner = RootDesigner
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorFactory.vb
@@ -115,23 +115,23 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         Private Function OnAfterRenameFiles(cProjects As Integer, cFiles As Integer, rgpProjects() As IVsProject, rgFirstIndices() As Integer, rgszMkOldNames() As String, rgszMkNewNames() As String, rgFlags() As VSRENAMEFILEFLAGS) As Integer Implements IVsTrackProjectDocumentsEvents2.OnAfterRenameFiles
             ' Validate arguments....
             Debug.Assert(rgpProjects IsNot Nothing AndAlso rgpProjects.Length = cProjects, "null rgpProjects or bad-length array")
-            Requires.NotNull(rgpProjects, NameOf(rgpProjects))
+            Requires.NotNull(rgpProjects)
             If rgpProjects.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgpProjects))
 
             Debug.Assert(rgFirstIndices IsNot Nothing AndAlso rgFirstIndices.Length = cProjects, "null rgFirstIndices or bad-length array")
-            Requires.NotNull(rgFirstIndices, NameOf(rgFirstIndices))
+            Requires.NotNull(rgFirstIndices)
             If rgFirstIndices.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgFirstIndices))
 
             Debug.Assert(rgszMkOldNames IsNot Nothing AndAlso rgszMkOldNames.Length = cFiles, "null rgszMkOldNames or bad-length array")
-            Requires.NotNull(rgszMkOldNames, NameOf(rgszMkOldNames))
+            Requires.NotNull(rgszMkOldNames)
             If rgszMkOldNames.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgszMkOldNames))
 
             Debug.Assert(rgszMkNewNames IsNot Nothing AndAlso rgszMkNewNames.Length = cFiles, "null rgszMkNewNames or bad-length array")
-            Requires.NotNull(rgszMkNewNames, NameOf(rgszMkNewNames))
+            Requires.NotNull(rgszMkNewNames)
             If rgszMkNewNames.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgszMkNewNames))
 
             Debug.Assert(rgFlags IsNot Nothing AndAlso rgFlags.Length = cFiles, "null rgFlags or bad-length array")
-            Requires.NotNull(rgFlags, NameOf(rgFlags))
+            Requires.NotNull(rgFlags)
             If rgFlags.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgFlags))
 
             For i As Integer = 0 To cFiles - 1

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService.vb
@@ -78,7 +78,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Stream">The stream to load from.</param>
         ''' <returns>The loaded store for resources.</returns>
         Public Overrides Function LoadStore(Stream As Stream) As SerializationStore
-            Requires.NotNull(Stream, NameOf(Stream))
+            Requires.NotNull(Stream)
 
             Return ResourceSerializationStore.Load(Stream)
         End Function
@@ -91,8 +91,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Value">The object (must be a Resource instance) to serialize into the store.</param>
         Public Overrides Sub Serialize(Store As SerializationStore, Value As Object)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Value, NameOf(Value))
+            Requires.NotNull(Store)
+            Requires.NotNull(Value)
 
             If TypeOf Value IsNot Resource Then
                 Throw CreateArgumentException(NameOf(Value))
@@ -126,9 +126,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         '''   *want* to serialize it.  It will actually get serialized when the store is closed.
         ''' </remarks>
         Public Overrides Sub SerializeMember(Store As SerializationStore, OwningObject As Object, Member As MemberDescriptor)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(OwningObject, NameOf(OwningObject))
-            Requires.NotNull(Member, NameOf(Member))
+            Requires.NotNull(Store)
+            Requires.NotNull(OwningObject)
+            Requires.NotNull(Member)
 
             Dim OwningResource As Resource = TryCast(OwningObject, Resource)
             If OwningObject Is Nothing Then
@@ -171,7 +171,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Store">The store to serialize into.</param>
         ''' <returns>The set of components that were deserialized.</returns>
         Public Overrides Function Deserialize(Store As SerializationStore) As ICollection
-            Requires.NotNull(Store, NameOf(Store))
+            Requires.NotNull(Store)
 
             Dim RFStore As ResourceSerializationStore = TryCast(Store, ResourceSerializationStore)
             If RFStore Is Nothing Then
@@ -190,8 +190,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         ''' <returns>The list of objects that were deserialized.</returns>
         Public Overrides Function Deserialize(Store As SerializationStore, Container As IContainer) As ICollection
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Container, NameOf(Container))
+            Requires.NotNull(Store)
+            Requires.NotNull(Container)
 
             Dim RFStore As ResourceSerializationStore = TryCast(Store, ResourceSerializationStore)
             If RFStore Is Nothing Then
@@ -216,8 +216,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' <param name="Store">The store to serialize into.</param>
         ''' <param name="Container">The container to add deserialized objects to (or Nothing if none)</param>
         Public Overrides Sub DeserializeTo(Store As SerializationStore, Container As IContainer, ValidateRecycledTypes As Boolean, applyDefault As Boolean)
-            Requires.NotNull(Store, NameOf(Store))
-            Requires.NotNull(Container, NameOf(Container))
+            Requires.NotNull(Store)
+            Requires.NotNull(Container)
 
             Dim RFStore As ResourceSerializationStore = TryCast(Store, ResourceSerializationStore)
             If RFStore Is Nothing Then

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService_Store.vb
@@ -456,7 +456,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                 ''' </summary>
                 ''' <param name="Member">The property (must be a PropertyDescriptor) to be serialized.</param>
                 Public Sub AddPropertyToSerialize(Member As MemberDescriptor)
-                    Requires.NotNull(Member, NameOf(Member))
+                    Requires.NotNull(Member)
 
                     If TypeOf Member Is PropertyDescriptor Then
                         Dim Prop As PropertyDescriptor = DirectCast(Member, PropertyDescriptor)

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncodingConverter.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/SerializableEncodingConverter.vb
@@ -59,7 +59,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Converts the given value object to the specified destination type.
         ''' </summary>
         Public Overrides Function ConvertTo(Context As ITypeDescriptorContext, Culture As CultureInfo, Value As Object, DestinationType As Type) As Object
-            Requires.NotNull(DestinationType, NameOf(DestinationType))
+            Requires.NotNull(DestinationType)
 
             If DestinationType.Equals(GetType(String)) AndAlso TypeOf Value Is SerializableEncoding Then
                 Dim SerializableEncoding As SerializableEncoding = DirectCast(Value, SerializableEncoding)

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/AppConfigSerializer.vb
@@ -238,9 +238,9 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' <param name="AppConfigDocData"></param>
         Friend Shared Sub Serialize(Settings As DesignTimeSettings, typeCache As SettingsTypeCache, valueCache As SettingsValueCache, ClassName As String, NamespaceName As String, AppConfigDocData As DocData, Hierarchy As IVsHierarchy, SynchronizeUserConfig As Boolean)
             Common.Switches.TraceSDSerializeSettings(TraceLevel.Info, "Serializing {0} settings to App.Config", Settings.Count)
-            Requires.NotNull(Settings, NameOf(Settings))
-            Requires.NotNull(NamespaceName, NameOf(NamespaceName))
-            Requires.NotNull(AppConfigDocData, NameOf(AppConfigDocData))
+            Requires.NotNull(Settings)
+            Requires.NotNull(NamespaceName)
+            Requires.NotNull(AppConfigDocData)
 
             If ClassName = "" Then
                 Debug.Fail("Must provide a valid class name!")

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ConnectionStringUITypeEditor.vb
@@ -216,8 +216,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
         ''' there exists sensitive information in the string and whether the user chooses to persist it
         '''</returns>
         Private Shared Function GetConnectionString(ServiceProvider As IServiceProvider, Dialog As IVsDataConnectionDialog, PromptIfContainsSensitiveData As Boolean) As String
-            Requires.NotNull(Dialog, NameOf(Dialog))
-            Requires.NotNull(ServiceProvider, NameOf(ServiceProvider))
+            Requires.NotNull(Dialog)
+            Requires.NotNull(ServiceProvider)
 
             Dim SafeConnectionString As String = Dialog.SafeConnectionString
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/ProjectUtils.vb
@@ -740,7 +740,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner.ProjectUtils
         ''' </summary>
         ''' <param name="cc2"></param>
         Friend Function CodeModelToCodeDomTypeAttributes(cc2 As EnvDTE80.CodeClass2) As TypeAttributes
-            Requires.NotNull(cc2, NameOf(cc2))
+            Requires.NotNull(cc2)
 
             Dim returnValue As TypeAttributes
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsGlobalObject/SettingsGlobalObjectProvider.vb
@@ -854,19 +854,19 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
 
             ' Validate arguments....
             Debug.Assert(rgpProjects IsNot Nothing AndAlso rgpProjects.Length = cProjects, "null rgpProjects or bad-length array")
-            Requires.NotNull(rgpProjects, NameOf(rgpProjects))
+            Requires.NotNull(rgpProjects)
             If rgpProjects.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgpProjects))
 
             Debug.Assert(rgFirstIndices IsNot Nothing AndAlso rgFirstIndices.Length = cProjects, "null rgFirstIndices or bad-length array")
-            Requires.NotNull(rgFirstIndices, NameOf(rgFirstIndices))
+            Requires.NotNull(rgFirstIndices)
             If rgFirstIndices.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgFirstIndices))
 
             Debug.Assert(rgpszMkDocuments IsNot Nothing AndAlso rgpszMkDocuments.Length = cFiles, "null rgpszMkDocuments or bad-length array")
-            Requires.NotNull(rgpszMkDocuments, NameOf(rgpszMkDocuments))
+            Requires.NotNull(rgpszMkDocuments)
             If rgpszMkDocuments.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgpszMkDocuments))
 
             Debug.Assert(rgFlags IsNot Nothing AndAlso rgFlags.Length = cFiles, "null rgFlags or bad-length array")
-            Requires.NotNull(rgFlags, NameOf(rgFlags))
+            Requires.NotNull(rgFlags)
             If rgFlags.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgFlags))
 
             ' CONSIDER: Check/pass the flags to the MapToSettingsFileProjectItems to exclude special/dependent/nested files from being added
@@ -889,19 +889,19 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Public Function OnAfterRemoveFiles(cProjects As Integer, cFiles As Integer, rgpProjects() As IVsProject, rgFirstIndices() As Integer, rgpszMkDocuments() As String, rgFlags() As VSREMOVEFILEFLAGS) As Integer Implements IVsTrackProjectDocumentsEvents2.OnAfterRemoveFiles
             ' Validate arguments....
             Debug.Assert(rgpProjects IsNot Nothing AndAlso rgpProjects.Length = cProjects, "null rgpProjects or bad-length array")
-            Requires.NotNull(rgpProjects, NameOf(rgpProjects))
+            Requires.NotNull(rgpProjects)
             If rgpProjects.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgpProjects))
 
             Debug.Assert(rgFirstIndices IsNot Nothing AndAlso rgFirstIndices.Length = cProjects, "null rgFirstIndices or bad-length array")
-            Requires.NotNull(rgFirstIndices, NameOf(rgFirstIndices))
+            Requires.NotNull(rgFirstIndices)
             If rgFirstIndices.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgFirstIndices))
 
             Debug.Assert(rgpszMkDocuments IsNot Nothing AndAlso rgpszMkDocuments.Length = cFiles, "null rgpszMkDocuments or bad-length array")
-            Requires.NotNull(rgpszMkDocuments, NameOf(rgpszMkDocuments))
+            Requires.NotNull(rgpszMkDocuments)
             If rgpszMkDocuments.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgpszMkDocuments))
 
             Debug.Assert(rgFlags IsNot Nothing AndAlso rgFlags.Length = cFiles, "null rgFlags or bad-length array")
-            Requires.NotNull(rgFlags, NameOf(rgFlags))
+            Requires.NotNull(rgFlags)
             If rgFlags.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgFlags))
 
             Dim expandedHierarchies() As IVsHierarchy = GetCorrespondingProjects(rgpProjects, rgFirstIndices, cFiles)
@@ -920,23 +920,23 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
         Public Function OnAfterRenameFiles(cProjects As Integer, cFiles As Integer, rgpProjects() As IVsProject, rgFirstIndices() As Integer, rgszMkOldNames() As String, rgszMkNewNames() As String, rgFlags() As VSRENAMEFILEFLAGS) As Integer Implements IVsTrackProjectDocumentsEvents2.OnAfterRenameFiles
             ' Validate arguments....
             Debug.Assert(rgpProjects IsNot Nothing AndAlso rgpProjects.Length = cProjects, "null rgpProjects or bad-length array")
-            Requires.NotNull(rgpProjects, NameOf(rgpProjects))
+            Requires.NotNull(rgpProjects)
             If rgpProjects.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgpProjects))
 
             Debug.Assert(rgFirstIndices IsNot Nothing AndAlso rgFirstIndices.Length = cProjects, "null rgFirstIndices or bad-length array")
-            Requires.NotNull(rgFirstIndices, NameOf(rgFirstIndices))
+            Requires.NotNull(rgFirstIndices)
             If rgFirstIndices.Length <> cProjects Then Throw Common.CreateArgumentException(NameOf(rgFirstIndices))
 
             Debug.Assert(rgszMkOldNames IsNot Nothing AndAlso rgszMkOldNames.Length = cFiles, "null rgszMkOldNames or bad-length array")
-            Requires.NotNull(rgszMkOldNames, NameOf(rgszMkOldNames))
+            Requires.NotNull(rgszMkOldNames)
             If rgszMkOldNames.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgszMkOldNames))
 
             Debug.Assert(rgszMkNewNames IsNot Nothing AndAlso rgszMkNewNames.Length = cFiles, "null rgszMkNewNames or bad-length array")
-            Requires.NotNull(rgszMkNewNames, NameOf(rgszMkNewNames))
+            Requires.NotNull(rgszMkNewNames)
             If rgszMkNewNames.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgszMkNewNames))
 
             Debug.Assert(rgFlags IsNot Nothing AndAlso rgFlags.Length = cFiles, "null rgFlags or bad-length array")
-            Requires.NotNull(rgFlags, NameOf(rgFlags))
+            Requires.NotNull(rgFlags)
             If rgFlags.Length <> cFiles Then Throw Common.CreateArgumentException(NameOf(rgFlags))
 
             Dim expandedHierarchies() As IVsHierarchy = GetCorrespondingProjects(rgpProjects, rgFirstIndices, cFiles)
@@ -2012,7 +2012,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             Public Overrides Function GetPropertyValue(prop As PropertyInfo, instance As Object, args() As Object) As Object
 
                 Debug.Assert(prop IsNot Nothing, "bad property passed to GetPropertyValue")
-                Requires.NotNull(prop, NameOf(prop))
+                Requires.NotNull(prop)
 
                 ' make sure this .settings file is generating code, otherwise it's not really
                 '   worth it to attempt to get property values...
@@ -2111,7 +2111,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
             Public Overrides Sub SetPropertyValue(prop As PropertyInfo, instance As Object, value As Object, args As Object())
 
                 Debug.Assert(prop IsNot Nothing, "bad property passed to SetPropertyValue")
-                Requires.NotNull(prop, NameOf(prop))
+                Requires.NotNull(prop)
 
 #If DEBUG Then
                 Debug.WriteLineIf(SettingsGlobalObjectProvider.GlobalSettings.TraceVerbose, "SettingsFileTypeImplementor.SetPropertyValue(" & CStr(_globalObject._className) & " -- " & CStr(prop.Name) & ")...")
@@ -2261,7 +2261,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
                     '
                     MyBase.OnAddComplete(prop)
 
-                    Requires.NotNull(prop, NameOf(prop))
+                    Requires.NotNull(prop)
 
                     ' we need the collection of settings objects to which we can add the new setting
                     '
@@ -2339,7 +2339,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsGlobalObjects
 #End If
                 MyBase.OnRemoveComplete([property])
 
-                Requires.NotNull([property], NameOf([property]))
+                Requires.NotNull([property])
 
                 ' we need the collection of settings objects from which we can remove the setting
                 '

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/DotNetVSImports.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/DotNetVSImports.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Automation
 
         public void OnSinkAdded(_dispImportsEvents sink)
         {
-            Requires.NotNull(sink, nameof(sink));
+            Requires.NotNull(sink);
 
             ImportAdded += new _dispImportsEvents_ImportAddedEventHandler(sink.ImportAdded);
             ImportRemoved += new _dispImportsEvents_ImportRemovedEventHandler(sink.ImportRemoved);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.ErrorListDetails.cs
@@ -101,8 +101,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             /// <returns>An absolute path, or the empty string if <paramref name="path"/> invalid.</returns>
             private static string TryMakeRooted(string basePath, string path)
             {
-                Requires.NotNullOrEmpty(basePath, nameof(basePath));
-                Requires.NotNullOrEmpty(path, nameof(path));
+                Requires.NotNullOrEmpty(basePath);
+                Requires.NotNullOrEmpty(path);
 
                 try
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
         public Task<AddMessageResult> AddMessageAsync(TargetGeneratedError error)
         {
-            Requires.NotNull(error, nameof(error));
+            Requires.NotNull(error);
 
             return AddMessageCoreAsync(error);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPoint.cs
@@ -19,8 +19,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
 
         internal ConnectionPoint(ConnectionPointContainer container, IEventSource<TSinkType> source)
         {
-            Requires.NotNull(container, nameof(container));
-            Requires.NotNull(source, nameof(source));
+            Requires.NotNull(container);
+            Requires.NotNull(source);
 
             _container = container;
             _source = source;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPointContainer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ConnectionPoint/ConnectionPointContainer.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.ConnectionPoint
         internal void AddEventSource<SinkType>(IEventSource<SinkType> source)
             where SinkType : class
         {
-            Requires.NotNull(source, nameof(source));
+            Requires.NotNull(source);
             Verify.Operation(!_connectionPoints.ContainsKey(typeof(SinkType).GUID), "EventSource guid already added to the list of connection points");
 
             _connectionPoints.Add(typeof(SinkType).GUID, new ConnectionPoint<SinkType>(this, source));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -32,8 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// <returns>true if file is added successfully.</returns>
         public async Task<bool> CreateFileAsync(string templateFile, string path)
         {
-            Requires.NotNull(templateFile, nameof(templateFile));
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNull(templateFile);
+            Requires.NotNullOrEmpty(path);
 
             string directoryName = Path.GetDirectoryName(path);
             string fileName = Path.GetFileName(path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/NameQuotedValuePairListEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/NameQuotedValuePairListEncoding.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         public IEnumerable<(string Name, string Value)> Parse(string value)
         {
-            Requires.NotNull(value, nameof(value));
+            Requires.NotNull(value);
             if (string.IsNullOrEmpty(value))
             {
                 yield break;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ExportProjectNodeComServiceAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ExportProjectNodeComServiceAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private static string[] GetIids(Type[] comTypes)
         {
-            Requires.NotNull(comTypes, nameof(comTypes));
+            Requires.NotNull(comTypes);
 
             // Reuse ComServiceIdAttribute's logic for calculating IIDs.
             return comTypes.Select(type => new ComServiceIidAttribute(type))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
-            Requires.NotNull(nodes, nameof(nodes));
+            Requires.NotNull(nodes);
 
             if (nodes.Count == 1 && _addItemDialogService.CanAddNewOrExistingItemTo(nodes.First()) && TryGetTemplateDetails(commandId, out _))
             {
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         public async Task<bool> TryHandleCommandAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            Requires.NotNull(nodes, nameof(nodes));
+            Requires.NotNull(nodes);
 
             if (nodes.Count == 1 && _addItemDialogService.CanAddNewOrExistingItemTo(nodes.First()) && TryGetTemplateDetails(commandId, out TemplateDetails? result))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractGenerateNuGetPackageCommand.cs
@@ -21,10 +21,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
             ISolutionBuildManager vsSolutionBuildManagerService,
             GeneratePackageOnBuildPropertyProvider generatePackageOnBuildPropertyProvider)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(threadingService, nameof(threadingService));
-            Requires.NotNull(vsSolutionBuildManagerService, nameof(vsSolutionBuildManagerService));
-            Requires.NotNull(generatePackageOnBuildPropertyProvider, nameof(generatePackageOnBuildPropertyProvider));
+            Requires.NotNull(project);
+            Requires.NotNull(threadingService);
+            Requires.NotNull(vsSolutionBuildManagerService);
+            Requires.NotNull(generatePackageOnBuildPropertyProvider);
 
             Project = project;
             _threadingService = threadingService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommand.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
 
         protected AbstractOpenProjectDesignerCommand(IProjectDesignerService designerService)
         {
-            Requires.NotNull(designerService, nameof(designerService));
+            Requires.NotNull(designerService);
 
             _designerService = designerService;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractAddItemCommand.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             IAddItemDialogService addItemDialogService,
             OrderAddItemHintReceiver orderAddItemHintReceiver)
         {
-            Requires.NotNull(addItemDialogService, nameof(addItemDialogService));
-            Requires.NotNull(orderAddItemHintReceiver, nameof(orderAddItemHintReceiver));
+            Requires.NotNull(addItemDialogService);
+            Requires.NotNull(orderAddItemHintReceiver);
 
             _addItemDialogService = addItemDialogService;
             _orderAddItemHintReceiver = orderAddItemHintReceiver;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/AbstractMoveCommand.cs
@@ -15,10 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
         protected AbstractMoveCommand(IPhysicalProjectTree projectTree, SVsServiceProvider serviceProvider, ConfiguredProject configuredProject, IProjectAccessor accessor)
         {
-            Requires.NotNull(projectTree, nameof(projectTree));
-            Requires.NotNull(serviceProvider, nameof(serviceProvider));
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(accessor, nameof(accessor));
+            Requires.NotNull(projectTree);
+            Requires.NotNull(serviceProvider);
+            Requires.NotNull(configuredProject);
+            Requires.NotNull(accessor);
 
             _projectTree = projectTree;
             _serviceProvider = serviceProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/NodeHelper.cs
@@ -18,9 +18,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static async Task SelectAsync(ConfiguredProject configuredProject, IServiceProvider serviceProvider, IProjectTree node)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(serviceProvider, nameof(serviceProvider));
-            Requires.NotNull(node, nameof(node));
+            Requires.NotNull(configuredProject);
+            Requires.NotNull(serviceProvider);
+            Requires.NotNull(node);
 
             await configuredProject.Services.ProjectService.Services.ThreadingPolicy.SwitchToUIThread();
 
@@ -65,7 +65,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <returns>A reference to an IVsUIHierarchyWindow interface, or <see langword="null"/> if the window isn't available, such as command line mode.</returns>
         private static IVsUIHierarchyWindow? GetUIHierarchyWindow(IServiceProvider serviceProvider, Guid persistenceSlot)
         {
-            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(serviceProvider);
 
             if (serviceProvider is null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -59,8 +59,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public async Task CaptureAsync(OrderingMoveAction action, IProjectTree target, Func<Task> task)
         {
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(task, nameof(task));
+            Requires.NotNull(target);
+            Requires.NotNull(task);
 
             _action = action;
             _target = target;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -17,10 +17,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static Task MoveAsync(ConfiguredProject configuredProject, IProjectAccessor accessor, ImmutableHashSet<string> previousIncludes, IProjectTree target, OrderingMoveAction action)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(accessor, nameof(accessor));
-            Requires.NotNull(previousIncludes, nameof(previousIncludes));
-            Requires.NotNull(target, nameof(target));
+            Requires.NotNull(configuredProject);
+            Requires.NotNull(accessor);
+            Requires.NotNull(previousIncludes);
+            Requires.NotNull(target);
 
             return accessor.OpenProjectForWriteAsync(configuredProject, project =>
             {
@@ -44,8 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static Task<ImmutableHashSet<string>> GetAllEvaluatedIncludesAsync(ConfiguredProject configuredProject, IProjectAccessor accessor)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(accessor, nameof(accessor));
+            Requires.NotNull(configuredProject);
+            Requires.NotNull(accessor);
 
             return accessor.OpenProjectForReadAsync(configuredProject, project =>
                 project.AllEvaluatedItems.Select(x => x.EvaluatedInclude).ToImmutableHashSet(StringComparers.ItemNames));
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool CanMoveUp(IProjectTree projectTree)
         {
-            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(projectTree);
 
             return GetSiblingByMoveAction(projectTree, MoveAction.Above) is not null;
         }
@@ -87,8 +87,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool TryMoveUp(Project project, IProjectTree projectTree)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(project);
+            Requires.NotNull(projectTree);
 
             return TryMove(project, projectTree, MoveAction.Above);
         }
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool CanMoveDown(IProjectTree projectTree)
         {
-            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(projectTree);
 
             return GetSiblingByMoveAction(projectTree, MoveAction.Below) is not null;
         }
@@ -108,8 +108,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool TryMoveDown(Project project, IProjectTree projectTree)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(project);
+            Requires.NotNull(projectTree);
 
             return TryMove(project, projectTree, MoveAction.Below);
         }
@@ -119,8 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool TryMoveElementsAbove(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(target, nameof(target));
+            Requires.NotNull(project);
+            Requires.NotNull(target);
 
             ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Above);
             if (referenceElement is null)
@@ -136,8 +136,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool TryMoveElementsBelow(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(target, nameof(target));
+            Requires.NotNull(project);
+            Requires.NotNull(target);
 
             ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Below);
             if (referenceElement is null)
@@ -153,8 +153,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static bool TryMoveElementsToTop(Project project, ImmutableArray<ProjectItemElement> elements, IProjectTree target)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(target, nameof(target));
+            Requires.NotNull(project);
+            Requires.NotNull(target);
 
             IProjectTree? newTarget = target;
 
@@ -181,8 +181,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// </summary>
         public static ImmutableArray<ProjectItemElement> GetItemElements(Project project, IProjectTree projectTree, ImmutableArray<string> excludeIncludes)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(projectTree, nameof(projectTree));
+            Requires.NotNull(project);
+            Requires.NotNull(projectTree);
 
             var includes = GetEvaluatedIncludes(projectTree).Except(excludeIncludes, StringComparers.ItemNames).ToImmutableArray();
             return GetItemElements(project, includes);
@@ -364,7 +364,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         /// <returns>true or false; 'true' if all elements were successfully moved. 'false' if just one element was not moved successfully.</returns>
         private static bool TryMoveElements(ImmutableArray<ProjectItemElement> elements, ProjectItemElement referenceElement, MoveAction moveAction)
         {
-            Requires.NotNull(referenceElement, nameof(referenceElement));
+            Requires.NotNull(referenceElement);
 
             ProjectElementContainer parent = referenceElement.Parent;
             if (parent is null || !elements.Any())

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/CSharp/CSharpLanguageFeaturesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/CSharp/CSharpLanguageFeaturesProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.CSharp
         /// </exception>
         public string MakeProperIdentifier(string name)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNullOrEmpty(name);
 
             string identifier = string.Concat(name.Select(c => IsValidIdentifierChar(c) ? c : '_'));
             if (!IsValidFirstIdentifierChar(identifier[0]))
@@ -81,7 +81,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.CSharp
         /// </exception>
         public string MakeProperNamespace(string name)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNullOrEmpty(name);
 
             IEnumerable<string> namespaceNames = new LazyStringSplit(name, '.').Select(MakeProperIdentifier);
 
@@ -109,7 +109,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices.CSharp
         /// </exception>
         public string ConcatNamespaces(params string[] namespaceNames)
         {
-            Requires.NotNullEmptyOrNullElements(namespaceNames, nameof(namespaceNames));
+            Requires.NotNullEmptyOrNullElements(namespaceNames);
 
             return string.Join(".", namespaceNames.Where(name => name.Length > 0));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         /// </exception>
         protected AbstractEvaluationCommandLineHandler(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             _project = project;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/ProjectContextCodeModelProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         public CodeModel? GetCodeModel(Project project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             return _threadingService.ExecuteSynchronously(() =>
             {
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.LanguageServices
 
         public FileCodeModel? GetFileCodeModel(ProjectItem fileItem)
         {
-            Requires.NotNull(fileItem, nameof(fileItem));
+            Requires.NotNull(fileItem);
 
             return _threadingService.ExecuteSynchronously(() =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -543,7 +543,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
     public async Task WriteAsync(Func<IWorkspace, Task> action, CancellationToken cancellationToken)
     {
-        Requires.NotNull(action, nameof(action));
+        Requires.NotNull(action);
         Verify.NotDisposed(this);
 
         cancellationToken = CancellationTokenExtensions.CombineWith(_unloadCancellationToken, cancellationToken).Token;
@@ -555,7 +555,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
     public async Task<T> WriteAsync<T>(Func<IWorkspace, Task<T>> action, CancellationToken cancellationToken)
     {
-        Requires.NotNull(action, nameof(action));
+        Requires.NotNull(action);
         Verify.NotDisposed(this);
 
         cancellationToken = CancellationTokenExtensions.CombineWith(_unloadCancellationToken, cancellationToken).Token;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
             ProjectProperties projectProperties,
             IProjectThreadingService threadingService)
         {
-            Requires.NotNull(projectProperties, nameof(projectProperties));
-            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(projectProperties);
+            Requires.NotNull(threadingService);
 
             _projectProperties = projectProperties;
             _threadingService = threadingService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/MapDynamicEnumValuesProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic
             IDictionary<string, IEnumValue> valueMap,
             ICollection<IEnumValue>? getValues = null)
         {
-            Requires.NotNull(valueMap, nameof(valueMap));
+            Requires.NotNull(valueMap);
 
             _valueMap = valueMap;
             _getValues = getValues;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)
         {
-            Requires.NotNull(executableStep, nameof(executableStep));
+            Requires.NotNull(executableStep);
 
             return executableStep.Action switch
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public bool TryGetVersion(string versionKey, out long version)
         {
-            Requires.NotNullOrEmpty(versionKey, nameof(versionKey));
+            Requires.NotNullOrEmpty(versionKey);
             lock (SyncObject)
             {
                 return _versions.TryGetValue(versionKey, out version);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public static IEntityValue CreateCategoryValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(parent, nameof(parent));
-            Requires.NotNull(category, nameof(category));
+            Requires.NotNull(parent);
+            Requires.NotNull(category);
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static IEntityValue CreateCategoryValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, Rule rule, Category category, int order, ICategoryPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(category, nameof(category));
+            Requires.NotNull(category);
             var newCategory = new CategorySnapshot(queryExecutionContext.EntityRuntime, id, new CategoryPropertiesAvailableStatus());
 
             if (requestedProperties.DisplayName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromRuleDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/CategoryFromRuleDataProducer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public CategoryFromRuleDataProducer(ICategoryPropertiesAvailableStatus properties)
         {
-            Requires.NotNull(properties, nameof(properties));
+            Requires.NotNull(properties);
             _properties = properties;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)
         {
-            Requires.NotNull(executableStep, nameof(executableStep));
+            Requires.NotNull(executableStep);
 
             return executableStep.Action switch
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetEvaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetEvaluatedUIPropertyValueAction.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public ProjectSetEvaluatedUIPropertyValueAction(SetEvaluatedUIPropertyValue parameter)
             : base(parameter.Page, parameter.Name, parameter.Dimensions)
         {
-            Requires.NotNull(parameter, nameof(parameter));
-            Requires.NotNull(parameter.Dimensions, $"{nameof(parameter)}.{nameof(parameter.Dimensions)}");
+            Requires.NotNull(parameter);
+            Requires.NotNull(parameter.Dimensions);
 
             _parameter = parameter;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUIPropertyValueActionBase.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public Task OnBeforeExecutingBatchAsync(IReadOnlyList<QueryProcessResult<IEntityValue>> allItems, CancellationToken cancellationToken)
         {
-            Requires.NotNull(allItems, nameof(allItems));
+            Requires.NotNull(allItems);
 
             IEnumerable<UnconfiguredProject> targetProjects = allItems
                 .Select(item => ((IEntityValueFromProvider)item.Result).ProviderState)
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public async Task ReceiveResultAsync(QueryProcessResult<IEntityValue> result)
         {
-            Requires.NotNull(result, nameof(result));
+            Requires.NotNull(result);
             result.Request.QueryExecutionContext.CancellationToken.ThrowIfCancellationRequested();
             if (((IEntityValueFromProvider)result.Result).ProviderState is UnconfiguredProject project)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectSetUnevaluatedUIPropertyValueAction.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         public ProjectSetUnevaluatedUIPropertyValueAction(SetUnevaluatedUIPropertyValue parameter)
             : base(parameter.Page, parameter.Name, parameter.Dimensions)
         {
-            Requires.NotNull(parameter, nameof(parameter));
-            Requires.NotNull(parameter.Dimensions, $"{nameof(parameter)}.{nameof(parameter.Dimensions)}");
+            Requires.NotNull(parameter);
+            Requires.NotNull(parameter.Dimensions);
 
             _parameter = parameter;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageByIdDataProducer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public PropertyPageByIdDataProducer(IPropertyPagePropertiesAvailableStatus properties, IProjectService2 projectService)
         {
-            Requires.NotNull(properties, nameof(properties));
-            Requires.NotNull(projectService, nameof(projectService));
+            Requires.NotNull(properties);
+            Requires.NotNull(projectService);
 
             _properties = properties;
             _projectService = projectService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public static IEntityValue CreatePropertyPageValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IProjectState cache, QueryProjectPropertiesContext propertiesContext, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(parent, nameof(parent));
-            Requires.NotNull(rule, nameof(rule));
+            Requires.NotNull(parent);
+            Requires.NotNull(rule);
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static IEntityValue CreatePropertyPageValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, IProjectState cache, QueryProjectPropertiesContext propertiesContext, Rule rule, IPropertyPagePropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(rule, nameof(rule));
+            Requires.NotNull(rule);
             var newPropertyPage = new PropertyPageSnapshot(queryExecutionContext.EntityRuntime, id, new PropertyPagePropertiesAvailableStatus());
 
             if (requestedProperties.Name)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyByIdProducer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public UIPropertyByIdProducer(IUIPropertyPropertiesAvailableStatus properties, IProjectService2 projectService)
         {
-            Requires.NotNull(properties, nameof(properties));
-            Requires.NotNull(projectService, nameof(projectService));
+            Requires.NotNull(properties);
+            Requires.NotNull(projectService);
             _properties = properties;
             _projectService = projectService;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducer.cs
@@ -17,8 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, IProjectState cache, QueryProjectPropertiesContext propertiesContext, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(parent, nameof(parent));
-            Requires.NotNull(property, nameof(property));
+            Requires.NotNull(parent);
+            Requires.NotNull(property);
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static IEntityValue CreateUIPropertyValue(IQueryExecutionContext queryExecutionContext, EntityIdentity id, IProjectState cache, QueryProjectPropertiesContext propertiesContext, BaseProperty property, int order, IUIPropertyPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(property, nameof(property));
+            Requires.NotNull(property);
             var newUIProperty = new UIPropertySnapshot(queryExecutionContext.EntityRuntime, id, new UIPropertyPropertiesAvailableStatus());
 
             if (requestedProperties.Name)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorByIdDataProducer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public UIPropertyEditorByIdDataProducer(IUIPropertyEditorPropertiesAvailableStatus properties, IProjectService2 projectService)
         {
-            Requires.NotNull(properties, nameof(properties));
-            Requires.NotNull(projectService, nameof(projectService));
+            Requires.NotNull(properties);
+            Requires.NotNull(projectService);
             _properties = properties;
             _projectService = projectService;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -15,8 +15,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public static IEntityValue CreateEditorValue(IQueryExecutionContext queryExecutionContext, IEntityValue parent, ValueEditor editor, IUIPropertyEditorPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(parent, nameof(parent));
-            Requires.NotNull(editor, nameof(editor));
+            Requires.NotNull(parent);
+            Requires.NotNull(editor);
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
@@ -30,7 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static IEntityValue CreateEditorValue(IQueryExecutionContext queryExecutionContext, EntityIdentity identity, ValueEditor editor, IUIPropertyEditorPropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(editor, nameof(editor));
+            Requires.NotNull(editor);
             var newEditorValue = new UIPropertyEditorSnapshot(queryExecutionContext.EntityRuntime, identity, new UIPropertyEditorPropertiesAvailableStatus());
 
             if (requestedProperties.Name)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -15,9 +15,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
     {
         public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityValue parent, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(parent, nameof(parent));
-            Requires.NotNull(configuration, nameof(configuration));
-            Requires.NotNull(property, nameof(property));
+            Requires.NotNull(parent);
+            Requires.NotNull(configuration);
+            Requires.NotNull(property);
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
         public static async Task<IEntityValue> CreateUIPropertyValueValueAsync(IEntityRuntimeModel runtimeModel, EntityIdentity id, ProjectConfiguration configuration, ProjectSystem.Properties.IProperty property, IUIPropertyValuePropertiesAvailableStatus requestedProperties)
         {
-            Requires.NotNull(property, nameof(property));
+            Requires.NotNull(property);
 
             var newUIPropertyValue = new UIPropertyValueSnapshot(runtimeModel, id, new UIPropertyValuePropertiesAvailableStatus());
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         internal Task RemoveReferenceAsync(ConfiguredProject configuredProject,
             string itemSpecification)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Requires.NotNull(configuredProject);
             Assumes.Present(configuredProject.Services);
 
             return RemoveReferenceAsync(configuredProject.Services, itemSpecification);
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         internal Task AddReferenceAsync(ConfiguredProject configuredProject,
             string itemSpecification)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Requires.NotNull(configuredProject);
             Assumes.Present(configuredProject.Services);
 
             return AddReferenceAsync(configuredProject.Services, itemSpecification);
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
         public Task<IEnumerable<IProjectItem>> GetUnresolvedReferencesAsync(ConfiguredProject selectedConfiguredProject)
         {
-            Requires.NotNull(selectedConfiguredProject, nameof(selectedConfiguredProject));
+            Requires.NotNull(selectedConfiguredProject);
             Assumes.Present(selectedConfiguredProject.Services);
 
             return GetUnresolvedReferencesAsync(selectedConfiguredProject.Services);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/DesignTimeAssemblyResolution.cs
@@ -35,7 +35,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         [ImportingConstructor]
         public DesignTimeAssemblyResolution(IUnconfiguredProjectVsServices projectVsServices)
         {
-            Requires.NotNull(projectVsServices, nameof(projectVsServices));
+            Requires.NotNull(projectVsServices);
 
             _projectVsServices = projectVsServices;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Globalization;
-using System.Runtime.Remoting.Contexts;
 using EnvDTE;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Rename;
@@ -72,9 +71,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
 
         public override async Task RenameAsync(IProjectTreeActionHandlerContext context, IProjectTree node, string value)
         {
-            Requires.NotNull(context, nameof(Context));
-            Requires.NotNull(node, nameof(node));
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Requires.NotNull(context);
+            Requires.NotNull(node);
+            Requires.NotNullOrEmpty(value);
 
             string? oldFilePath = node.FilePath;
             string oldName = Path.GetFileNameWithoutExtension(oldFilePath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainedByRelationCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainedByRelationCollection.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         internal AggregateContainedByRelationCollection(List<object> parentItems)
         {
-            Requires.NotNull(parentItems, nameof(parentItems));
+            Requires.NotNull(parentItems);
 
             _parentItems = parentItems;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollectionSpan.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateContainsRelationCollectionSpan.cs
@@ -29,8 +29,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         internal AggregateContainsRelationCollectionSpan(AggregateContainsRelationCollection parent, IRelation relation)
         {
-            Requires.NotNull(parent, nameof(parent));
-            Requires.NotNull(relation, nameof(relation));
+            Requires.NotNull(parent);
+            Requires.NotNull(relation);
 
             _parent = parent;
             Relation = relation;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AggregateRelationCollectionSource.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public AggregateRelationCollectionSource(object sourceItem, IAggregateRelationCollection? collection = null)
         {
-            _sourceItem = Requires.NotNull(sourceItem, nameof(sourceItem));
+            _sourceItem = Requires.NotNull(sourceItem);
 
             if (collection is not null)
             {
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 throw new InvalidOperationException("Backing collection has already been provided.");
             }
 
-            _collection = Requires.NotNull(collection, nameof(collection));
+            _collection = Requires.NotNull(collection);
             _collection.HasItemsChanged += delegate
             {
                 PropertyChanged?.Invoke(this, KnownEventArgs.HasItemsPropertyChanged);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/AttachedCollectionItemBase.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         protected AttachedCollectionItemBase(string name)
         {
-            Requires.NotNullOrWhiteSpace(name, nameof(name));
+            Requires.NotNullOrWhiteSpace(name);
 
             _text = name;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeProjectSearchContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeProjectSearchContext.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public async Task<IDependenciesTreeConfiguredProjectSearchContext?> ForConfiguredProjectAsync(ConfiguredProject configuredProject, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(configuredProject, nameof(configuredProject));
+            Requires.NotNull(configuredProject);
 
             IProjectTree targetRootNode;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/DependenciesTreeSearchProvider.cs
@@ -66,8 +66,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public void Search(IRelationshipSearchParameters parameters, Action<ISearchResult> resultAccumulator)
         {
-            Requires.NotNull(parameters, nameof(parameters));
-            Requires.NotNull(resultAccumulator, nameof(resultAccumulator));
+            Requires.NotNull(parameters);
+            Requires.NotNull(resultAccumulator);
 
             if (_providers.IsEmpty)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/FlagsStringMatcher.cs
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public bool Matches(string flagsString)
         {
-            Requires.NotNull(flagsString, nameof(flagsString));
+            Requires.NotNull(flagsString);
 
             if (_regex is null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         public FrameworkReferenceAssemblyItem(string assemblyName, string? path, string? assemblyVersion, string? fileVersion, FrameworkReferenceIdentity framework)
             : base(assemblyName)
         {
-            Requires.NotNull(framework, nameof(framework));
+            Requires.NotNull(framework);
             AssemblyName = assemblyName;
             Path = path;
             AssemblyVersion = assemblyVersion;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceIdentity.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
         public FrameworkReferenceIdentity(string path, string? profile, string name)
         {
-            Requires.NotNullOrWhiteSpace(path, nameof(path));
-            Requires.NotNullOrWhiteSpace(name, nameof(name));
+            Requires.NotNullOrWhiteSpace(path);
+            Requires.NotNullOrWhiteSpace(name);
 
             Path = path;
             Profile = profile;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/Commands/DependenciesContextMenuProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 
         public bool TryGetContextMenu(IProjectTree projectItem, out Guid menuCommandGuid, out int menuCommandId)
         {
-            Requires.NotNull(projectItem, nameof(projectItem));
+            Requires.NotNull(projectItem);
 
             if (projectItem.Flags.Contains(DependencyTreeFlags.DependenciesRootNode))
             {
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.Commands
 
         public bool TryGetMixedItemsContextMenu(IEnumerable<IProjectTree> projectItems, out Guid menuCommandGuid, out int menuCommandId)
         {
-            Requires.NotNull(projectItems, nameof(projectItems));
+            Requires.NotNull(projectItems);
 
             menuCommandGuid = default;
             menuCommandId = default;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/ProjectImports/ImportTreeCommandGroupHandler.cs
@@ -29,11 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.ProjectImports
             IVsUIService<IVsExternalFilesManager> externalFilesManager,
             IVsUIService<IOleServiceProvider> oleServiceProvider)
         {
-            Requires.NotNull(serviceProvider, nameof(serviceProvider));
-            Requires.NotNull(configuredProject, nameof(configuredProject));
-            Requires.NotNull(uiShellOpenDocument, nameof(uiShellOpenDocument));
-            Requires.NotNull(externalFilesManager, nameof(externalFilesManager));
-            Requires.NotNull(oleServiceProvider, nameof(oleServiceProvider));
+            Requires.NotNull(serviceProvider);
+            Requires.NotNull(configuredProject);
+            Requires.NotNull(uiShellOpenDocument);
+            Requires.NotNull(externalFilesManager);
+            Requires.NotNull(oleServiceProvider);
 
             _serviceProvider = serviceProvider;
             _configuredProject = configuredProject;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/AddItemDialogService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/AddItemDialogService.cs
@@ -32,8 +32,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UI
 
         public Task<bool> ShowAddNewItemDialogAsync(IProjectTree node, string directoryLocalizedName, string templateLocalizedName)
         {
-            Requires.NotNullOrEmpty(directoryLocalizedName, nameof(directoryLocalizedName));
-            Requires.NotNullOrEmpty(templateLocalizedName, nameof(templateLocalizedName));
+            Requires.NotNullOrEmpty(directoryLocalizedName);
+            Requires.NotNullOrEmpty(templateLocalizedName);
 
             return ShowDialogAsync(node,
                __VSADDITEMFLAGS.VSADDITEM_AddNewItems |

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/InfoBarUI.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/InfoBarUI.cs
@@ -16,8 +16,8 @@ internal class InfoBarUI
     /// <param name="closeAfterAction"><see langword="true"/> if the information bar should close after <paramref name="action"/> is run.</param>
     public InfoBarUI(string title, InfoBarUIKind kind, Action action, bool closeAfterAction = true)
     {
-        Requires.NotNullOrEmpty(title, nameof(title));
-        Requires.NotNull(action, nameof(action));
+        Requires.NotNullOrEmpty(title);
+        Requires.NotNull(action);
 
         Title = title;
         Kind = kind;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.InfoBarEntry.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.InfoBarEntry.cs
@@ -36,8 +36,8 @@ internal partial class VsInfoBarService
 
         public void OnActionItemClicked(IVsInfoBarUIElement element, IVsInfoBarActionItem actionItem)
         {
-            Requires.NotNull(element, nameof(element));
-            Requires.NotNull(actionItem, nameof(actionItem));
+            Requires.NotNull(element);
+            Requires.NotNull(actionItem);
 
             InfoBarUI item = _items.First(i => i.Title == actionItem.Text);
             item.Action();
@@ -50,7 +50,7 @@ internal partial class VsInfoBarService
 
         public void OnClosed(IVsInfoBarUIElement element)
         {
-            Requires.NotNull(element, nameof(element));
+            Requires.NotNull(element);
 
             _element.Unadvise(_cookie);
             _onClose(this);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBarService/VsInfoBarService.cs
@@ -34,8 +34,8 @@ internal partial class VsInfoBarService : IInfoBarService
 
     public async Task ShowInfoBarAsync(string message, ImageMoniker image, CancellationToken cancellationToken, params InfoBarUI[] items)
     {
-        Requires.NotNullOrEmpty(message, nameof(message));
-        Requires.NotNull(items, nameof(items));
+        Requires.NotNullOrEmpty(message);
+        Requires.NotNull(items);
 
         if (!await _vsShellServices.IsCommandLineModeAsync(cancellationToken))
         {
@@ -122,7 +122,7 @@ internal partial class VsInfoBarService : IInfoBarService
 
     private void OnClosed(InfoBarEntry entry)
     {
-        Requires.NotNull(entry, nameof(entry));
+        Requires.NotNull(entry);
 
         _threadingService.VerifyOnUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsUIService`1.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [ImportingConstructor]
         public VsUIService([Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider, JoinableTaskContext joinableTaskContext)
         {
-            Requires.NotNull(serviceProvider, nameof(serviceProvider));
-            Requires.NotNull(joinableTaskContext, nameof(joinableTaskContext));
+            Requires.NotNull(serviceProvider);
+            Requires.NotNull(joinableTaskContext);
 
             _value = new Lazy<T>(() => (T)serviceProvider.GetService(ServiceType));
             _joinableTaskContext = joinableTaskContext;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
@@ -761,8 +761,8 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
 
         public BufferLock(IVsTextLines buffer, IDebugLockCheck debugLockCheck)
         {
-            Requires.NotNull(buffer, nameof(buffer));
-            Requires.NotNull(debugLockCheck, nameof(debugLockCheck));
+            Requires.NotNull(buffer);
+            Requires.NotNull(debugLockCheck);
 
             _buffer = buffer;
             _debugLockCheck = debugLockCheck;
@@ -815,9 +815,9 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
 
         public XamlProperty(IVsTextLines vsTextLines, Location startLocation, Location endLocation, string? unescapedValue, bool definitionIncludesQuotes)
         {
-            Requires.NotNull(vsTextLines, nameof(vsTextLines));
-            Requires.NotNull(startLocation, nameof(startLocation));
-            Requires.NotNull(endLocation, nameof(endLocation));
+            Requires.NotNull(vsTextLines);
+            Requires.NotNull(startLocation);
+            Requires.NotNull(endLocation);
 
             unescapedValue ??= string.Empty;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.EditorInfo.cs
@@ -8,8 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
         {
             public EditorInfo(Guid editor, string displayName, bool isDefaultEditor)
             {
-                Requires.NotEmpty(editor, nameof(editor));
-                Requires.NotNullOrEmpty(displayName, nameof(displayName));
+                Requires.NotEmpty(editor);
+                Requires.NotNullOrEmpty(displayName);
 
                 EditorFactory = editor;
                 DisplayName = displayName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
         public async Task<IProjectSpecificEditorInfo?> GetSpecificEditorAsync(string documentMoniker)
         {
-            Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
+            Requires.NotNullOrEmpty(documentMoniker);
 
             IProjectSpecificEditorInfo? editor = await GetDefaultEditorAsync(documentMoniker);
             if (editor is null)
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
         public async Task<bool> SetUseGlobalEditorAsync(string documentMoniker, bool useGlobalEditor)
         {
-            Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
+            Requires.NotNullOrEmpty(documentMoniker);
 
             SubTypeDescriptor? editorInfo = await GetSubTypeDescriptorAsync(documentMoniker);
             if (editorInfo is null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </exception>
         public static void ActivatePane(this IVsOutputWindow outputWindow, Guid paneGuid)
         {
-            Requires.NotNull(outputWindow, nameof(outputWindow));
-            Requires.NotEmpty(paneGuid, nameof(paneGuid));
+            Requires.NotNull(outputWindow);
+            Requires.NotEmpty(paneGuid);
 
             HResult hr = outputWindow.GetPane(ref paneGuid, out IVsOutputWindowPane pane);
             if (hr.IsOK) // Pane found
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </exception>
         public static Guid GetActivePane(this IVsOutputWindow outputWindow)
         {
-            Requires.NotNull(outputWindow, nameof(outputWindow));
+            Requires.NotNull(outputWindow);
 
             if (outputWindow is IVsOutputWindow2 outputWindow2)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowPaneExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/IVsOutputWindowPaneExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </exception>
         public static void OutputStringNoPump(this IVsOutputWindowPane pane, string pszOutputString)
         {
-            Requires.NotNull(pane, nameof(pane));
+            Requires.NotNull(pane);
 
             if (pane is IVsOutputWindowPaneNoPump noPumpPane)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsHierarchyExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </summary>
         public static Guid GetGuidProperty(this IVsHierarchy hierarchy, VsHierarchyPropID property)
         {
-            Requires.NotNull(hierarchy, nameof(hierarchy));
+            Requires.NotNull(hierarchy);
             Verify.HResult(hierarchy.GetGuidProperty(HierarchyId.Root, (int)property, out Guid result));
 
             return result;
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </summary>
         public static int GetProperty<T>(this IVsHierarchy hierarchy, HierarchyId item, VsHierarchyPropID property, T defaultValue, out T? result)
         {
-            Requires.NotNull(hierarchy, nameof(hierarchy));
+            Requires.NotNull(hierarchy);
 
             if (item.IsNilOrEmpty || item.IsSelection)
                 throw new ArgumentException(null, nameof(item));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsProjectExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/Interop/VsProjectExtensions.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </summary>
         public static HierarchyId GetHierarchyId(this IVsProject project, string documentMoniker)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNullOrEmpty(documentMoniker, nameof(documentMoniker));
+            Requires.NotNull(project);
+            Requires.NotNullOrEmpty(documentMoniker);
 
             var priority = new VSDOCUMENTPRIORITY[1];
             Verify.HResult(project.IsDocumentInProject(documentMoniker, out int isFound, priority, out uint itemId));
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
         /// </returns>
         public static IVsWindowFrame? OpenItemWithSpecific(this IVsProject4 project, HierarchyId id, Guid editorType)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             Verify.HResult(project.OpenItemWithSpecific(id, 0, ref editorType, "", VSConstants.LOGVIEWID_Primary, (IntPtr)(-1), out IVsWindowFrame frame));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/ServiceProviderToOleServiceProviderAdapter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Shell
 
         public ServiceProviderToOleServiceProviderAdapter(IServiceProvider serviceProvider)
         {
-            Requires.NotNull(serviceProvider, nameof(serviceProvider));
+            Requires.NotNull(serviceProvider);
 
             _serviceProvider = serviceProvider;
         }
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.Shell
 
         private static HResult GetComInterfaceForObject(object instance, Guid iid, out IntPtr ppvObject)
         {
-            Requires.NotNull(instance, nameof(instance));
+            Requires.NotNull(instance);
 
             IntPtr unknown = Marshal.GetIUnknownForObject(instance);
             if (iid.Equals(VSConstants.IID_IUnknown))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/SolutionExplorerWindow.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/SolutionExplorerWindow.cs
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.Shell
 
         private HResult ExpandItem(IVsUIHierarchy uiHierarchy, HierarchyId id, EXPANDFLAGS flags)
         {
-            Requires.NotNull(uiHierarchy, nameof(uiHierarchy));
+            Requires.NotNull(uiHierarchy);
             Requires.Argument(!(id.IsNilOrEmpty || id.IsSelection), nameof(id), "id must not be nil, empty or represent a selection.");
 
             return Invoke(window => window.ExpandItem(uiHierarchy, id, flags));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Threading/JoinableTaskContextExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Threading/JoinableTaskContextExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.Threading
         /// </summary>
         public static void VerifyIsOnMainThread(this JoinableTaskContext joinableTaskContext)
         {
-            Requires.NotNull(joinableTaskContext, nameof(joinableTaskContext));
+            Requires.NotNull(joinableTaskContext);
 
             if (!joinableTaskContext.IsOnMainThread)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.Build
         /// </exception>
         public static string GetUnescapedValue(this ProjectPropertyElement element)
         {
-            Requires.NotNull(element, nameof(element));
+            Requires.NotNull(element);
 
             return ProjectCollection.Unescape(element.Value);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.Build
         /// </summary>
         public static bool HasWellKnownConditionsThatAlwaysEvaluateToTrue(ProjectPropertyElement element)
         {
-            Requires.NotNull(element, nameof(element));
+            Requires.NotNull(element);
 
             // We look for known conditions that evaluate to true so that 
             // projects can have patterns where they opt in/out of target 
@@ -46,7 +46,7 @@ namespace Microsoft.VisualStudio.Build
         /// <returns>Requested project property. Null if the property is not present.</returns>
         public static ProjectPropertyElement? GetProperty(ProjectRootElement project, string propertyName)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             return project.Properties
                 .FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparisons.PropertyNames));
@@ -93,9 +93,9 @@ namespace Microsoft.VisualStudio.Build
         /// <param name="valueToAppend">Value to add to the property.</param>
         public static void AppendPropertyValue(ProjectRootElement project, string evaluatedPropertyValue, string propertyName, string valueToAppend)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(evaluatedPropertyValue, nameof(evaluatedPropertyValue));
-            Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
+            Requires.NotNull(project);
+            Requires.NotNull(evaluatedPropertyValue);
+            Requires.NotNullOrEmpty(propertyName);
 
             ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
             var newValue = PooledStringBuilder.GetInstance();
@@ -122,9 +122,9 @@ namespace Microsoft.VisualStudio.Build
         /// </remarks>
         public static void RemovePropertyValue(ProjectRootElement project, string evaluatedPropertyValue, string propertyName, string valueToRemove)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(evaluatedPropertyValue, nameof(evaluatedPropertyValue));
-            Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
+            Requires.NotNull(project);
+            Requires.NotNull(evaluatedPropertyValue);
+            Requires.NotNullOrEmpty(propertyName);
 
             ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
             var newValue = new StringBuilder();
@@ -168,9 +168,9 @@ namespace Microsoft.VisualStudio.Build
         /// </remarks>
         public static void RenamePropertyValue(ProjectRootElement project, string evaluatedPropertyValue, string propertyName, string? oldValue, string newValue)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(evaluatedPropertyValue, nameof(evaluatedPropertyValue));
-            Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
+            Requires.NotNull(project);
+            Requires.NotNull(evaluatedPropertyValue);
+            Requires.NotNullOrEmpty(propertyName);
 
             ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
             var value = new StringBuilder();
@@ -208,7 +208,7 @@ namespace Microsoft.VisualStudio.Build
         /// <param name="propertyName">Property name.</param>
         public static ProjectPropertyElement GetOrAddProperty(ProjectRootElement project, string propertyName)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
             ProjectPropertyElement? property = GetProperty(project, propertyName);
 
             if (property is not null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ConcurrentHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ConcurrentHashSet.cs
@@ -39,7 +39,7 @@ namespace System.Collections.Concurrent
 
         public bool AddRange(IEnumerable<T> elements)
         {
-            Requires.NotNull(elements, nameof(elements));
+            Requires.NotNull(elements);
 
             bool changed = false;
             foreach (var element in elements)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ComparableExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ComparableExtensions.cs
@@ -20,8 +20,8 @@ namespace Microsoft.VisualStudio
         /// </exception>
         public static bool IsLaterThan(this IComparable source, IComparable comparable)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(comparable, nameof(comparable));
+            Requires.NotNull(source);
+            Requires.NotNull(comparable);
 
             return source.CompareTo(comparable) > 0;
         }
@@ -39,8 +39,8 @@ namespace Microsoft.VisualStudio
         /// </exception>
         public static bool IsLaterThanOrEqualTo(this IComparable source, IComparable comparable)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(comparable, nameof(comparable));
+            Requires.NotNull(source);
+            Requires.NotNull(comparable);
 
             return source.CompareTo(comparable) >= 0;
         }
@@ -58,8 +58,8 @@ namespace Microsoft.VisualStudio
         /// </exception>
         public static bool IsEarlierThan(this IComparable source, IComparable comparable)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(comparable, nameof(comparable));
+            Requires.NotNull(source);
+            Requires.NotNull(comparable);
 
             return source.CompareTo(comparable) < 0;
         }
@@ -77,8 +77,8 @@ namespace Microsoft.VisualStudio
         /// </exception>
         public static bool IsEarlierThanOrEqualTo(this IComparable source, IComparable comparable)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(comparable, nameof(comparable));
+            Requires.NotNull(source);
+            Requires.NotNull(comparable);
 
             return source.CompareTo(comparable) <= 0;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/OrderPrecedenceImportCollectionExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Composition/OrderPrecedenceImportCollectionExtensions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Composition
         /// <returns>The safely constructed sequence of extensions.</returns>
         internal static IEnumerable<T> ExtensionValues<T>(this OrderPrecedenceImportCollection<T> extensions, bool onlyCreatedValues = false)
         {
-            Requires.NotNull(extensions, nameof(extensions));
+            Requires.NotNull(extensions);
             string traceErrorMessage = "Roslyn project system extension rejected due to exception: {0}";
 
             foreach (Lazy<T> extension in extensions)
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public static T? FirstOrDefaultValue<T>(this OrderPrecedenceImportCollection<T> imports, Func<T, bool> predicate) where T : class
         {
-            Requires.NotNull(imports, nameof(imports));
+            Requires.NotNull(imports);
 
             foreach (Lazy<T> import in imports)
             {
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public static TImport? FirstOrDefaultValue<TImport, TArg>(this OrderPrecedenceImportCollection<TImport> imports, Func<TImport, TArg, bool> predicate, TArg arg) where TImport : class
         {
-            Requires.NotNull(imports, nameof(imports));
+            Requires.NotNull(imports);
 
             foreach (Lazy<TImport> import in imports)
             {
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.Composition
 
         public static ImmutableArray<T> ToImmutableValueArray<T>(this OrderPrecedenceImportCollection<T> imports)
         {
-            Requires.NotNull(imports, nameof(imports));
+            Requires.NotNull(imports);
 
             ImmutableArray<T>.Builder builder = ImmutableArray.CreateBuilder<T>(imports.Count);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsFileExplorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/WindowsFileExplorer.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.IO
 
         public void OpenContainingFolder(string path)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(path);
 
             // When 'path' doesn't exist, Explorer just opens the default
             // "Quick Access" page, so try to something better than that.
@@ -42,7 +42,7 @@ namespace Microsoft.VisualStudio.IO
 
         public void OpenFolder(string path)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(path);
 
             // Tell Explorer just open the contents of the folder, selecting nothing
             ShellExecute("explore", path);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledStringBuilder.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
 
         private PooledStringBuilder(ObjectPool<PooledStringBuilder> pool)
         {
-            Requires.NotNull(pool, nameof(pool));
+            Requires.NotNull(pool);
             _pool = pool;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredObjects.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredObjects.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         public ActiveConfiguredObjects(ImmutableArray<T> objects, IImmutableSet<string> dimensionNames)
         {
-            Requires.NotNull(dimensionNames, nameof(dimensionNames));
+            Requires.NotNull(dimensionNames);
             Requires.Argument(!objects.IsDefaultOrEmpty, nameof(objects), "Must not be default or empty.");
 
             Objects = objects;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/OutputGroup.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/OutputGroup.cs
@@ -15,10 +15,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
         /// </summary>
         internal OutputGroup(string name, string targetName, string displayName, string? description, IImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>> items, bool successful)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
-            Requires.NotNullOrEmpty(targetName, nameof(targetName));
-            Requires.NotNullOrEmpty(displayName, nameof(displayName));
-            Requires.NotNull(items, nameof(items));
+            Requires.NotNullOrEmpty(name);
+            Requires.NotNullOrEmpty(targetName);
+            Requires.NotNullOrEmpty(displayName);
+            Requires.NotNull(items);
 
             Name = name;
             TargetName = targetName;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         /// <param name="dimensionDefaultValue">The default value of the dimension, for example "AnyCPU".</param>
         protected BaseProjectConfigurationDimensionProvider(IProjectAccessor projectAccessor, string dimensionName, string propertyName, string? dimensionDefaultValue = null)
         {
-            Requires.NotNull(projectAccessor, nameof(projectAccessor));
+            Requires.NotNull(projectAccessor);
 
             ProjectAccessor = projectAccessor;
             DimensionName = dimensionName;
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         /// </remarks>
         private async Task<ImmutableArray<string>> GetOrderedPropertyValuesAsync(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             ConfiguredProject? configuredProject = await project.GetSuggestedConfiguredProjectAsync();
 
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         /// <returns>Collection of values for the dimension.</returns>
         private ImmutableArray<string> GetOrderedPropertyValues(Project project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             string? propertyValue = project.GetProperty(PropertyName)?.EvaluatedValue;
 
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         /// </remarks>
         public virtual async Task<IEnumerable<KeyValuePair<string, string>>> GetDefaultValuesForDimensionsAsync(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project);
             if (values.IsEmpty)
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         /// </remarks>
         public virtual async Task<IEnumerable<KeyValuePair<string, IEnumerable<string>>>> GetProjectConfigurationDimensionsAsync(UnconfiguredProject project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project);
             if (values.IsEmpty)
@@ -203,7 +203,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
         public virtual Task<IEnumerable<KeyValuePair<string, IEnumerable<string>>>> GetProjectConfigurationDimensionsAsync(Project project)
         {
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(project);
 
             ImmutableArray<string> values = GetOrderedPropertyValues(project);
             if (values.IsEmpty)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/ImplicitlyActiveDimensionProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
         public IEnumerable<string> GetImplicitlyActiveDimensions(IEnumerable<string> dimensionNames)
         {
-            Requires.NotNull(dimensionNames, nameof(dimensionNames));
+            Requires.NotNull(dimensionNames);
 
             ImmutableArray<string> builtInDimensions = _builtInImplicitlyActiveDimensions.Value;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/CopyPaste/DependencyTextPackager.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.CopyPaste
 
         private static bool IsValidSetOfNodes(IEnumerable<IProjectTree> treeNodes)
         {
-            Requires.NotNull(treeNodes, nameof(treeNodes));
+            Requires.NotNull(treeNodes);
 
             return treeNodes.All(node => node.Flags.Contains(DependencyTreeFlags.Dependency | DependencyTreeFlags.SupportsBrowse));
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowBlockFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowBlockFactory.cs
@@ -16,8 +16,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         public static ITargetBlock<TInput> CreateActionBlock<TInput>(Action<TInput> target, UnconfiguredProject project, ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable, string? nameFormat = null, bool skipIntermediateInputData = false)
         {
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             ITargetBlock<TInput> block = DataflowBlockSlim.CreateActionBlock(target, nameFormat, skipIntermediateInputData: skipIntermediateInputData);
 
@@ -31,8 +31,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         public static ITargetBlock<TInput> CreateActionBlock<TInput>(Func<TInput, Task> target, UnconfiguredProject project, ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable, string? nameFormat = null, bool skipIntermediateInputData = false)
         {
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             ITargetBlock<TInput> block = DataflowBlockSlim.CreateActionBlock(target, nameFormat, skipIntermediateInputData: skipIntermediateInputData);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowOption.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowOption.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         public static StandardRuleDataflowLinkOptions WithRuleNames(IEnumerable<string> ruleNames)
         {
-            Requires.NotNull(ruleNames, nameof(ruleNames));
+            Requires.NotNull(ruleNames);
 
             return WithRuleNames(ImmutableHashSet.CreateRange(ruleNames));
         }
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         public static StandardRuleDataflowLinkOptions WithRuleNames(params string[] ruleNames)
         {
-            Requires.NotNull(ruleNames, nameof(ruleNames));
+            Requires.NotNull(ruleNames);
 
             return WithRuleNames(ImmutableHashSet.Create(ruleNames));
         }
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         public static StandardRuleDataflowLinkOptions WithRuleNames(IImmutableSet<string> ruleNames)
         {
-            Requires.NotNull(ruleNames, nameof(ruleNames));
+            Requires.NotNull(ruleNames);
 
             return new StandardRuleDataflowLinkOptions()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DataflowUtilities.cs
@@ -49,9 +49,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool suppressVersionOnlyUpdates = true,
             params string[] ruleNames)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(source);
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             return source.LinkTo(DataflowBlockFactory.CreateActionBlock(target, project, severity),
                                  DataflowOption.PropagateCompletion,
@@ -103,9 +103,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool suppressVersionOnlyUpdates = true,
             IEnumerable<string>? ruleNames = null)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(source);
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             return source.LinkTo(DataflowBlockFactory.CreateActionBlock(target, project, severity),
                                  DataflowOption.PropagateCompletion,
@@ -153,9 +153,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool suppressVersionOnlyUpdates = true,
             params string[] ruleNames)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(source);
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             return source.LinkTo(DataflowBlockFactory.CreateActionBlock(target, project, ProjectFaultSeverity.Recoverable),
                                  DataflowOption.PropagateCompletion,
@@ -207,9 +207,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool suppressVersionOnlyUpdates = true,
             IEnumerable<string>? ruleNames = null)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(source);
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             return source.LinkTo(DataflowBlockFactory.CreateActionBlock(target, project, severity),
                                  DataflowOption.PropagateCompletion,
@@ -250,9 +250,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Action<T> target,
             UnconfiguredProject project)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(source);
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             return source.LinkTo(DataflowBlockFactory.CreateActionBlock(target, project, ProjectFaultSeverity.Recoverable),
                                  DataflowOption.PropagateCompletion);
@@ -281,9 +281,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
             Func<T, Task> target,
             UnconfiguredProject project)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(target, nameof(target));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(source);
+            Requires.NotNull(target);
+            Requires.NotNull(project);
 
             return source.LinkTo(DataflowBlockFactory.CreateActionBlock(target, project, ProjectFaultSeverity.Recoverable),
                                  DataflowOption.PropagateCompletion);
@@ -318,8 +318,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             this ISourceBlock<IProjectVersionedValue<TInput>> source,
             Func<IProjectVersionedValue<TInput>, TOut> transform)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(transform, nameof(transform));
+            Requires.NotNull(source);
+            Requires.NotNull(transform);
 
             IPropagatorBlock<IProjectVersionedValue<TInput>, TOut> transformBlock = DataflowBlockSlim.CreateTransformBlock(transform);
 
@@ -359,8 +359,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             this ISourceBlock<IProjectVersionedValue<TInput>> source,
             Func<IProjectVersionedValue<TInput>, Task<IEnumerable<TOut>>> transform)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(transform, nameof(transform));
+            Requires.NotNull(source);
+            Requires.NotNull(transform);
 
             IPropagatorBlock<IProjectVersionedValue<TInput>, TOut> transformBlock = DataflowBlockSlim.CreateTransformManyBlock(transform, skipIntermediateInputData: true, skipIntermediateOutputData: true);
 
@@ -400,8 +400,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             this ISourceBlock<IProjectVersionedValue<TInput>> source,
             Func<IProjectVersionedValue<TInput>, TOut> transform)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(transform, nameof(transform));
+            Requires.NotNull(source);
+            Requires.NotNull(transform);
 
             IPropagatorBlock<IProjectVersionedValue<TInput>, TOut> transformBlock = DataflowBlockSlim.CreateTransformBlock(transform, skipIntermediateInputData: true, skipIntermediateOutputData: true);
 
@@ -441,8 +441,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             this ISourceBlock<IProjectVersionedValue<TInput>> source,
             Func<IProjectVersionedValue<TInput>, Task<TOut>> transform)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(transform, nameof(transform));
+            Requires.NotNull(source);
+            Requires.NotNull(transform);
 
             IPropagatorBlock<IProjectVersionedValue<TInput>, TOut> transformBlock = DataflowBlockSlim.CreateTransformBlock(transform, skipIntermediateInputData: true, skipIntermediateOutputData: true);
 
@@ -528,8 +528,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             bool suppressVersionOnlyUpdates,
             IEnumerable<string>? ruleNames = null)
         {
-            Requires.NotNull(source, nameof(source));
-            Requires.NotNull(transform, nameof(transform));
+            Requires.NotNull(source);
+            Requires.NotNull(transform);
 
             IPropagatorBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>, TOut> transformBlock = DataflowBlockSlim.CreateTransformBlock(transform, skipIntermediateInputData: true, skipIntermediateOutputData: true);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -23,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             ILaunchSettingsProvider profileProvider,
             IProjectThreadingService threadingService)
         {
-            Requires.NotNull(profileProvider, nameof(profileProvider));
-            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(profileProvider);
+            Requires.NotNull(threadingService);
 
             _listedValues = new AsyncLazy<ICollection<IEnumValue>>(delegate
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Extensibility/ProjectExportProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Extensibility/ProjectExportProvider.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Extensibility
 
         public T? GetExport<T>(string projectFilePath) where T : class
         {
-            Requires.NotNullOrEmpty(projectFilePath, nameof(projectFilePath));
+            Requires.NotNullOrEmpty(projectFilePath);
 
             IProjectService projectService = _projectServiceAccessor.GetProjectService();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FaultExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FaultExtensions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             UnconfiguredProject? project,
             ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable)
         {
-            Requires.NotNull(faultHandlerService, nameof(faultHandlerService));
+            Requires.NotNull(faultHandlerService);
 
             return faultHandlerService.HandleFaultAsync(ex, s_defaultReportSettings, severity, project);
         }
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             UnconfiguredProject? project,
             ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable)
         {
-            Requires.NotNull(faultHandlerService, nameof(faultHandlerService));
+            Requires.NotNull(faultHandlerService);
 
             faultHandlerService.RegisterFaultHandler(task, s_defaultReportSettings, severity, project);
         }
@@ -94,7 +94,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             UnconfiguredProject? project,
             ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable)
         {
-            Requires.NotNull(faultHandlerService, nameof(faultHandlerService));
+            Requires.NotNull(faultHandlerService);
 
             faultHandlerService.RegisterFaultHandler(task, s_defaultReportSettings, severity, project);
         }
@@ -125,7 +125,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable,
             ForkOptions options = ForkOptions.Default)
         {
-            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(threadingService);
 
             // If you do not pass in a project it is not legal to ask the threading service to cancel this operation on project unloading
             if (unconfiguredProject is null)
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable,
             ForkOptions options = ForkOptions.Default)
         {
-            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(threadingService);
 
             // If you do not pass in a project it is not legal to ask the threading service to cancel this operation on project unloading
             if (configuredProject is null)
@@ -195,8 +195,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             UnconfiguredProject? project,
             ProjectFaultSeverity severity = ProjectFaultSeverity.Recoverable)
         {
-            Requires.NotNull(faultHandlerService, nameof(faultHandlerService));
-            Requires.NotNull(block, nameof(block));
+            Requires.NotNull(faultHandlerService);
+            Requires.NotNull(block);
 
             return block.Completion.ContinueWith(_ =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/FileItemServices.cs
@@ -10,9 +10,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         public static string[]? GetLogicalFolderNames(string basePath, string fullPath, IImmutableDictionary<string, string> metadata)
         {
-            Requires.NotNullOrEmpty(basePath, nameof(basePath));
-            Requires.NotNullOrEmpty(fullPath, nameof(fullPath));
-            Requires.NotNull(metadata, nameof(metadata));
+            Requires.NotNullOrEmpty(basePath);
+            Requires.NotNullOrEmpty(fullPath);
+            Requires.NotNull(metadata);
 
             // Roslyn wants the effective set of folders from the source up to, but not including the project 
             // root to handle the cases where linked files have a different path in the tree than what its path 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Frameworks/TargetFramework.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public TargetFramework(string moniker)
         {
-            Requires.NotNull(moniker, nameof(moniker));
+            Requires.NotNull(moniker);
 
             TargetFrameworkAlias = moniker;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/AppDesignerFolderProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/AppDesignerFolderProjectImageProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
 
         public ProjectImageMoniker? GetProjectImage(string key)
         {
-            Requires.NotNullOrEmpty(key, nameof(key));
+            Requires.NotNullOrEmpty(key);
 
             return key switch
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/CSharp/CSharpProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/CSharp/CSharpProjectImageProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging.CSharp
 
         public ProjectImageMoniker? GetProjectImage(string key)
         {
-            Requires.NotNullOrEmpty(key, nameof(key));
+            Requires.NotNullOrEmpty(key);
 
             return key switch
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/FSharp/FSharpProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/FSharp/FSharpProjectImageProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging.FSharp
 
         public ProjectImageMoniker? GetProjectImage(string key)
         {
-            Requires.NotNullOrEmpty(key, nameof(key));
+            Requires.NotNullOrEmpty(key);
 
             return key == ProjectImageKey.ProjectRoot ?
                 KnownMonikers.FSProjectNode.ToProjectSystemType() :

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageProviderAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/ProjectImageProviderAggregator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging
 
         public ProjectImageMoniker? GetProjectImage(string key)
         {
-            Requires.NotNullOrEmpty(key, nameof(key));
+            Requires.NotNullOrEmpty(key);
 
             foreach (Lazy<IProjectImageProvider> provider in ImageProviders)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/VisualBasic/VisualBasicProjectImageProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Imaging/VisualBasic/VisualBasicProjectImageProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Imaging.VisualBasic
 
         public ProjectImageMoniker? GetProjectImage(string key)
         {
-            Requires.NotNullOrEmpty(key, nameof(key));
+            Requires.NotNullOrEmpty(key);
 
             return key switch
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/AbstractProjectCommand.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/AbstractProjectCommand.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
 
         public Task<CommandStatusResult> GetCommandStatusAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, string? commandText, CommandStatus progressiveStatus)
         {
-            Requires.NotNull(nodes, nameof(nodes));
+            Requires.NotNull(nodes);
 
             foreach (long otherCommandId in _commandIds.Value)
             {
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input
 
         public Task<bool> TryHandleCommandAsync(IImmutableSet<IProjectTree> nodes, long commandId, bool focused, long commandExecuteOptions, IntPtr variantArgIn, IntPtr variantArgOut)
         {
-            Requires.NotNull(nodes, nameof(nodes));
+            Requires.NotNull(nodes);
 
             foreach (long otherCommandId in _commandIds.Value)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveEditorContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveEditorContextTracker.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public bool IsActiveEditorContext(string contextId)
         {
-            Requires.NotNullOrEmpty(contextId, nameof(contextId));
+            Requires.NotNullOrEmpty(contextId);
 
             if (!_contexts.Contains(contextId))
             {
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public IDisposable RegisterContext(string contextId)
         {
-            Requires.NotNullOrEmpty(contextId, nameof(contextId));
+            Requires.NotNullOrEmpty(contextId);
 
             bool changed = ThreadingTools.ApplyChangeOptimistically(ref _contexts, projectContexts =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 
         public static BuildOptions FromCommandLineArguments(CommandLineArguments commandLineArguments)
         {
-            Requires.NotNull(commandLineArguments, nameof(commandLineArguments));
+            Requires.NotNull(commandLineArguments);
 
             return new BuildOptions(
                 commandLineArguments.SourceFiles,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildUpdate.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/BuildUpdate.cs
@@ -9,8 +9,8 @@ internal sealed class BuildUpdate
 {
     public BuildUpdate(ConfiguredProject configuredProject, IProjectSubscriptionUpdate buildRuleUpdate)
     {
-        Requires.NotNull(configuredProject, nameof(configuredProject));
-        Requires.NotNull(buildRuleUpdate, nameof(buildRuleUpdate));
+        Requires.NotNull(configuredProject);
+        Requires.NotNull(buildRuleUpdate);
 
         ConfiguredProject = configuredProject;
         BuildRuleUpdate = buildRuleUpdate;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CSharp/CSharpCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/CSharp/CSharpCommandLineParserService.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.CSharp
     {
         public BuildOptions Parse(IEnumerable<string> arguments, string baseDirectory)
         {
-            Requires.NotNull(arguments, nameof(arguments));
-            Requires.NotNullOrEmpty(baseDirectory, nameof(baseDirectory));
+            Requires.NotNull(arguments);
+            Requires.NotNullOrEmpty(baseDirectory);
 
             return BuildOptions.FromCommandLineArguments(
                 CSharpCommandLineParser.Default.Parse(arguments, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/EvaluationUpdate.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/EvaluationUpdate.cs
@@ -9,10 +9,10 @@ internal sealed class EvaluationUpdate
 {
     public EvaluationUpdate(ConfiguredProject configuredProject, IProjectSnapshot projectSnapshot, IProjectSubscriptionUpdate evaluationRuleUpdate, IProjectSubscriptionUpdate sourceItemsUpdate)
     {
-        Requires.NotNull(configuredProject, nameof(configuredProject));
-        Requires.NotNull(projectSnapshot, nameof(projectSnapshot));
-        Requires.NotNull(evaluationRuleUpdate, nameof(evaluationRuleUpdate));
-        Requires.NotNull(sourceItemsUpdate, nameof(sourceItemsUpdate));
+        Requires.NotNull(configuredProject);
+        Requires.NotNull(projectSnapshot);
+        Requires.NotNull(evaluationRuleUpdate);
+        Requires.NotNull(sourceItemsUpdate);
 
         ConfiguredProject = configuredProject;
         ProjectSnapshot = projectSnapshot;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
@@ -23,8 +23,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
 
         public BuildOptions Parse(IEnumerable<string> arguments, string baseDirectory)
         {
-            Requires.NotNull(arguments, nameof(arguments));
-            Requires.NotNullOrEmpty(baseDirectory, nameof(baseDirectory));
+            Requires.NotNull(arguments);
+            Requires.NotNullOrEmpty(baseDirectory);
 
             var sourceFiles = new List<CommandLineSourceFile>();
             var metadataReferences = new List<CommandLineReference>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/VisualBasic/VisualBasicCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/VisualBasic/VisualBasicCommandLineParserService.cs
@@ -10,8 +10,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.VisualBasic
     {
         public BuildOptions Parse(IEnumerable<string> arguments, string baseDirectory)
         {
-            Requires.NotNull(arguments, nameof(arguments));
-            Requires.NotNullOrEmpty(baseDirectory, nameof(baseDirectory));
+            Requires.NotNull(arguments);
+            Requires.NotNullOrEmpty(baseDirectory);
 
             return BuildOptions.FromCommandLineArguments(
                 VisualBasicCommandLineParser.Default.Parse(arguments, baseDirectory, sdkDirectory: null, additionalReferenceDirectories: null));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/BatchLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/BatchLogger.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public BatchLogger(IManagedProjectDiagnosticOutputService outputService)
         {
-            Requires.NotNull(outputService, nameof(outputService));
+            Requires.NotNull(outputService);
 
             _outputService = outputService;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectDiagnosticOutputServiceExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Logging/ProjectDiagnosticOutputServiceExtensions.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </exception>
         public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, object? argument)
         {
-            Requires.NotNull(logger, nameof(logger));
+            Requires.NotNull(logger);
 
             if (logger.IsEnabled)
             {
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </exception>
         public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, object? argument1, object? argument2)
         {
-            Requires.NotNull(logger, nameof(logger));
+            Requires.NotNull(logger);
 
             if (logger.IsEnabled)
             {
@@ -77,7 +77,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </exception>
         public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, object? argument1, object? argument2, object? argument3)
         {
-            Requires.NotNull(logger, nameof(logger));
+            Requires.NotNull(logger);
 
             if (logger.IsEnabled)
             {
@@ -103,7 +103,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// </exception>
         public static void WriteLine(this IManagedProjectDiagnosticOutputService logger, string format, params object?[] arguments)
         {
-            Requires.NotNull(logger, nameof(logger));
+            Requires.NotNull(logger);
 
             if (logger.IsEnabled)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsync.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsync.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         protected Task<T> ExecuteUnderLockAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             return ExecuteUnderLockCoreAsync(action, cancellationToken);
         }
@@ -101,14 +101,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         protected Task ExecuteUnderLockAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             return ExecuteUnderLockCoreAsync(action, cancellationToken);
         }
 
         private async Task<T> ExecuteUnderLockCoreAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             using var source = CancellationTokenExtensions.CombineWith(cancellationToken, DisposalToken);
             CancellationToken jointCancellationToken = source.Token;
@@ -131,7 +131,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private async Task ExecuteUnderLockCoreAsync(Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             using var source = CancellationTokenExtensions.CombineWith(cancellationToken, DisposalToken);
             CancellationToken jointCancellationToken = source.Token;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/ProjectProperty.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/ProjectProperty.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
     {
         public ProjectProperty(string name, string value)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNullOrEmpty(name);
 
             Name = name;
             Value = value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/ReferenceItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/ReferenceItem.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
 
         public ReferenceItem(string name, IVsReferenceProperties properties)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNullOrEmpty(name);
 
             Name = name;
             Properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/ReferenceProperty.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/ReferenceProperty.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
     {
         public ReferenceProperty(string name, string value)
         {
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNullOrEmpty(name);
 
             Name = name;
             Value = value;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreHasher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreHasher.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
     {
         public static byte[] CalculateHash(ProjectRestoreInfo restoreInfo)
         {
-            Requires.NotNull(restoreInfo, nameof(restoreInfo));
+            Requires.NotNull(restoreInfo);
 
             using var hasher = new IncrementalHasher();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PhysicalProjectTreeStorage.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task AddFileAsync(string path)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(path);
 
             string fullPath = _project.MakeRooted(path);
 
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task CreateEmptyFileAsync(string path)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(path);
 
             string fullPath = _project.MakeRooted(path);
 
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task CreateFolderAsync(string path)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(path);
 
             string fullPath = _project.MakeRooted(path);
 
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task AddFolderAsync(string path)
         {
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNullOrEmpty(path);
 
             string fullPath = _project.MakeRooted(path);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectAccessor.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task EnterWriteLockAsync(Func<ProjectCollection, CancellationToken, Task> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             await _projectLockService.WriteLockAsync(async access =>
             {
@@ -38,8 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task<TResult> OpenProjectForReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(project, nameof(action));
+            Requires.NotNull(project);
+            Requires.NotNull(action);
 
             return _projectLockService.ReadLockAsync(async access =>
             {
@@ -53,8 +53,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task<TResult> OpenProjectForUpgradeableReadAsync<TResult>(ConfiguredProject project, Func<Project, TResult> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(project, nameof(action));
+            Requires.NotNull(project);
+            Requires.NotNull(action);
 
             return _projectLockService.UpgradeableReadLockAsync(async access =>
             {
@@ -68,8 +68,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task<TResult> OpenProjectXmlForReadAsync<TResult>(UnconfiguredProject project, Func<ProjectRootElement, TResult> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(project, nameof(action));
+            Requires.NotNull(project);
+            Requires.NotNull(action);
 
             return _projectLockService.ReadLockAsync(async access =>
             {
@@ -83,8 +83,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task OpenProjectXmlForUpgradeableReadAsync(UnconfiguredProject project, Func<ProjectRootElement, CancellationToken, Task> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(project, nameof(action));
+            Requires.NotNull(project);
+            Requires.NotNull(action);
 
             await _projectLockService.UpgradeableReadLockAsync(async access =>
             {
@@ -98,8 +98,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task OpenProjectXmlForWriteAsync(UnconfiguredProject project, Action<ProjectRootElement> action, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(project, nameof(action));
+            Requires.NotNull(project);
+            Requires.NotNull(action);
 
             await _projectLockService.WriteLockAsync(async access =>
             {
@@ -118,8 +118,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public async Task OpenProjectForWriteAsync(ConfiguredProject project, Action<Project> action, ProjectCheckoutOption option = ProjectCheckoutOption.Checkout, CancellationToken cancellationToken = default)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(project, nameof(action));
+            Requires.NotNull(project);
+            Requires.NotNull(action);
 
             await _projectLockService.WriteLockAsync(async access =>
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapabilitiesService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectCapabilitiesService.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public bool Contains(string capability)
         {
-            Requires.NotNullOrEmpty(capability, nameof(capability));
+            Requires.NotNullOrEmpty(capability);
 
             // Just to check capabilities, requires static state and call context that we cannot influence
             return _project.Capabilities.Contains(capability);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectConfigurationExtensions.cs
@@ -21,8 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </summary>
         internal static bool EqualIgnoringTargetFramework(this ProjectConfiguration projectConfiguration1, ProjectConfiguration projectConfiguration2)
         {
-            Requires.NotNull(projectConfiguration1, nameof(projectConfiguration1));
-            Requires.NotNull(projectConfiguration2, nameof(projectConfiguration2));
+            Requires.NotNull(projectConfiguration1);
+            Requires.NotNull(projectConfiguration2);
 
             if (projectConfiguration1.Dimensions.Count != projectConfiguration2.Dimensions.Count)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             get => _nuGetPackageFoldersString;
             set
             {
-                Requires.NotNull(value, nameof(value));
+                Requires.NotNull(value);
 
                 if (!string.Equals(_nuGetPackageFoldersString, value, StringComparisons.Paths))
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// </exception>
         public static string? GetRootedAddNewItemDirectory(this IProjectTreeProvider provider, IProjectTree target)
         {
-            Requires.NotNull(provider, nameof(provider));
-            Requires.NotNull(target, nameof(target));
+            Requires.NotNull(provider);
+            Requires.NotNull(target);
 
             string? relativePath = provider.GetAddNewItemDirectory(target);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -25,10 +25,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectThreadingService threadingService)
             : base(delegatedProvider, instanceProvider, project)
         {
-            Requires.NotNull(interceptingValueProviders, nameof(interceptingValueProviders));
-            Requires.NotNull(getActiveProjectId, nameof(getActiveProjectId));
-            Requires.NotNull(workspace, nameof(workspace));
-            Requires.NotNull(threadingService, nameof(threadingService));
+            Requires.NotNull(interceptingValueProviders);
+            Requires.NotNull(getActiveProjectId);
+            Requires.NotNull(workspace);
+            Requires.NotNull(threadingService);
 
             _interceptingValueProviders = interceptingValueProviders.ToImmutableArray();
             _project = project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/BasePropertyExtensions.cs
@@ -26,8 +26,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </exception>
         public static string? GetMetadataValueOrNull(this BaseProperty property, string metadataName)
         {
-            Requires.NotNull(property, nameof(property));
-            Requires.NotNullOrEmpty(metadataName, nameof(metadataName));
+            Requires.NotNull(property);
+            Requires.NotNullOrEmpty(metadataName);
 
             return property.Metadata.FirstOrDefault(nvp => nvp.Name == metadataName)?.Value;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         protected DelegatedProjectPropertiesBase(IProjectProperties properties)
         {
-            Requires.NotNull(properties, nameof(properties));
+            Requires.NotNull(properties);
 
             DelegatedProperties = properties;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/DelegatedProjectPropertiesProviderBase.cs
@@ -33,9 +33,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public DelegatedProjectPropertiesProviderBase(IProjectPropertiesProvider provider, IProjectInstancePropertiesProvider instanceProvider, UnconfiguredProject project)
         {
-            Requires.NotNull(provider, nameof(provider));
-            Requires.NotNull(instanceProvider, nameof(instanceProvider));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(provider);
+            Requires.NotNull(instanceProvider);
+            Requires.NotNull(project);
 
             DelegatedProvider = provider;
             DelegatedInstanceProvider = instanceProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectProperties.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             : base(defaultProperties)
         {
             _project = project;
-            Requires.NotNullOrEmpty(valueProviders, nameof(valueProviders));
+            Requires.NotNullOrEmpty(valueProviders);
 
             ImmutableDictionary<string, Providers>.Builder builder = 
                 ImmutableDictionary.CreateBuilder<string, Providers>(StringComparers.PropertyNames);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/MetadataExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/MetadataExtensions.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <returns>The key is item name and the value is the metadata dictionary.</returns>
         public static IImmutableDictionary<string, string>? GetProjectItemProperties(this IProjectRuleSnapshot projectRuleSnapshot, string itemSpec)
         {
-            Requires.NotNull(projectRuleSnapshot, nameof(projectRuleSnapshot));
-            Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
+            Requires.NotNull(projectRuleSnapshot);
+            Requires.NotNullOrEmpty(itemSpec);
 
             return projectRuleSnapshot.Items.TryGetValue(itemSpec, out IImmutableDictionary<string, string> properties)
                 ? properties

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.cs
@@ -14,8 +14,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public static string GetPropertyOrEmpty(this IImmutableDictionary<string, string> properties, string name)
         {
-            Requires.NotNull(properties, nameof(properties));
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNull(properties);
+            Requires.NotNullOrEmpty(name);
 
             return properties.GetValueOrDefault(name, string.Empty);
         }
@@ -26,9 +26,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [return: NotNullIfNotNull(parameterName: "defaultValue")]
         public static string? GetPropertyOrDefault(this IImmutableDictionary<string, IProjectRuleSnapshot> snapshots, string ruleName, string propertyName, string? defaultValue)
         {
-            Requires.NotNull(snapshots, nameof(snapshots));
-            Requires.NotNullOrEmpty(ruleName, nameof(ruleName));
-            Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
+            Requires.NotNull(snapshots);
+            Requires.NotNullOrEmpty(ruleName);
+            Requires.NotNullOrEmpty(propertyName);
 
             if (snapshots.TryGetValue(ruleName, out IProjectRuleSnapshot snapshot) && snapshot.Properties.TryGetValue(propertyName, out string value))
             {
@@ -47,9 +47,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public static bool IsPropertyTrue(this IImmutableDictionary<string, IProjectRuleSnapshot> snapshots, string ruleName, string propertyName, bool defaultValue)
         {
-            Requires.NotNull(snapshots, nameof(snapshots));
-            Requires.NotNull(ruleName, nameof(ruleName));
-            Requires.NotNull(propertyName, nameof(propertyName));
+            Requires.NotNull(snapshots);
+            Requires.NotNull(ruleName);
+            Requires.NotNull(propertyName);
 
             string value = snapshots.GetPropertyOrDefault(ruleName, propertyName, defaultValue ? "true" : "false");
 
@@ -61,9 +61,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public static bool? GetBooleanPropertyValue(this IImmutableDictionary<string, IProjectRuleSnapshot> snapshots, string ruleName, string propertyName)
         {
-            Requires.NotNull(snapshots, nameof(snapshots));
-            Requires.NotNull(ruleName, nameof(ruleName));
-            Requires.NotNull(propertyName, nameof(propertyName));
+            Requires.NotNull(snapshots);
+            Requires.NotNull(ruleName);
+            Requires.NotNull(propertyName);
 
             string? value = snapshots.GetPropertyOrDefault(ruleName, propertyName, defaultValue: null);
 
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </summary>
         public static IProjectRuleSnapshot GetSnapshotOrEmpty(this IImmutableDictionary<string, IProjectRuleSnapshot> snapshots, string ruleName)
         {
-            Requires.NotNull(snapshots, nameof(snapshots));
+            Requires.NotNull(snapshots);
 
             if (snapshots.TryGetValue(ruleName, out IProjectRuleSnapshot result))
             {
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public static bool HasChange(this IImmutableDictionary<string, IProjectChangeDescription> changesByRule)
         {
-            Requires.NotNull(changesByRule, nameof(changesByRule));
+            Requires.NotNull(changesByRule);
 
             foreach ((_, IProjectChangeDescription change) in changesByRule)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PropertyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PropertyExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// </exception>
         public static async Task<Guid> GetValueAsGuidAsync(this IProperty property)
         {
-            Requires.NotNull(property, nameof(property));
+            Requires.NotNull(property);
 
             string? value = (string?)await property.GetValueAsync();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/References/AlwaysAllowValidProjectReferenceChecker.cs
@@ -26,14 +26,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
 
         public Task<SupportedCheckResult> CanAddProjectReferenceAsync(object referencedProject)
         {
-            Requires.NotNull(referencedProject, nameof(referencedProject));
+            Requires.NotNull(referencedProject);
 
             return s_supported;
         }
 
         public Task<CanAddProjectReferencesResult> CanAddProjectReferencesAsync(IImmutableSet<object> referencedProjects)
         {
-            Requires.NotNullEmptyOrNullElements(referencedProjects, nameof(referencedProjects));
+            Requires.NotNullEmptyOrNullElements(referencedProjects);
 
             IImmutableDictionary<object, SupportedCheckResult> results = ImmutableDictionary.Create<object, SupportedCheckResult>();
 
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
 
         public Task<SupportedCheckResult> CanBeReferencedAsync(object referencingProject)
         {
-            Requires.NotNull(referencingProject, nameof(referencingProject));
+            Requires.NotNull(referencingProject);
 
             return s_supported;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AbstractSpecialFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AbstractSpecialFolderProjectTreePropertiesProvider.cs
@@ -40,8 +40,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
         {
-            Requires.NotNull(propertyContext, nameof(propertyContext));
-            Requires.NotNull(propertyValues, nameof(propertyValues));
+            Requires.NotNull(propertyContext);
+            Requires.NotNull(propertyValues);
 
             if (!IsSupported)
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProvider.cs
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
         public void UpdateProjectTreeSettings(IImmutableDictionary<string, IProjectRuleSnapshot> ruleSnapshots, ref IImmutableDictionary<string, string> projectTreeSettings)
         {
-            Requires.NotNull(ruleSnapshots, nameof(ruleSnapshots));
-            Requires.NotNull(projectTreeSettings, nameof(projectTreeSettings));
+            Requires.NotNull(ruleSnapshots);
+            Requires.NotNull(projectTreeSettings);
 
             // Retrieves the <AppDesignerFolder> and <AppDesignerFolderContentsVisibleOnlyInShowAllFiles> properties from the project file
             //

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/CrossTarget/AggregateCrossTargetProjectContext.cs
@@ -22,8 +22,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.CrossTarget
             ITargetFrameworkProvider targetFrameworkProvider)
         {
             Requires.Argument(!targetFrameworks.IsDefaultOrEmpty, nameof(targetFrameworks), "Must contain at least one item.");
-            Requires.NotNullOrEmpty(configuredProjectByTargetFramework, nameof(configuredProjectByTargetFramework));
-            Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
+            Requires.NotNullOrEmpty(configuredProjectByTargetFramework);
+            Requires.NotNull(activeTargetFramework);
 
             if (!targetFrameworks.Contains(activeTargetFramework))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -424,7 +424,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// </summary>
         protected override ConfiguredProjectExports GetActiveConfiguredProjectExports(ConfiguredProject newActiveConfiguredProject)
         {
-            Requires.NotNull(newActiveConfiguredProject, nameof(newActiveConfiguredProject));
+            Requires.NotNull(newActiveConfiguredProject);
 
             return GetActiveConfiguredProjectExports<MyConfiguredProjectExports>(newActiveConfiguredProject);
         }
@@ -473,11 +473,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         public async Task<IRule?> GetBrowseObjectRuleAsync(IDependency dependency, TargetFramework targetFramework, IProjectCatalogSnapshot? catalogs)
         {
-            Requires.NotNull(dependency, nameof(dependency));
+            Requires.NotNull(dependency);
 
             IImmutableDictionary<string, IPropertyPagesCatalog> namedCatalogs = await GetNamedCatalogsAsync();
 
-            Requires.NotNull(namedCatalogs, nameof(namedCatalogs));
+            Requires.NotNull(namedCatalogs);
 
             if (!namedCatalogs.TryGetValue(PropertyPageContexts.BrowseObject, out IPropertyPagesCatalog browseObjectsCatalog))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependencyServices.cs
@@ -13,8 +13,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
         /// </summary>
         public static async Task<string?> GetBrowsePathAsync(UnconfiguredProject project, IProjectTree node)
         {
-            Requires.NotNull(project, nameof(project));
-            Requires.NotNull(node, nameof(node));
+            Requires.NotNull(project);
+            Requires.NotNull(node);
 
             string? path = await GetMaybeRelativeBrowsePathAsync(project, node);
             if (path is null)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependencyModelEqualityComparer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/IDependencyModelEqualityComparer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
 
         public int GetHashCode(IDependencyModel obj)
         {
-            Requires.NotNull(obj, nameof(obj));
+            Requires.NotNull(obj);
 
             return unchecked(StringComparers.DependencyTreeIds.GetHashCode(obj.Id) * 397 ^
                              StringComparers.DependencyProviderTypes.GetHashCode(obj.ProviderType));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyId.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyId.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
 
         public DependencyId(string providerId, string modelId)
         {
-            Requires.NotNull(providerId, nameof(providerId));
-            Requires.NotNull(modelId, nameof(modelId));
+            Requires.NotNull(providerId);
+            Requires.NotNull(modelId);
 
             ProviderId = providerId;
             ModelId = modelId;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Models/DependencyModel.cs
@@ -39,12 +39,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Models
             IImmutableDictionary<string, string>? properties,
             bool isVisible = true)
         {
-            Requires.NotNullOrEmpty(caption, nameof(caption));
+            Requires.NotNullOrEmpty(caption);
 
             // IDependencyModel allows original item spec to be null, but we can satisfy a
             // more strict requirement for the dependency types produced internally.
             // External providers may not have a meaningful value, but do not use this type.
-            Requires.NotNullOrEmpty(originalItemSpec, nameof(originalItemSpec));
+            Requires.NotNullOrEmpty(originalItemSpec);
 
             Path = path;
             OriginalItemSpec = originalItemSpec;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependenciesSnapshot.cs
@@ -34,8 +34,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             ImmutableArray<TargetFramework> targetFrameworks,
             TargetFramework? activeTargetFramework)
         {
-            Requires.NotNull(previousSnapshot, nameof(previousSnapshot));
-            Requires.NotNull(changedTargetFramework, nameof(changedTargetFramework));
+            Requires.NotNull(previousSnapshot);
+            Requires.NotNull(changedTargetFramework);
 
             var builder = previousSnapshot.DependenciesByTargetFramework.ToBuilder();
 
@@ -147,8 +147,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             TargetFramework activeTargetFramework,
             ImmutableDictionary<TargetFramework, TargetedDependenciesSnapshot> dependenciesByTargetFramework)
         {
-            Requires.NotNull(activeTargetFramework, nameof(activeTargetFramework));
-            Requires.NotNull(dependenciesByTargetFramework, nameof(dependenciesByTargetFramework));
+            Requires.NotNull(activeTargetFramework);
+            Requires.NotNull(dependenciesByTargetFramework);
 
 #if false
             // The validation in this #if/#endif block is sound in theory, however is causing quite a few NFEs.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/Dependency.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
     {
         public Dependency(IDependencyModel dependencyModel)
         {
-            Requires.NotNull(dependencyModel, nameof(dependencyModel));
-            Requires.NotNullOrEmpty(dependencyModel.ProviderType, nameof(dependencyModel.ProviderType));
-            Requires.NotNullOrEmpty(dependencyModel.Id, nameof(dependencyModel.Id));
+            Requires.NotNull(dependencyModel);
+            Requires.NotNullOrEmpty(dependencyModel.ProviderType);
+            Requires.NotNullOrEmpty(dependencyModel.Id);
 
             Id = dependencyModel.Id;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/TargetedDependenciesSnapshot.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             IDependenciesChanges? changes,
             IProjectCatalogSnapshot? catalogs)
         {
-            Requires.NotNull(previousSnapshot, nameof(previousSnapshot));
+            Requires.NotNull(previousSnapshot);
 
             bool anyChanges = false;
 
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
             IProjectCatalogSnapshot? catalogs,
             ImmutableArray<IDependency> dependencies)
         {
-            Requires.NotNull(targetFramework, nameof(targetFramework));
+            Requires.NotNull(targetFramework);
             Requires.Argument(!dependencies.IsDefault, nameof(dependencies), "Cannot be default.");
 
             TargetFramework = targetFramework;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.ContextTracker.cs
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
                 Lazy<AggregateCrossTargetProjectContextProvider> contextProvider,
                 IActiveProjectConfigurationRefreshService activeProjectConfigurationRefreshService)
             {
-                Requires.NotNull(targetFrameworkProvider, nameof(targetFrameworkProvider));
-                Requires.NotNull(commonServices, nameof(commonServices));
-                Requires.NotNull(contextProvider, nameof(contextProvider));
-                Requires.NotNull(activeProjectConfigurationRefreshService, nameof(activeProjectConfigurationRefreshService));
+                Requires.NotNull(targetFrameworkProvider);
+                Requires.NotNull(commonServices);
+                Requires.NotNull(contextProvider);
+                Requires.NotNull(activeProjectConfigurationRefreshService);
 
                 _targetFrameworkProvider = targetFrameworkProvider;
                 _commonServices = commonServices;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -384,7 +384,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
     {
         public SnapshotChangedEventArgs(DependenciesSnapshot snapshot, CancellationToken token)
         {
-            Requires.NotNull(snapshot, nameof(snapshot));
+            Requires.NotNull(snapshot);
 
             Snapshot = snapshot;
             Token = token;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencyRulesSubscriberBase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
 
         public virtual void AddSubscriptions(AggregateCrossTargetProjectContext projectContext)
         {
-            Requires.NotNull(projectContext, nameof(projectContext));
+            Requires.NotNull(projectContext);
             Assumes.True(IsInitialized);
 
             foreach (ConfiguredProject configuredProject in projectContext.InnerConfiguredProjects)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependencySharedProjectsSubscriber.cs
@@ -78,9 +78,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             TargetFramework targetFramework,
             DependenciesChangesBuilder changesBuilder)
         {
-            Requires.NotNull(sharedFolders, nameof(sharedFolders));
-            Requires.NotNull(targetFramework, nameof(targetFramework));
-            Requires.NotNull(changesBuilder, nameof(changesBuilder));
+            Requires.NotNull(sharedFolders);
+            Requires.NotNull(targetFramework);
+            Requires.NotNull(changesBuilder);
 
             DependenciesSnapshot snapshot = _dependenciesSnapshotProvider.CurrentSnapshot;
             if (!snapshot.DependenciesByTargetFramework.TryGetValue(targetFramework, out TargetedDependenciesSnapshot? targetedSnapshot))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/DependenciesRuleHandlerBase.cs
@@ -19,8 +19,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             string evaluatedRuleName,
             string resolvedRuleName)
         {
-            Requires.NotNullOrWhiteSpace(evaluatedRuleName, nameof(evaluatedRuleName));
-            Requires.NotNullOrWhiteSpace(resolvedRuleName, nameof(resolvedRuleName));
+            Requires.NotNullOrWhiteSpace(evaluatedRuleName);
+            Requires.NotNullOrWhiteSpace(resolvedRuleName);
 
             EvaluatedRuleName = evaluatedRuleName;
             ResolvedRuleName = resolvedRuleName;
@@ -180,8 +180,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             string projectFullPath,
             IImmutableDictionary<string, string> properties)
         {
-            Requires.NotNull(projectFullPath, nameof(projectFullPath));
-            Requires.NotNull(properties, nameof(properties));
+            Requires.NotNull(projectFullPath);
+            Requires.NotNull(properties);
             
             // Check for "IsImplicitlyDefined" metadata, which is available on certain items.
             bool? isImplicitMetadata = properties.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/RuleHandlers/PackageRuleHandler.cs
@@ -99,9 +99,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.R
             DependenciesChangesBuilder changesBuilder,
             [NotNullWhen(returnValue: true)] out PackageDependencyModel? dependencyModel)
         {
-            Requires.NotNullOrEmpty(itemSpec, nameof(itemSpec));
-            Requires.NotNull(properties, nameof(properties));
-            Requires.NotNull(targetFramework, nameof(targetFramework));
+            Requires.NotNullOrEmpty(itemSpec);
+            Requires.NotNull(properties);
+            Requires.NotNull(targetFramework);
 
             string originalItemSpec;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/FileIconProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree
 
         public ImageMoniker GetFileExtensionImageMoniker(string path)
         {
-            Requires.NotNull(path, nameof(path));
+            Requires.NotNull(path);
 
             string extension = Path.GetExtension(path);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -346,7 +346,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
 
         protected override ConfiguredProjectExports GetActiveConfiguredProjectExports(ConfiguredProject newActiveConfiguredProject)
         {
-            Requires.NotNull(newActiveConfiguredProject, nameof(newActiveConfiguredProject));
+            Requires.NotNull(newActiveConfiguredProject);
 
             return GetActiveConfiguredProjectExports<MyConfiguredProjectExports>(newActiveConfiguredProject);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectRootImageProjectTreePropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectRootImageProjectTreePropertiesProvider.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree
 
         public void CalculatePropertyValues(IProjectTreeCustomizablePropertyContext propertyContext, IProjectTreeCustomizablePropertyValues propertyValues)
         {
-            Requires.NotNull(propertyContext, nameof(propertyContext));
-            Requires.NotNull(propertyValues, nameof(propertyValues));
+            Requires.NotNull(propertyContext);
+            Requires.NotNull(propertyValues);
 
             if (propertyValues.Flags.Contains(ProjectTreeFlags.Common.ProjectRoot))
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -89,7 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task<T> PrioritizedProjectLoadedInHostAsync<T>(Func<Task<T>> action)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             _tasksService.UnloadCancellationToken.ThrowIfCancellationRequested();
 
@@ -102,7 +102,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public Task PrioritizedProjectLoadedInHostAsync(Func<Task> action)
         {
-            Requires.NotNull(action, nameof(action));
+            Requires.NotNull(action);
 
             _tasksService.UnloadCancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -60,8 +60,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             public Subscription(IUpToDateCheckConfiguredInputDataSource inputDataSource, ConfiguredProject configuredProject, IUpToDateCheckHost host, IUpToDateCheckStatePersistence persistence)
             {
-                Requires.NotNull(inputDataSource, nameof(inputDataSource));
-                Requires.NotNull(configuredProject, nameof(configuredProject));
+                Requires.NotNull(inputDataSource);
+                Requires.NotNull(configuredProject);
 
                 _inputDataSource = inputDataSource;
                 _configuredProject = configuredProject;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItem.cs
@@ -31,7 +31,7 @@ internal readonly struct CopyItem
 
     public CopyItem(string path, string targetPath, BuildUpToDateCheck.CopyType copyType, bool isBuildAccelerationOnly)
     {
-        Requires.NotNull(targetPath, nameof(targetPath));
+        Requires.NotNull(targetPath);
         System.Diagnostics.Debug.Assert(Path.IsPathRooted(path), "Path.IsPathRooted(path)");
         System.Diagnostics.Debug.Assert(!Path.IsPathRooted(targetPath), "!Path.IsPathRooted(targetPath)");
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableDelegate.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Utilities/DisposableDelegate.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Utilities
 
         public DisposableDelegate(Action onDispose)
         {
-            Requires.NotNull(onDispose, nameof(onDispose));
+            Requires.NotNull(onDispose);
 
             _onDispose = onDispose;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
@@ -10,16 +10,16 @@ namespace Microsoft.VisualStudio.Telemetry
     {
         public void PostEvent(string eventName)
         {
-            Requires.NotNullOrEmpty(eventName, nameof(eventName));
+            Requires.NotNullOrEmpty(eventName);
 
             PostTelemetryEvent(new TelemetryEvent(eventName));
         }
 
         public void PostProperty(string eventName, string propertyName, object propertyValue)
         {
-            Requires.NotNullOrEmpty(eventName, nameof(eventName));
-            Requires.NotNullOrEmpty(propertyName, nameof(propertyName));
-            Requires.NotNull(propertyValue, nameof(propertyValue));
+            Requires.NotNullOrEmpty(eventName);
+            Requires.NotNullOrEmpty(propertyName);
+            Requires.NotNull(propertyValue);
 
             var telemetryEvent = new TelemetryEvent(eventName);
             telemetryEvent.Properties.Add(propertyName, propertyValue);
@@ -29,8 +29,8 @@ namespace Microsoft.VisualStudio.Telemetry
 
         public void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties)
         {
-            Requires.NotNullOrEmpty(eventName, nameof(eventName));
-            Requires.NotNullOrEmpty(properties, nameof(properties));
+            Requires.NotNullOrEmpty(eventName);
+            Requires.NotNullOrEmpty(properties);
 
             var telemetryEvent = new TelemetryEvent(eventName);
             foreach ((string propertyName, object propertyValue) in properties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/IncrementalHasher.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/IncrementalHasher.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Text
 
         public void Append(string value)
         {
-            Requires.NotNull(value, nameof(value));
+            Requires.NotNull(value);
 
             int charIndex = 0;
             while (charIndex < value.Length)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/LazyStringSplit.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Text/LazyStringSplit.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.Text
 
         public LazyStringSplit(string input, char delimiter)
         {
-            Requires.NotNull(input, nameof(input));
+            Requires.NotNull(input);
 
             _input = input;
             _delimiter = delimiter;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/SetDiff.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Utilities/SetDiff.cs
@@ -17,8 +17,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public SetDiff(IEnumerable<T> before, IEnumerable<T> after, IEqualityComparer<T>? equalityComparer = null)
         {
-            Requires.NotNull(before, nameof(before));
-            Requires.NotNull(after, nameof(after));
+            Requires.NotNull(before);
+            Requires.NotNull(after);
 
             equalityComparer ??= EqualityComparer<T>.Default;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public ProjectTreeParser(string value)
         {
-            Requires.NotNullOrEmpty(value, nameof(value));
+            Requires.NotNullOrEmpty(value);
 
             _tokenizer = new Tokenizer(new SimpleStringReader(value), Delimiters.Structural);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
@@ -48,8 +48,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public IProjectTree? FindByPath(IProjectTree root, string path)
         {
-            Requires.NotNull(root, nameof(root));
-            Requires.NotNullOrEmpty(path, nameof(path));
+            Requires.NotNull(root);
+            Requires.NotNullOrEmpty(path);
 
             foreach (IProjectTree child in root.GetSelfAndDescendentsBreadthFirst())
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeWriter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public ProjectTreeWriter(IProjectTree tree, ProjectTreeWriterOptions options)
         {
-            Requires.NotNull(tree, nameof(tree));
+            Requires.NotNull(tree);
 
             _parent = tree;
             _options = options;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -46,8 +46,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                   workspace: workspace,
                   threadingService: threadingService ?? IProjectThreadingServiceFactory.Create())
         {
-            Requires.NotNull(workspace, nameof(workspace));
-            Requires.NotNull(project, nameof(project));
+            Requires.NotNull(workspace);
+            Requires.NotNull(project);
         }
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Snapshot/DependencyTests.cs
@@ -16,13 +16,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot
                 new Dependency(null!);
             });
 
-            Assert.Throws<ArgumentNullException>("ProviderType", () =>
+            Assert.Throws<ArgumentNullException>("dependencyModel.ProviderType", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = null!, Id = "Id" };
                 new Dependency(dependencyModel);
             });
 
-            Assert.Throws<ArgumentNullException>("Id", () =>
+            Assert.Throws<ArgumentNullException>("dependencyModel.Id", () =>
             {
                 var dependencyModel = new TestDependencyModel { ProviderType = "providerType", Id = null! };
                 new Dependency(dependencyModel);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.cs
@@ -134,7 +134,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private static Dictionary<string, ContractMetadata> CollectContractMetadata(IEnumerable<Assembly> assemblies)
         {
-            Requires.NotNull(assemblies, nameof(assemblies));
+            Requires.NotNull(assemblies);
             var contracts = new Dictionary<string, ContractMetadata>(StringComparer.Ordinal);
             foreach (Assembly contractAssembly in assemblies)
             {
@@ -146,8 +146,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private static void ReadContractMetadata(Dictionary<string, ContractMetadata> contracts, Assembly contractAssembly)
         {
-            Requires.NotNull(contracts, nameof(contracts));
-            Requires.NotNull(contractAssembly, nameof(contractAssembly));
+            Requires.NotNull(contracts);
+            Requires.NotNull(contractAssembly);
             foreach (ProjectSystemContractAttribute assemblyAttribute in contractAssembly.GetCustomAttributes<ProjectSystemContractAttribute>())
             {
                 var contractName = assemblyAttribute.ContractName;
@@ -212,8 +212,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private static void AddContractMetadata(Dictionary<string, ContractMetadata> contracts, string name, ProjectSystemContractScope scope, ProjectSystemContractProvider provider, ImportCardinality cardinality)
         {
-            Requires.NotNull(contracts, nameof(contracts));
-            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNull(contracts);
+            Requires.NotNullOrEmpty(name);
 
             if (!contracts.TryGetValue(name, out ContractMetadata metadata))
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
@@ -322,7 +322,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         private bool ValidateContractAnnotation(string? typeName, string contractName, ComposablePartDefinition part)
         {
-            Requires.NotNull(contractName, nameof(contractName));
+            Requires.NotNull(contractName);
 
             if (typeName is not null && ComponentComposition.Instance.Contracts.ContainsKey(typeName))
             {


### PR DESCRIPTION
The new release of vs-validation fixed https://github.com/microsoft/vs-validation/issues/127 which means our call sites can be simplified.

These changes were made via regular expressions.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8828)