### PR TITLE
Prevent race condition during dependencies tree initialization

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesProjectTreeProvider.cs
@@ -296,6 +296,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies
                         UnconfiguredProjectAsynchronousTasksService
                             .UnloadCancellationToken.ThrowIfCancellationRequested();
 
+                        await _dependenciesSnapshotProvider.InitializeSubscriptionsAsync();
+
                         lock (SyncObject)
                         {
                             Verify.NotDisposed(this);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -145,12 +145,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions
             }
         }
 
-        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectFactoryCompleted)]
-        [AppliesTo(ProjectCapability.DependenciesTree)]
-        public Task OnProjectFactoryCompletedAsync()
+        public Task InitializeSubscriptionsAsync()
         {
-            // The project factory is completing.
-
             // Subscribe to project data. Ensure the project doesn't unload during subscription.
             return _tasksService.LoadedProjectAsync(AddInitialSubscriptionsAsync);
 


### PR DESCRIPTION
Two components of the dependencies tree were initialized via different means.

1. `DependenciesProjectTreeProvider` was initialized via the CPS `PhysicalProjectTreeProvider`.
2. `DependenciesSnapshotProvider` was initialized when the project factory completes (`ProjectAutoLoad`).

There was an implicit contract between these components that they were initialized in that specific order. If that contract is broken, there are runtime exceptions due to the use of an uninitialized instance of `DependencyRulesSubscriber`.

This change causes both initializations to occur in a single path, so that the initialization order is enforced directly within the dependencies node's own code, rather than relying on environmental support.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8836)