### PR TITLE
Warn if build acceleration enabled but not reference assemblies

### DIFF
--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -100,6 +100,12 @@ Looking through the build output with the following points in mind:
 
    Then any project that references the indicated project (directy or transitively) cannot be accelerated. This can happen if the mentioned project uses the legacy `.csproj` format, or for any other project system within Visual Studio that doesn't support build acceleration. Currently only .NET SDK-style projects (loaded with the project system from this GitHub repository) provide the needed data.
 
+- ⛔ If you see:
+
+   > This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'.
+
+   Then build acceleration will not know whether it is safe to copy a modified output DLL from a referenced project or not. We rely on the use of reference assemblies to convey this information. To address this, ensure all referenced projects have the `ProduceReferenceAssembly` property set to `true`. You may like to add this to your `Directory.Build.props` file alongside the `AccelerateBuildsInVisualStudio` property. Note that projects targeting `net5.0` or later produce reference assemblies by default. Projects that target .NET Standard may require this to be specified manually (see https://github.com/dotnet/project-system/issues/8865).
+
 - 🗒️ TODO Add validation and output message when reference assemblies are not enabled (https://github.com/dotnet/project-system/issues/8798)
 
 - ✅ You should see a section listing items to copy:

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -164,6 +164,9 @@
   <StringProperty Name="Platform"
                   Visible="False" />
 
+  <StringProperty Name="ProduceReferenceAssembly"
+                  Visible="False" />
+
   <StringProperty Name="ProjectAssetsFile"
                   ReadOnly="true"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -57,6 +57,16 @@ internal sealed partial class BuildUpToDateCheck
         /// </remarks>
         public bool? IsAccelerationEnabled { get; internal set; }
 
+        /// <summary>
+        /// Gets whether all referenced projects produce reference assemblies or not.
+        /// </summary>
+        /// <remarks>
+        /// Build acceleration works best when all referenced projects produce reference assemblies.
+        /// This flag allows us to prompt the user when they have enabled build acceleration, but
+        /// they are referencing projects that do not produce reference assemblies.
+        /// </remarks>
+        public bool AllReferencesProduceReferenceAssemblies { get; internal set; } = true;
+
         public BuildAccelerationResult AccelerationResult
         {
             get
@@ -187,7 +197,7 @@ internal sealed partial class BuildUpToDateCheck
         private readonly FileSystemOperationAggregator _parent;
         private readonly bool? _isBuildAccelerationEnabled;
 
-        public ConfiguredFileSystemOperationAggregator(FileSystemOperationAggregator parent, bool? isBuildAccelerationEnabled)
+        public ConfiguredFileSystemOperationAggregator(FileSystemOperationAggregator parent, bool? isBuildAccelerationEnabled, bool referencesProduceReferenceAssemblies)
         {
             _parent = parent;
             _isBuildAccelerationEnabled = isBuildAccelerationEnabled;
@@ -201,6 +211,11 @@ internal sealed partial class BuildUpToDateCheck
             {
                 // Note an explicit disable
                 _parent.IsAccelerationEnabled = false;
+            }
+
+            if (referencesProduceReferenceAssemblies is false)
+            {
+                _parent.AllReferencesProduceReferenceAssemblies = false;
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -1054,11 +1054,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                         // We may have an incomplete set of copy items.
                         // We check timestamps of whatever items we can find, but only perform acceleration when the full set is available.
-                        (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> copyItemsByProject, bool isCopyItemsComplete) = _copyItemAggregator.TryGatherCopyItemsForProject(implicitState.ProjectTargetPath, logger);
+                        (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> copyItemsByProject, bool isCopyItemsComplete, bool allReferencesProduceReferenceAssemblies)
+                            = _copyItemAggregator.TryGatherCopyItemsForProject(implicitState.ProjectTargetPath, logger);
 
                         bool? isBuildAccelerationEnabled = IsBuildAccelerationEnabled(isCopyItemsComplete, implicitState);
 
-                        var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled);
+                        var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled, allReferencesProduceReferenceAssemblies);
 
                         string outputFullPath = Path.Combine(implicitState.MSBuildProjectDirectory, implicitState.OutputRelativeOrFullPath);
 
@@ -1111,6 +1112,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         // and the project does not specify AccelerateBuildsInVisualStudio. Log a message to
                         // let the user know that their project might benefit from Build Acceleration.
                         logger.Minimal(nameof(Resources.FUTD_AccelerationCandidate));
+                    }
+
+                    if (fileSystemOperations.IsAccelerationEnabled is true && fileSystemOperations.AllReferencesProduceReferenceAssemblies is false)
+                    {
+                        // This project is configured to use build acceleration, but some of its references do not
+                        // produce reference assemblies. Log a message to let the user know that they may be able
+                        // to improve their build performance by enabling the production of reference assemblies.
+                        logger.Minimal(nameof(Resources.FUTD_NotAllReferencesProduceReferenceAssemblies));
                     }
 
                     logger.Verbose(nameof(Resources.FUTD_Completed), sw.Elapsed.TotalMilliseconds);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
@@ -20,7 +20,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
         }
     }
 
-    public (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger)
+    public (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete, bool AllReferencesProduceReferenceAssemblies) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger)
     {
         // Keep track of all projects we've visited to avoid infinite recursion or duplicated results.
         HashSet<string> explored = new(StringComparers.Paths);
@@ -37,6 +37,10 @@ internal class CopyItemAggregator : ICopyItemAggregator
         // for copies, which will trigger builds that would otherwise have been skipped. Using incomplete
         // results is strictly an improvement over ignoring what results we do have.
         bool isComplete = true;
+
+        // Whether all referenced projects have ProduceReferenceAssembly set to true. The originating project
+        // is not included in this check (targetPath).
+        bool allReferencesProduceReferenceAssemblies = true;
 
         List<ProjectCopyData>? contributingProjects = null;
 
@@ -60,6 +64,12 @@ internal class CopyItemAggregator : ICopyItemAggregator
                     continue;
                 }
 
+                if (!data.ProduceReferenceAssembly && project != targetPath)
+                {
+                    // One of the referenced projects does not produce a reference assembly.
+                    allReferencesProduceReferenceAssemblies = false;
+                }
+
                 foreach (string referencedProjectTargetPath in data.ReferencedProjectTargetPaths)
                 {
                     frontier.Enqueue(referencedProjectTargetPath);
@@ -73,7 +83,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
             }
         }
 
-        return (GenerateCopyItems(), isComplete);
+        return (GenerateCopyItems(), isComplete, allReferencesProduceReferenceAssemblies);
 
         IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> GenerateCopyItems()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
@@ -30,9 +30,10 @@ internal interface ICopyItemAggregator
     /// <list type="number">
     ///   <item><c>Items</c> a sequence of items by project, that are reachable from the current project.</item>
     ///   <item><c>IsComplete</c> indicating whether we have items from all reachable projects.</item>
+    ///   <item><c>AllReferencesProduceReferenceAssemblies</c> indicating whether all referenced projects produce reference assemblies.</item>
     /// </list>
     /// </returns>
-    (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger);
+    (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete, bool AllReferencesProduceReferenceAssemblies) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger);
 }
 
 /// <summary>
@@ -40,11 +41,13 @@ internal interface ICopyItemAggregator
 /// </summary>
 /// <param name="ProjectFullPath">The full path to the project file (e.g. the <c>.csproj</c> file).</param>
 /// <param name="TargetPath">The full path to the target file (e.g. a <c>.dll</c> file), which should be unique to the configuration.</param>
+/// <param name="ProduceReferenceAssembly">Whether this project produces a reference assembly or not, determined by the <c>ProduceReferenceAssembly</c> MSBuild property.</param>
 /// <param name="CopyItems">The set of items the project provider to the output directory of itself and other projects.</param>
 /// <param name="ReferencedProjectTargetPaths">The target paths resolved from this project's references to other projects.</param>
 internal record struct ProjectCopyData(
     string? ProjectFullPath,
     string TargetPath,
+    bool ProduceReferenceAssembly,
     ImmutableArray<CopyItem> CopyItems,
     ImmutableArray<string> ReferencedProjectTargetPaths)
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -628,6 +628,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the &apos;ProduceReferenceAssembly&apos; MSBuild property set to &apos;true&apos;. See https://aka.ms/vs-build-acceleration..
+        /// </summary>
+        internal static string FUTD_NotAllReferencesProduceReferenceAssemblies {
+            get {
+                return ResourceManager.GetString("FUTD_NotAllReferencesProduceReferenceAssemblies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Output &apos;{0}&apos; does not exist, not up-to-date..
         /// </summary>
         internal static string FUTD_OutputDoesNotExist_1 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -449,6 +449,10 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</value>
     <comment>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</comment>
   </data>
+  <data name="FUTD_NotAllReferencesProduceReferenceAssemblies" xml:space="preserve">
+    <value>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</value>
+    <comment>Do not translate 'ProduceReferenceAssembly' or 'true'.</comment>
+  </data>
   <data name="FUTD_AccelerationDisabledCopyItemsIncomplete" xml:space="preserve">
     <value>Build acceleration is not available for this project because not all transitively referenced projects have provided acceleration data.</value>
   </data>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Vstupní položka {1} {0} neexistuje, i když je povinná.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">Výstup {0} neexistuje. Není aktuální.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Die Eingabe {1}-Element "{0}" ist nicht vorhanden, aber nicht erforderlich.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">Die Ausgabe "{0}" ist nicht vorhanden, nicht aktuell.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -297,6 +297,11 @@
         <target state="translated">El elemento {1} de entrada "{0}" no existe, pero no es necesario.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">La salida "{0}" no existe, no está actualizada.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -297,6 +297,11 @@
         <target state="translated">L''{0}' d’élément de {1} d’entrée n’existe pas, mais n’est pas obligatoire.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">La sortie '{0}' n’existe pas, elle n’est pas à jour.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -297,6 +297,11 @@
         <target state="translated">L'input {1} 'elemento '{0}' non esiste, ma non è obbligatorio.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">L'output '{0}' non esiste, non è aggiornato.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -297,6 +297,11 @@
         <target state="translated">入力 {1} の項目 '{0}' は存在しませんが、必須ではありません。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">出力 '{0}' が存在せず、最新ではありません。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -297,6 +297,11 @@
         <target state="translated">입력 {1} 항목 '{0}'이(가) 존재하지 않지만 필수는 아닙니다.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">출력 '{0}'이(가) 존재하지 않으며 최신 상태가 아닙니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Wejściowy {1} element „{0}” nie istnieje, ale nie jest wymagany.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">Dane wyjściowe „{0}’ nie istnieją, nie są aktualne.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -297,6 +297,11 @@
         <target state="translated">O item '{0}' de entrada {1} não existe, mas não é necessário.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">A saída '{0}' não existe, não atualizada.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -297,6 +297,11 @@
         <target state="translated">Элемент "{0}" входных данных {1} не существует и не является обязательным.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">Выходные данные "{0}" не существуют. Обновление не выполнено.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -297,6 +297,11 @@
         <target state="translated">{1} girişinin '{0}' öğesi yok ancak gerekli değil.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">'{0}' çıkışı yok ve güncel değil.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -297,6 +297,11 @@
         <target state="translated">输入{1}项'{0}'不存在，但不需要。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">输出 '{0}' 不存在，不是最新的。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -297,6 +297,11 @@
         <target state="translated">輸入 {1} 項目 '{0}' 不存在，但並非必要項目。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
+        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
+      </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">
         <source>Output '{0}' does not exist, not up-to-date.</source>
         <target state="translated">輸出 '{0}' 不存在，不是最新狀態。</target>


### PR DESCRIPTION
Fixes #8798

Build acceleration relies heavily upon the presence of reference assemblies. If a referenced project does not produce a reference assembly, we will be unable to accelerate the case where that referenced project had a private (non public-API) change.

This change introduces a log message when we detect this scenario, directing the user to consider a change that would improve their incremental build performance.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8870)