### PR TITLE
Sort PackageReferences

### DIFF
--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -17,37 +17,37 @@
     <Reference Include="WindowsBase" />
 
     <!-- Infrastructure -->
+    <!-- Path Property: PkgCodecov -->
+    <PackageReference Include="Codecov"                             ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="MicroBuild.Core.Sentinel"                  PrivateAssets="all" />
+    <!-- Path Property: PkgMicrosoft_DiaSymReader_Pdb2Pdb -->
+    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb"      ExcludeAssets="all" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.DotNet.XliffTasks"         PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub"         PrivateAssets="all" />
     <!-- Path Property: PkgMicrosoft_VisualStudioEng_MicroBuild_Core -->
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" PrivateAssets="all" GeneratePathProperty="true" />
     <!-- SwixBuild does not have the assets accessed via PackageReference. Instead, they are accessed directly from the NuGet cache on disk via property: PkgMicrosoft_VisualStudioEng_MicroBuild_Plugins_SwixBuild. -->
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild" ExcludeAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Nerdbank.Streams"                    ExcludeAssets="all" />
     <!-- Note: We require Nerdbank.GitVersioning beyond simply generating version numbers. It also produces some assembly information such as AssemblyName and PublicKeyToken into a *.ThisAssembly.cs file. -->
     <PackageReference Include="Nerdbank.GitVersioning"              PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.Streams"                    ExcludeAssets="all" />
     <PackageReference Include="System.IO.Pipelines"                 ExcludeAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
-    <PackageReference Include="Microsoft.DotNet.XliffTasks"         PrivateAssets="all" />
-    <!-- Path Property: PkgMicrosoft_DiaSymReader_Pdb2Pdb -->
-    <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb"      ExcludeAssets="all" GeneratePathProperty="true" />
-    <!-- Path Property: PkgCodecov -->
-    <PackageReference Include="Codecov"                             ExcludeAssets="all" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub"         PrivateAssets="all" />
 
     <!-- CPS -->
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Query" />
-    <PackageReference Include="Microsoft.VisualStudio.Validation" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" />
+    <PackageReference Include="Microsoft.VisualStudio.Validation" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
     
     <!-- VS MEF -->
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
 
     <!-- Roslyn -->
-    <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CSharp" />
+    <PackageReference Include="Microsoft.CodeAnalysis" />
 
     <!-- Needed to tie-break a potentially misspecified dependency somewhere -->
     <PackageReference Include="Microsoft.ServiceHub.Framework" />
@@ -55,10 +55,10 @@
     <!-- Analyzers-->
     <!-- Set PrivateAssets="all" to prevent consumers of our packages from picking up these analyzers transitively. -->
     <PackageReference Include="CSharpIsNullAnalyzer"                           PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers"               PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"        PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"   PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers"                   PrivateAssets="all" Condition="'$(IsTestProject)' != 'true'" />
 
     <!-- Framework packages -->
@@ -68,8 +68,8 @@
     <PackageReference Include="Newtonsoft.Json" />
 
     <!-- Host-Agnostic Visual Studio -->
-    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsUnitTestProject)' == 'true'">
@@ -82,6 +82,7 @@
     <PackageReference Include="xunit.extensibility.execution" />
     <PackageReference Include="xunit.runner.console" GeneratePathProperty="true" />
     <PackageReference Include="xunit.runner.visualstudio" GeneratePathProperty="true" />
+    
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
   </ItemGroup>
 

--- a/eng/imports/Packages.targets
+++ b/eng/imports/Packages.targets
@@ -3,30 +3,29 @@
 
   <ItemGroup>
     <!-- Infrastructure -->
+    <!-- This package is deprecated. CodecovUploader is now the recommended package. -->
+    <PackageReference Update="Codecov"                                                                Version="1.13.0" />
     <PackageReference Update="MicroBuild.Core.Sentinel"                                               Version="1.0.0" />
-    <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
-    <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild"                 Version="1.1.286" />
-    <PackageReference Update="Nerdbank.Streams"                                                       Version="2.9.112" />
-    <PackageReference Update="Nerdbank.GitVersioning"                                                 Version="3.5.107" />
-    <PackageReference Update="System.IO.Pipelines"                                                    Version="6.0.3" />
-    <PackageReference Update="Microsoft.DotNet.XliffTasks"                                            Version="1.0.0-beta.23073.2" />
     <!-- This is used for publishing PDBs to the legacy symbol server. It converts portable PDBs to Windows PDBs (embedded). -->
     <!-- https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb?anchor=portable-pdbs -->
     <PackageReference Update="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="1.1.0-beta2-22320-02" />
-    <!-- This package is deprecated. CodecovUploader is now the recommended package. -->
-    <PackageReference Update="Codecov"                                                                Version="1.13.0" />
+    <PackageReference Update="Microsoft.DotNet.XliffTasks"                                            Version="1.0.0-beta.23073.2" />
     <PackageReference Update="Microsoft.SourceLink.GitHub"                                            Version="1.1.1" />
+    <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
+    <PackageReference Update="Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild"                 Version="1.1.286" />
+    <PackageReference Update="Nerdbank.GitVersioning"                                                 Version="3.5.107" />
+    <PackageReference Update="Nerdbank.Streams"                                                       Version="2.9.112" />
+    <PackageReference Update="System.IO.Pipelines"                                                    Version="6.0.3" />
 
     <!-- VS SDK -->
     <PackageReference Update="EnvDTE"                                                                 Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.Internal.VisualStudio.Interop"                                Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.ServiceHub.Framework"                                         Version="4.1.2060-alpha" />
-    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.5.18-preview1" />
     <PackageReference Update="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.3.198" />
     <PackageReference Update="Microsoft.VisualStudio.Composition"                                     Version="17.4.1-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
-    <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
+    <PackageReference Update="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.4.0-beta.22470.1" />
     <PackageReference Update="Microsoft.VisualStudio.Debugger.UI.Interfaces"                          Version="17.4.0-beta.22470.1" />
@@ -35,9 +34,9 @@
     <PackageReference Update="Microsoft.VisualStudio.Interop"                                         Version="17.4.0-preview-2-32826-307" />
     <PackageReference Update="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
     <PackageReference Update="Microsoft.VisualStudio.RpcContracts"                                    Version="17.4.7-alpha" />
+    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
     <PackageReference Update="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.0.4492" />
-    <PackageReference Update="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Design"                                    Version="17.3.32804.24" />
     <PackageReference Update="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.3.32804.24" />
@@ -48,6 +47,7 @@
     <PackageReference Update="Microsoft.VisualStudio.Utilities"                                       Version="17.4.0-preview-3-32908-042" />
     <PackageReference Update="Microsoft.VisualStudio.Validation"                                      Version="17.6.4-alpha" />
     <PackageReference Update="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
+    <PackageReference Update="Microsoft.VSSDK.BuildTools"                                             Version="17.5.18-preview1" />
     <PackageReference Update="System.Threading.Tasks.Dataflow"                                        Version="6.0.0" />
     <PackageReference Update="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageReference Update="VsWebSite.Interop"                                                      Version="16.8.30523.219" />
@@ -57,17 +57,17 @@
 
     <!-- CPS -->
     <!-- Find versions at https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl -->
-    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="17.5.396-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="17.5.396-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="17.5.396-pre" />
+    <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="17.5.396-pre" />
     <PackageReference Update="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="17.5.396-pre" />
 
     <!-- Roslyn -->
+    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.5.0-2.22528.3" />
+    <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
     <PackageReference Update="Microsoft.Net.Compilers.Toolset"                                        Version="4.4.0" />
     <PackageReference Update="Microsoft.VisualStudio.LanguageServices"                                Version="4.5.0-2.22528.3" />
-    <PackageReference Update="Microsoft.CodeAnalysis"                                                 Version="4.5.0-2.22528.3" />
     <PackageReference Update="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
-    <PackageReference Update="Microsoft.CSharp"                                                       Version="4.7.0" />
 
     <!-- Analyzers -->
     <PackageReference Update="CSharpIsNullAnalyzer"                                                   Version="0.1.329" />
@@ -92,21 +92,21 @@
     <PackageReference Update="Moq"                                                                    Version="4.16.1" />
     <PackageReference Update="Verify.Xunit"                                                           Version="14.2.0" />
     <PackageReference Update="xunit"                                                                  Version="2.4.2-pre.13" />
+    <PackageReference Update="xunit.analyzers"                                                        Version="0.12.0-pre.19"/>
     <PackageReference Update="xunit.assert"                                                           Version="2.4.2-pre.13" />
     <PackageReference Update="xunit.combinatorial"                                                    Version="1.4.1" />
     <PackageReference Update="xunit.extensibility.core"                                               Version="2.4.2-pre.13" />
     <PackageReference Update="xunit.extensibility.execution"                                          Version="2.4.2-pre.13" NoWarn="NU1608" />
-    <PackageReference Update="xunit.runner.visualstudio"                                              Version="2.4.3" />
     <PackageReference Update="xunit.runner.console"                                                   Version="2.4.1" />
-    <PackageReference Update="xunit.analyzers"                                                        Version="0.12.0-pre.19"/>
+    <PackageReference Update="xunit.runner.visualstudio"                                              Version="2.4.3" />
 
     <!-- Integration Tests -->
-    <PackageReference Update="MSTest.TestFramework"                                                   Version="2.1.2" />
-    <PackageReference Update="MSTest.TestAdapter"                                                     Version="2.1.2" />
+    <PackageReference Update="Microsoft.DotNet.Common.ProjectTemplates.1.x"                           Version="1.0.0-beta2-20170629-269" />
+    <PackageReference Update="Microsoft.DotNet.Test.ProjectTemplates.1.x"                             Version="1.0.0-beta2-20170629-269" />
     <PackageReference Update="Microsoft.Test.Apex.VisualStudio"                                       Version="17.0.0-preview-2-31221-277" />
     <PackageReference Update="Microsoft.TestPlatform"                                                 Version="16.2.0" />
-    <PackageReference Update="Microsoft.DotNet.Test.ProjectTemplates.1.x"                             Version="1.0.0-beta2-20170629-269" />
-    <PackageReference Update="Microsoft.DotNet.Common.ProjectTemplates.1.x"                           Version="1.0.0-beta2-20170629-269" />
+    <PackageReference Update="MSTest.TestAdapter"                                                     Version="2.1.2" />
+    <PackageReference Update="MSTest.TestFramework"                                                   Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/eng/imports/VisualStudioDesigner.props
+++ b/eng/imports/VisualStudioDesigner.props
@@ -10,8 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Data.Core" />
     <PackageReference Include="Microsoft.VisualStudio.Data.Services" />
-    <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.DataDesign.Common" />
+    <PackageReference Include="Microsoft.VisualStudio.DataTools.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.TemplateWizardInterface" />
     <PackageReference Include="Microsoft.VisualStudio.XmlEditor" />
     <PackageReference Include="Microsoft.VSDesigner" />

--- a/eng/imports/VisualStudioIntegration.props
+++ b/eng/imports/VisualStudioIntegration.props
@@ -9,8 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Test.Apex.VisualStudio" />
-    <PackageReference Include="MSTest.TestFramework" />
     <PackageReference Include="MSTest.TestAdapter" />
+    <PackageReference Include="MSTest.TestFramework" />
 
     <!-- Provides vstest.console.exe -->
     <PackageReference Include="Microsoft.TestPlatform" GeneratePathProperty="true" ExcludeAssets="all" />


### PR DESCRIPTION
Sort the `PackageReference` items in our shared .props and .targets files. So long as we keep these sorted as we add new ones it will reduce the possibility of merge conflicts.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8866)