### PR TITLE
FUTDC excludes non-modifiable input items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -411,8 +411,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     before = ImmutableArray<string>.Empty;
                 }
 
+                projectFileClassifier ??= BuildClassifier();
+
                 var after = projectChange.After.Items
                     .Select(item => item.Key)
+                    .Where(path => !projectFileClassifier.IsNonModifiable(path))
                     .ToHashSet(StringComparers.Paths);
 
                 var diff = new SetDiff<string>(before, after, StringComparers.Paths);


### PR DESCRIPTION
Fixes #8805

Items in certain locations on disk are considered non-modifiable, and therefore are not inspected for changes during the fast up-to-date check. The fewer files we check, the faster the check will be.

Previous work in this area filtered various references, such as framework assemblies, using our `ProjectFileClassifier`.

This change extends the behaviour to input items, primarily to exclude items added via NuGet packages such as `Compile` and `AdditionalFiles` items.

## Before

```
FastUpToDate:     Adding AdditionalFiles inputs: (Microsoft.VisualStudio.Editors)
FastUpToDate:         D:\repos\project-system\src\Microsoft.VisualStudio.Editors\PublicAPI.Unshipped.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.MainThreadSwitchingMethods.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.MainThreadAssertingMethods.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\BannedSymbols.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.MainThreadSwitchingMethods.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.LegacyThreadSwitchingMembers.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.LegacyThreadSwitchingMembers.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         D:\repos\project-system\src\Microsoft.VisualStudio.Editors\PublicAPI.Shipped.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.projectsystem\17.5.396-pre\build\AdditionalFiles\vs-threading.MainThreadAssertingMethods.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.MembersRequiringMainThread.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.projectsystem\17.5.396-pre\build\AdditionalFiles\vs-threading.MainThreadSwitchingMethods.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.sdk.analyzers\16.10.10\build\AdditionalFiles\vs-threading.MainThreadAssertingMethods.txt (Microsoft.VisualStudio.Editors)
FastUpToDate:         C:\Users\drnoakes\.nuget\packages\microsoft.visualstudio.threading.analyzers\17.4.16-alpha\build\AdditionalFiles\vs-threading.MembersRequiringMainThread.txt (Microsoft.VisualStudio.Editors)
```

## After

```
FastUpToDate:     Adding AdditionalFiles inputs: (Microsoft.VisualStudio.AppDesigner)
FastUpToDate:         D:\repos\project-system\src\Microsoft.VisualStudio.AppDesigner\PublicAPI.Unshipped.txt (Microsoft.VisualStudio.AppDesigner)
FastUpToDate:         D:\repos\project-system\src\Microsoft.VisualStudio.AppDesigner\PublicAPI.Shipped.txt (Microsoft.VisualStudio.AppDesigner)
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8831)