### PR TITLE
Up-to-date check considers .ruleset files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -438,10 +438,12 @@
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
   <!-- This target collects all the extra inputs for the up to date check. -->
-  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckInput)">
+  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime;ResolveCodeAnalysisRuleSet" Returns="@(UpToDateCheckInput)">
     <ItemGroup>
-      <!-- app.manifest -->
+      <!-- app.manifest, if any -->
       <UpToDateCheckInput Condition=" '$(ApplicationManifest)' != '' " Include="$(ApplicationManifest)" />
+      <!-- .ruleset file, if any -->
+      <UpToDateCheckInput Condition=" '$(ResolvedCodeAnalysisRuleSet)' != '' " Include="$(ResolvedCodeAnalysisRuleSet)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #2374

Adds any resolved `.ruleset` file to the set of `UpToDateCheckInput` items considered by the fast up-to-date check.

---

A previous attempt at this caused a performance regression and was reverted. We take a slightly different approach here which I hope won't have the same issue:

- The [`ResolveCodeAnalysisRuleSet` target](https://github.com/dotnet/msbuild/blob/7bf511372af6bc80510e1ee6711661c2e0683fe0/src/Tasks/Microsoft.CSharp.CurrentVersion.targets#L125-L135) is fairly minimal and only run when a `CodeAnalysisRuleSet` property exists.
- The [`ResolveCodeAnalysisRuleSet` task](https://github.com/dotnet/msbuild/blob/7bf511372af6bc80510e1ee6711661c2e0683fe0/src/Tasks/ResolveCodeAnalysisRuleSet.cs) is likewise quite minimal.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8830)