### PR TITLE
Fix DLL signing verification + ApiScan

### DIFF
--- a/eng/pipelines/templates/analyze-api.yml
+++ b/eng/pipelines/templates/analyze-api.yml
@@ -25,10 +25,10 @@ jobs:
     patterns: |
       bin/Dlls/**/Microsoft.VisualStudio.AppDesigner*.pdb
       bin/Dlls/**/Microsoft.VisualStudio.Editors*.pdb
-      bin/Dlls/**/Microsoft.VisualStudio.Managed*.pdb
+      bin/Dlls/**/Microsoft.VisualStudio.ProjectSystem.Managed*.pdb
       bin/Dlls/**/Microsoft.VisualStudio.AppDesigner*.dll
       bin/Dlls/**/Microsoft.VisualStudio.Editors*.dll
-      bin/Dlls/**/Microsoft.VisualStudio.Managed*.dll
+      bin/Dlls/**/Microsoft.VisualStudio.ProjectSystem.Managed*.dll
 
   ###################################################################################################################################################################
   # RUN ANALYSIS

--- a/eng/pipelines/templates/analyze-compliance.yml
+++ b/eng/pipelines/templates/analyze-compliance.yml
@@ -49,7 +49,7 @@ jobs:
     inputs:
       Path: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/bin/Dlls/
       # Glob Format: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1378/Glob-Format
-      Targets: '**/Microsoft.VisualStudio.AppDesigner*.dll;**/Microsoft.VisualStudio.Editors*.dll;**/Microsoft.VisualStudio.Managed*.dll'
+      Targets: '**/Microsoft.VisualStudio.AppDesigner*.dll;**/Microsoft.VisualStudio.Editors*.dll;**/Microsoft.VisualStudio.ProjectSystem.Managed*.dll'
     condition: succeededOrFailed()
 
   # Verifies the packages (and files within) are signed appropriately.


### PR DESCRIPTION
## Description
When checking if files are signed appropriately, we do 2 scans which use different tasks. The first only checks if the *DLLs* are signed appropriately. The second checks to see if the package (and all contents within it) are signed appropriately. The first check had a copy-paste bug where the `ProjectSystem` was missing out of the filepath to search for files. This PR adds that back it so it is verified in the first signing check.

The same copy-paste issue was in APIScan for downloading the required files. This fixes that too.

## Test Build
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7392601&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8883)