### PR TITLE
Log details of referenced projects not producing a reference assembly

### DIFF
--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -106,8 +106,6 @@ Looking through the build output with the following points in mind:
 
    Then build acceleration will not know whether it is safe to copy a modified output DLL from a referenced project or not. We rely on the use of reference assemblies to convey this information. To address this, ensure all referenced projects have the `ProduceReferenceAssembly` property set to `true`. You may like to add this to your `Directory.Build.props` file alongside the `AccelerateBuildsInVisualStudio` property. Note that projects targeting `net5.0` or later produce reference assemblies by default. Projects that target .NET Standard may require this to be specified manually (see https://github.com/dotnet/project-system/issues/8865).
 
-- 🗒️ TODO Add validation and output message when reference assemblies are not enabled (https://github.com/dotnet/project-system/issues/8798)
-
 - ✅ You should see a section listing items to copy:
 
    ```

--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -102,9 +102,11 @@ Looking through the build output with the following points in mind:
 
 - ⛔ If you see:
 
-   > This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'.
+   > This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': '&lt;path1&gt;', '&lt;path2&gt;'.
 
    Then build acceleration will not know whether it is safe to copy a modified output DLL from a referenced project or not. We rely on the use of reference assemblies to convey this information. To address this, ensure all referenced projects have the `ProduceReferenceAssembly` property set to `true`. You may like to add this to your `Directory.Build.props` file alongside the `AccelerateBuildsInVisualStudio` property. Note that projects targeting `net5.0` or later produce reference assemblies by default. Projects that target .NET Standard may require this to be specified manually (see https://github.com/dotnet/project-system/issues/8865).
+
+   This message lists the referenced projects that are not producing a reference assembly. The `TargetPath` of those projects is used, as this can help disambiguate between target frameworks in multi-targeting projects.
 
 - ✅ You should see a section listing items to copy:
 

--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -98,7 +98,7 @@ Looking through the build output with the following points in mind:
 
    > Build acceleration data is unavailable for project with target 'C:\Solution\Project\bin\Debug\Project.dll'.
 
-   Then any project that references the indicated project (directy or transitively) cannot be accelerated. This can happen if the mentioned project uses the legacy `.csproj` format, or for any other project system within Visual Studio that doesn't support build acceleration. Currently only .NET SDK-style projects (loaded with the project system from this GitHub repository) provide the needed data.
+   Then any project that references the indicated project (directly or transitively) cannot be accelerated. This can happen if the mentioned project uses the legacy `.csproj` format, or for any other project system within Visual Studio that doesn't support build acceleration. Currently only .NET SDK-style projects (loaded with the project system from this GitHub repository) provide the needed data.
 
 - ⛔ If you see:
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -1058,7 +1058,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                         bool? isBuildAccelerationEnabled = IsBuildAccelerationEnabled(copyInfo.IsComplete, implicitState);
 
-                        var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled, copyInfo.AllReferencesProduceReferenceAssemblies);
+                        var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled, copyInfo.TargetsWithoutReferenceAssemblies);
 
                         string outputFullPath = Path.Combine(implicitState.MSBuildProjectDirectory, implicitState.OutputRelativeOrFullPath);
 
@@ -1113,12 +1113,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         logger.Minimal(nameof(Resources.FUTD_AccelerationCandidate));
                     }
 
-                    if (fileSystemOperations.IsAccelerationEnabled is true && fileSystemOperations.AllReferencesProduceReferenceAssemblies is false)
+                    if (fileSystemOperations.IsAccelerationEnabled is true && fileSystemOperations.TargetsWithoutReferenceAssemblies is { Count: > 0 })
                     {
                         // This project is configured to use build acceleration, but some of its references do not
                         // produce reference assemblies. Log a message to let the user know that they may be able
                         // to improve their build performance by enabling the production of reference assemblies.
-                        logger.Minimal(nameof(Resources.FUTD_NotAllReferencesProduceReferenceAssemblies));
+                        logger.Minimal(nameof(Resources.FUTD_NotAllReferencesProduceReferenceAssemblies_1), string.Join(", ", fileSystemOperations.TargetsWithoutReferenceAssemblies.Select(s => $"'{s}'")));
                     }
 
                     logger.Verbose(nameof(Resources.FUTD_Completed), sw.Elapsed.TotalMilliseconds);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -1054,12 +1054,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                         // We may have an incomplete set of copy items.
                         // We check timestamps of whatever items we can find, but only perform acceleration when the full set is available.
-                        (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> copyItemsByProject, bool isCopyItemsComplete, bool allReferencesProduceReferenceAssemblies)
-                            = _copyItemAggregator.TryGatherCopyItemsForProject(implicitState.ProjectTargetPath, logger);
+                        CopyItemsResult copyInfo = _copyItemAggregator.TryGatherCopyItemsForProject(implicitState.ProjectTargetPath, logger);
 
-                        bool? isBuildAccelerationEnabled = IsBuildAccelerationEnabled(isCopyItemsComplete, implicitState);
+                        bool? isBuildAccelerationEnabled = IsBuildAccelerationEnabled(copyInfo.IsComplete, implicitState);
 
-                        var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled, allReferencesProduceReferenceAssemblies);
+                        var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled, copyInfo.AllReferencesProduceReferenceAssemblies);
 
                         string outputFullPath = Path.Combine(implicitState.MSBuildProjectDirectory, implicitState.OutputRelativeOrFullPath);
 
@@ -1069,7 +1068,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                             !CheckInputsAndOutputs(logger, lastSuccessfulBuildStartTimeUtc, timestampCache, implicitState, ignoreKinds, token) ||
                             !CheckBuiltFromInputFiles(logger, timestampCache, implicitState, token) ||
                             !CheckMarkers(logger, timestampCache, implicitState, isBuildAccelerationEnabled, fileSystemOperations) ||
-                            !CheckCopyToOutputDirectoryItems(logger, implicitState, copyItemsByProject, configuredFileSystemOperations, isBuildAccelerationEnabled, token))
+                            !CheckCopyToOutputDirectoryItems(logger, implicitState, copyInfo.ItemsByProject, configuredFileSystemOperations, isBuildAccelerationEnabled, token))
                         {
                             return (false, checkedConfigurations);
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
@@ -38,9 +38,9 @@ internal class CopyItemAggregator : ICopyItemAggregator
         // results is strictly an improvement over ignoring what results we do have.
         bool isComplete = true;
 
-        // Whether all referenced projects have ProduceReferenceAssembly set to true. The originating project
-        // is not included in this check (targetPath).
-        bool allReferencesProduceReferenceAssemblies = true;
+        // Lazily populated list of referenced projects not having ProduceReferenceAssembly set to true.
+        // The originating project is not included in this check (targetPath).
+        List<string>? referencesNotProducingReferenceAssembly = null;
 
         List<ProjectCopyData>? contributingProjects = null;
 
@@ -67,7 +67,8 @@ internal class CopyItemAggregator : ICopyItemAggregator
                 if (!data.ProduceReferenceAssembly && project != targetPath)
                 {
                     // One of the referenced projects does not produce a reference assembly.
-                    allReferencesProduceReferenceAssemblies = false;
+                    referencesNotProducingReferenceAssembly ??= new();
+                    referencesNotProducingReferenceAssembly.Add(data.TargetPath);
                 }
 
                 foreach (string referencedProjectTargetPath in data.ReferencedProjectTargetPaths)
@@ -83,7 +84,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
             }
         }
 
-        return new(GenerateCopyItems(), isComplete, allReferencesProduceReferenceAssemblies);
+        return new(GenerateCopyItems(), isComplete, referencesNotProducingReferenceAssembly);
 
         IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> GenerateCopyItems()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/CopyItemAggregator.cs
@@ -20,7 +20,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
         }
     }
 
-    public (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete, bool AllReferencesProduceReferenceAssemblies) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger)
+    public CopyItemsResult TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger)
     {
         // Keep track of all projects we've visited to avoid infinite recursion or duplicated results.
         HashSet<string> explored = new(StringComparers.Paths);
@@ -83,7 +83,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
             }
         }
 
-        return (GenerateCopyItems(), isComplete, allReferencesProduceReferenceAssemblies);
+        return new(GenerateCopyItems(), isComplete, allReferencesProduceReferenceAssemblies);
 
         IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> GenerateCopyItems()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
@@ -25,16 +25,21 @@ internal interface ICopyItemAggregator
     /// </remarks>
     /// <param name="targetPath">The target path of the project to query from.</param>
     /// <param name="logger">An object for writing log messages.</param>
-    /// <returns>
-    /// A tuple comprising:
-    /// <list type="number">
-    ///   <item><c>Items</c> a sequence of items by project, that are reachable from the current project.</item>
-    ///   <item><c>IsComplete</c> indicating whether we have items from all reachable projects.</item>
-    ///   <item><c>AllReferencesProduceReferenceAssemblies</c> indicating whether all referenced projects produce reference assemblies.</item>
-    /// </list>
-    /// </returns>
-    (IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject, bool IsComplete, bool AllReferencesProduceReferenceAssemblies) TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger);
+    /// <returns>A structure containing the results of the operation.</returns>
+    CopyItemsResult TryGatherCopyItemsForProject(string targetPath, BuildUpToDateCheck.Log logger);
 }
+
+/// <summary>
+/// Results of gathering the items that must be copied as part of a project's build
+/// by <see cref="ICopyItemAggregator.TryGatherCopyItemsForProject(string, BuildUpToDateCheck.Log)"/>.
+/// </summary>
+/// <param name="ItemsByProject">A sequence of items by project, that are reachable from the current project</param>
+/// <param name="IsComplete">Indicates whether we have items from all reachable projects.</param>
+/// <param name="AllReferencesProduceReferenceAssemblies">Indicates whether all referenced projects produce reference assemblies.</param>
+internal record struct CopyItemsResult(
+    IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject,
+    bool IsComplete,
+    bool AllReferencesProduceReferenceAssemblies);
 
 /// <summary>
 /// Models the set of copy items a project produces, along with some details about the project.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/ICopyItemAggregator.cs
@@ -35,11 +35,14 @@ internal interface ICopyItemAggregator
 /// </summary>
 /// <param name="ItemsByProject">A sequence of items by project, that are reachable from the current project</param>
 /// <param name="IsComplete">Indicates whether we have items from all reachable projects.</param>
-/// <param name="AllReferencesProduceReferenceAssemblies">Indicates whether all referenced projects produce reference assemblies.</param>
+/// <param name="TargetsWithoutReferenceAssemblies">
+///     A list of target paths for projects that do not produce reference assemblies, or <see langword="null"/> if
+///     all reachable projects do in fact produce reference assemblies.
+/// </param>
 internal record struct CopyItemsResult(
     IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject,
     bool IsComplete,
-    bool AllReferencesProduceReferenceAssemblies);
+    IReadOnlyList<string>? TargetsWithoutReferenceAssemblies);
 
 /// <summary>
 /// Models the set of copy items a project produces, along with some details about the project.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -628,11 +628,11 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the &apos;ProduceReferenceAssembly&apos; MSBuild property set to &apos;true&apos;. See https://aka.ms/vs-build-acceleration..
+        ///   Looks up a localized string similar to This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the &apos;ProduceReferenceAssembly&apos; MSBuild property set to &apos;true&apos;: {0}. See https://aka.ms/vs-build-acceleration for more information..
         /// </summary>
-        internal static string FUTD_NotAllReferencesProduceReferenceAssemblies {
+        internal static string FUTD_NotAllReferencesProduceReferenceAssemblies_1 {
             get {
-                return ResourceManager.GetString("FUTD_NotAllReferencesProduceReferenceAssemblies", resourceCulture);
+                return ResourceManager.GetString("FUTD_NotAllReferencesProduceReferenceAssemblies_1", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -449,8 +449,8 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.</value>
     <comment>Do not translate 'AccelerateBuildsInVisualStudio' or 'true'.</comment>
   </data>
-  <data name="FUTD_NotAllReferencesProduceReferenceAssemblies" xml:space="preserve">
-    <value>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</value>
+  <data name="FUTD_NotAllReferencesProduceReferenceAssemblies_1" xml:space="preserve">
+    <value>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</value>
     <comment>Do not translate 'ProduceReferenceAssembly' or 'true'.</comment>
   </data>
   <data name="FUTD_AccelerationDisabledCopyItemsIncomplete" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -297,9 +297,9 @@
         <target state="translated">Vstupní položka {1} {0} neexistuje, i když je povinná.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Tento projekt povolil akceleraci sestavování, ale nejméně jeden odkazovaný projekt nevytváří referenční sestavení. Zajistěte, aby všechny odkazované projekty, přímé i nepřímé, měly vlastnost MSBuild ProduceReferenceAssembly nastavenou na hodnotu true. Viz https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -297,9 +297,9 @@
         <target state="translated">Die Eingabe {1}-Element "{0}" ist nicht vorhanden, aber nicht erforderlich.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Dieses Projekt hat die Buildbeschleunigung aktiviert, aber mindestens ein Projekt, auf das verwiesen wird, erzeugt keine Verweisassemblys. Stellen Sie sicher, dass die MSBuild-Eigenschaft "ProduceReferenceAssembly" für alle direkten und indirekten Projekte, auf die verwiesen wird, auf "true" festgelegt ist. Siehe https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -297,9 +297,9 @@
         <target state="translated">El elemento {1} de entrada "{0}" no existe, pero no es necesario.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Este proyecto ha habilitado la aceleración de compilación, pero al menos un proyecto al que se hace referencia no produce ensamblados de referencia. Asegúrese de que todos los proyectos a los que se hace referencia, directos e indirectos, tengan la propiedad 'ProduceReferenceAssembly' de MSBuild establecida en 'true'. Consulte https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -297,9 +297,9 @@
         <target state="translated">L''{0}' d’élément de {1} d’entrée n’existe pas, mais n’est pas obligatoire.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Ce projet a activé l’accélération de build, mais au moins un projet référencé ne produit pas d’assemblys de référence. Vérifiez que tous les projets référencés, directs et indirects, ont la propriété MSBuild 'ProduceReferenceAssembly' définie sur 'true'. Voir https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -297,9 +297,9 @@
         <target state="translated">L'input {1} 'elemento '{0}' non esiste, ma non è obbligatorio.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Questo progetto ha abilitato l'accelerazione della compilazione, ma almeno un progetto a cui si fa riferimento non produce assembly di riferimento. Assicurarsi che tutti i progetti di riferimento, sia diretti che indiretti, abbiano la proprietà MSBuild 'ProduceReferenceAssembly' impostata su 'true'. Vedere https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -297,9 +297,9 @@
         <target state="translated">入力 {1} の項目 '{0}' は存在しませんが、必須ではありません。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">このプロジェクトではビルド アクセラレーションが有効になっていますが、少なくとも 1 つの参照プロジェクトで参照アセンブリが生成されていません。直接的および間接的に参照されているすべてのプロジェクトで、'ProduceReferenceAssembly' MSBuild プロパティが 'true' に設定されていることを確認してください。参照: https://aka.ms/vs-build-acceleration</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -297,9 +297,9 @@
         <target state="translated">입력 {1} 항목 '{0}'이(가) 존재하지 않지만 필수는 아닙니다.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">이 프로젝트에 빌드 가속이 활성화되어 있지만 하나 이상의 참조된 프로젝트에서 참조 어셈블리를 생성하지 않습니다. 직접 및 간접적으로 참조된 모든 프로젝트에 'ProduceReferenceAssembly' MSBuild 속성이 'true'로 설정되어 있는지 확인하세요. https://aka.ms/vs-build-acceleration을 참조하세요.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -297,9 +297,9 @@
         <target state="translated">Wejściowy {1} element „{0}” nie istnieje, ale nie jest wymagany.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Ten projekt ma włączone przyspieszanie kompilacji, ale co najmniej jeden przywoływany projekt nie tworzy zestawów odwołań. Upewnij się, że wszystkie przywoływane projekty, zarówno bezpośrednie, jak i pośrednie, mają właściwość 'ProduceReferenceAssembly' MSBuild ustawioną na 'true'. Zobacz https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -297,9 +297,9 @@
         <target state="translated">O item '{0}' de entrada {1} não existe, mas não é necessário.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Este projeto habilitou a aceleração de compilação, mas pelo menos um projeto referenciado não produz assemblies de referência. Certifique-se de que todos os projetos referenciados, diretos e indiretos, tenham a propriedade MSBuild 'ProduceReferenceAssembly' definida como 'verdadeiro'. Veja https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -297,9 +297,9 @@
         <target state="translated">Элемент "{0}" входных данных {1} не существует и не является обязательным.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">В этом проекте включено ускорение сборки, но по крайней мере один указанный проект не создает 	базовые сборки. Убедитесь, что для всех указанных проектов (как прямых, так и косвенных), свойству MSBuild "ProduceReferenceAssembly" присвоено значение "true". Сведения: https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -297,9 +297,9 @@
         <target state="translated">{1} girişinin '{0}' öğesi yok ancak gerekli değil.</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">Bu proje derleme hızlandırmasını etkinleştirdi, ancak başvurulan en az bir proje başvuru bütünleştirilmiş kodları üretmez. Hem doğrudan hem de dolaylı başvurulan tüm projelerin 'ProduceReferenceAssembly' MSBuild özelliğinin 'true' olarak ayarlandığından emin olun. Bkz. https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -297,9 +297,9 @@
         <target state="translated">输入{1}项'{0}'不存在，但不需要。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">此项目已启用生成加速，但至少一个引用的项目不会生成引用程序集。请确保所有引用的项目(包括直接项目和间接项目)都将 "ProduceReferenceAssembly" MSBuild 属性设置为 "true"。请参阅 https://aka.ms/vs-build-acceleration。</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -297,9 +297,9 @@
         <target state="translated">輸入 {1} 項目 '{0}' 不存在，但並非必要項目。</target>
         <note>{0} is a file path. {1} is an MSBuild item type.</note>
       </trans-unit>
-      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies">
-        <source>This project has enabled build acceleration, but at least one referenced project does not produce reference assemblies. Ensure all referenced projects, both direct and indirect, have the 'ProduceReferenceAssembly' MSBuild property set to 'true'. See https://aka.ms/vs-build-acceleration.</source>
-        <target state="translated">此專案已啟用組建加速，但至少有一個參考專案未產生參考元件。請確認所有直接和間接參考的專案都已將 'ProduceReferenceAssembly' MSBuild 屬性設定為 'true'。請參閱 https://aka.ms/vs-build-acceleration.</target>
+      <trans-unit id="FUTD_NotAllReferencesProduceReferenceAssemblies_1">
+        <source>This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</source>
+        <target state="new">This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': {0}. See https://aka.ms/vs-build-acceleration for more information.</target>
         <note>Do not translate 'ProduceReferenceAssembly' or 'true'.</note>
       </trans-unit>
       <trans-unit id="FUTD_OutputDoesNotExist_1">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             var upToDateCheckHost = new Mock<IUpToDateCheckHost>(MockBehavior.Strict);
 
             var copyItemAggregator = new Mock<ICopyItemAggregator>(MockBehavior.Strict);
-            copyItemAggregator.Setup(o => o.TryGatherCopyItemsForProject(It.IsAny<string>(), It.IsAny<BuildUpToDateCheck.Log>())).Returns(() => (_copyItems, _isCopyItemsComplete, _allReferencesProduceReferenceAssemblies));
+            copyItemAggregator.Setup(o => o.TryGatherCopyItemsForProject(It.IsAny<string>(), It.IsAny<BuildUpToDateCheck.Log>())).Returns(() => new CopyItemsResult(_copyItems, _isCopyItemsComplete, _allReferencesProduceReferenceAssemblies));
 
             _currentSolutionBuildContext = new SolutionBuildContext(_fileSystem);
 


### PR DESCRIPTION
Fixes #8880

Build acceleration works best when all referenced projects produce a reference assembly each. We recently added a message highlighting when this was not the case, but didn't explain which project needed to be modified in order to fix this issue.

This change tracks and logs which projects need updating. The `TargetPath` is printed for those projects, which will generally also identify the target framework and so is therefore more helpful than just the `.csproj` file.




###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8885)