### PR TITLE
Prevent hang in LaunchSettingsProvider

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/TaskExtensionsTests.cs
@@ -12,6 +12,18 @@ namespace Microsoft.VisualStudio.Threading.Tasks
 
             var t2 = Task.Delay(10000);
             Assert.False(await t2.TryWaitForCompleteOrTimeoutAsync(20));
+
+            var t3 = Task.Delay(20);
+            Assert.True(await t3.TryWaitForCompleteOrTimeoutAsync(Timeout.Infinite));
+
+            var t4 = Task.FromCanceled(new CancellationToken(canceled: true));
+            await Assert.ThrowsAsync<TaskCanceledException>(() => t4.TryWaitForCompleteOrTimeoutAsync(1000));
+            await Assert.ThrowsAsync<TaskCanceledException>(() => t4.TryWaitForCompleteOrTimeoutAsync(Timeout.Infinite));
+
+            var ex = new Exception();
+            var t5 = Task.FromException(ex);
+            Assert.Same(ex, await Assert.ThrowsAsync<Exception>(() => t5.TryWaitForCompleteOrTimeoutAsync(1000)));
+            Assert.Same(ex, await Assert.ThrowsAsync<Exception>(() => t5.TryWaitForCompleteOrTimeoutAsync(Timeout.Infinite)));
         }
     }
 }


### PR DESCRIPTION
Fixes [AB#1745651](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1745651)

Ensure that we don't hang while waiting for snapshot data to arrive when the project is unloaded before that data can be produced.

Thanks @adrianvmsft for analyzing the dump and routing this bug to us with enough analysis to make the fix straightforward.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8856)