### PR TITLE
Simplify ActiveConfiguredProjectsLoader

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -8,9 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
     ///     Force loads the active <see cref="ConfiguredProject"/> objects so that any configured project-level
     ///     services, such as evaluation and build services, are started.
     /// </summary>
-    [Export(typeof(ActiveConfiguredProjectsLoader))]
 
-    internal class ActiveConfiguredProjectsLoader : ChainedProjectValueDataSourceBase<IEnumerable<ConfiguredProject>>
+    internal class ActiveConfiguredProjectsLoader : OnceInitializedOnceDisposed
     {
         private readonly UnconfiguredProject _project;
         private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
@@ -20,7 +19,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         [ImportingConstructor]
         public ActiveConfiguredProjectsLoader(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService, IUnconfiguredProjectTasksService tasksService)
-            : base(containingProject: project, synchronousDisposal: false)
         {
             _project = project;
             _activeConfigurationGroupService = activeConfigurationGroupService;
@@ -37,7 +35,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Task.CompletedTask;
         }
 
-        public ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> TargetBlock => _targetBlock;
+        /// <summary>
+        /// Exposed for unit testing only.
+        /// </summary>
+        internal ITargetBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> TargetBlock => _targetBlock;
 
         protected override void Initialize()
         {
@@ -57,43 +58,14 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private async Task OnActiveConfigurationsChangedAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> e)
         {
-            await GetLoadedProjectsAsync(e);
-        }
-
-        protected override IDisposable? LinkExternalInput(ITargetBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> targetBlock)
-        {
-            IReceivableSourceBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>> sourceBlock = _activeConfigurationGroupService.ActiveConfigurationGroupSource.SourceBlock;
-
-            DisposableValue<ISourceBlock<IProjectVersionedValue<IEnumerable<ConfiguredProject>>>>? transformBlock = sourceBlock.TransformWithNoDelta(TransformAsync);
-
-            transformBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
-
-            return transformBlock;
-        }
-
-        private async Task<IProjectVersionedValue<IEnumerable<ConfiguredProject>>> TransformAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
-        {
-            List<ConfiguredProject> generatedResult = await GetLoadedProjectsAsync(projectVersionedValue);
-
-            return new ProjectVersionedValue<IEnumerable<ConfiguredProject>>(generatedResult, projectVersionedValue.DataSourceVersions);
-        }
-
-        private async Task<List<ConfiguredProject>> GetLoadedProjectsAsync(IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>> projectVersionedValue)
-        {
-            List<ConfiguredProject> generatedResult = new List<ConfiguredProject>();
-
-            foreach (ProjectConfiguration configuration in projectVersionedValue.Value)
+            foreach (ProjectConfiguration configuration in e.Value)
             {
                 // Make sure we aren't currently unloading, or we don't unload while we load the configuration
-                var loadedConfiguredProject = await _tasksService.LoadedProjectAsync(() =>
+                await _tasksService.LoadedProjectAsync(() =>
                 {
                     return _project.LoadConfiguredProjectAsync(configuration);
                 });
-
-                generatedResult.Add(loadedConfiguredProject);
             }
-
-            return generatedResult;
         }
     }
 }


### PR DESCRIPTION
This class monitors CPS's `ActiveConfigurationGroupSource` block and forces CPS to eagerly load the project for all configurations in the project.

CPS is looking at moving this logic to within CPS itself, giving greater control over when configured projects (across all dimensions) are loaded, for example to prevent various race conditions.

The previous implementation had two distinct behaviours:

1. Use `[ProjectAutoLoad]` to link an action to the `ActiveConfigurationGroupSource` that forces loads to occur.
2. Export a `ChainedProjectValueDataSourceBase<>`, which allows it to participate in Dataflow so that other blocks can subscribe to its output (`IEnumerable<ConfiguredProject>`).

This change keeps 1 and removes 2. That way, when CPS adds the behaviour of 1, we can be sure we don't need the behaviour of 2.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8854)