### PR TITLE
Fix ruleset discovery error for F# projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -437,8 +437,14 @@
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
+  <PropertyGroup>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>CompileDesignTime</CollectUpToDateCheckInputDesignTimeDependsOn>
+    <!-- F# projects do not have the ResolveCodeAnalysisRuleSet target. -->
+    <CollectUpToDateCheckInputDesignTimeDependsOn Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'">$(CollectUpToDateCheckInputDesignTimeDependsOn);ResolveCodeAnalysisRuleSet</CollectUpToDateCheckInputDesignTimeDependsOn>
+  </PropertyGroup>
+
   <!-- This target collects all the extra inputs for the up to date check. -->
-  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="CompileDesignTime;ResolveCodeAnalysisRuleSet" Returns="@(UpToDateCheckInput)">
+  <Target Name="CollectUpToDateCheckInputDesignTime" DependsOnTargets="$(CollectUpToDateCheckInputDesignTimeDependsOn)" Returns="@(UpToDateCheckInput)">
     <ItemGroup>
       <!-- app.manifest, if any -->
       <UpToDateCheckInput Condition=" '$(ApplicationManifest)' != '' " Include="$(ApplicationManifest)" />


### PR DESCRIPTION
The `ResolveCodeAnalysisRuleSet` MSBuild target is only defined for C# and VB projects. This meant that F# projects encountered failing design-time builds with error:

> error MSB4057: The target "ResolveCodeAnalysisRuleSet" does not exist in the project.

This change ensures the target is only added to `DependsOnTargets` for projects with language C# and VB.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8842)