### PR TITLE
Avoid duplicating My in settings type if no root namespace exists

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -589,7 +589,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 fullTypeName = projectRootNamespace & "."
             End If
             
-            If defaultNamespace <> "" And Not defaultNamespace.Equals(MyNamespaceName) Then ' defaultNamespace, if none exists, will come in thru wszDefaultNamespace as My. We don't want to duplicate it.
+            If defaultNamespace <> "" AndAlso Not defaultNamespace.Equals(MyNamespaceName) Then ' defaultNamespace, if none exists, will come in thru wszDefaultNamespace as My. We don't want to duplicate it.
                 fullTypeName &= defaultNamespace & "."
             End If
 

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -589,7 +589,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 fullTypeName = projectRootNamespace & "."
             End If
             
-            If defaultNamespace <> "" Then
+            If defaultNamespace <> "" And Not defaultNamespace.Equals(MyNamespaceName) Then ' defaultNamespace, if none exists, will come in thru wszDefaultNamespace as My. We don't want to duplicate it.
                 fullTypeName &= defaultNamespace & "."
             End If
 


### PR DESCRIPTION
If the user has not defined a default namespace in VB .net framework, it will default to "My". We want to avoid My.My. being generated in the file generator.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8888)