### PR TITLE
Migrate vs-impl and vssdk feeds

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -6,10 +6,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <!-- CPS components including: Microsoft.VisualStudio.ProjectSystem -->
-    <add key="vs-impl" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vs-impl/nuget/v3/index.json" />
-    <!-- Microsoft.VisualStudio components -->
-    <add key="vssdk" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/nuget/v3/index.json" />
+    <!-- Combined vs-impl and vssdk feeds -->
+    <add key="msft_consumption" value="https://pkgs.dev.azure.com/azure-public/vside/_packaging/msft_consumption/nuget/v3/index.json" />
     <!--
       Various packages including:
         Microsoft.DiaSymReader.Pdb2Pdb


### PR DESCRIPTION
The feeds for vs-impl and vssdk are migrating behind a new consumption feed that will retain only those packages that are actually used.

This commit applies the update recommended via email.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8869)