### PR TITLE
Fix build without /m error

### DIFF
--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -31,4 +31,13 @@
   <!-- Specifies the version number that is used within the 'source.extension.vsixmanifest' files for VSIX packages. -->
   <Target Name="GetVsixVersion" Outputs="$(BuildVersion)" Condition="'$(IsVsixProject)' == 'true'" />
 
+  <!--
+    Creates the Insertion folder as the full folder path is required to create the .vsix file in CreateVsixContainer.
+    This line will fail in the VsixUtil tool if the folder path does not exist:
+    https://dev.azure.com/devdiv/DevDiv/_git/VSExtensibility?path=/src/product/vssdk/tools/VsixUtil/Packager.cs&version=GBdevelop&line=82&lineEnd=83&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents
+  -->
+  <Target Name="CreateInsertionFolder" BeforeTargets="CreateVsixContainer" Condition="'$(IsVsixProject)' == 'true'">
+    <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/8350

This error would occur on builds that did not either have the `/m` flag when calling MSBuild or non-deterministically for our current build (which uses `/m` in `build.cmd`). That flag determines if the projects build in parallel or in series (`/m` is parallel, without `/m` is series).

I compared the builds side-by-side and diffed all the properties and inputs to the failing target. That target is `CreateVsixContainer`, specifically for the `VisualStudioEditorsSetup.csproj`. Nothing was different. Then, I built the actual MSBuild task source code (for `CreateVsixContainer`) and debugged it. I didn't see anything awry. I found the exact line that was failing, and looked at the path again shown in the error:

> Could not find part of the path 'C:\Code\project-system\artifacts\Debug\VSSetup\Insertion\VisualStudioEditorsSetup.vsix'.

I looked in the `VSSetup` folder and noticed that, when building in series, the build didn't have an `Insertion` folder. That's what was causing the error. I looked at the binlogs again and noticed this:
![image](https://user-images.githubusercontent.com/17788297/216495306-96076426-b557-4967-bc33-3e913494eba6.png)

The left-side is the build where it succeeds (using `/m`). The right-side is the one where it fails. When it fails, the `...VS.UnitTests.csproj` is the one that takes a dependency on `VisualStudioEditorsSetup.csproj`. In the left-side build, `VisualStudioEditorsSetup.csproj` is building independently. I compared which projects are **not** build in the right-side (failing one) prior to it trying to build the `VisualStudioEditorsSetup.csproj`. The top 2 are:
- `ProjectSystemSetup.csproj`
- `...CommonFiles.csproj`

The first takes a project reference to `VisualStudioEditorsSetup.csproj` so that is unlikely the problem. The second, however, doesn't have any relationship to `VisualStudioEditorsSetup.csproj`. I looked in that project file (which isn't a VS Extension project) and saw that it builds the .swixproj. In that file:
https://github.com/dotnet/project-system/blob/a150d0057c208cb12d6fa2cedf649bc245704476/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles.swixproj#L15

This means that when that project builds, it outputs to the `Insertion` folder (normal for `OutputPath` to create itself). Thus, that project is the reason the `Insertion` folder was existing in time for the `/m` build to succeed.

Thus, the crux of the issue is that `CreateVsixContainer` doesn't create its own output path for the VSIX package it writes to disk. The solution was to create a target that runs prior to `CreateVsixContainer` that guarantees the output folder for the VSIX package exists. We use the `$(VisualStudioSetupInsertionPath)` property in our build system for that purpose.

After doing this (and disabling `/m` in `build.cmd` locally), the build succeeds. Within the `VisualStudioEditorsSetup.csproj` build in the binlog, you can see it not correctly creates the directory:
![image](https://user-images.githubusercontent.com/17788297/216497120-9cfb191d-6fc2-4a38-8247-1eae4a41d08d.png)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8835)