### PR TITLE
Document property editor metadata for disabling commands, add it to C# DefineConstants property

### DIFF
--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -105,9 +105,9 @@ the ability to set dimensions, reset the property values, or use a single value 
 By default, these configuration commands are enabled if the Property fulfills certain requirements. However, you may explicitly disable 
 one or more by setting any of the following Property editor metadata to false:
 
-- `SingleValueConfigurationCommandEnabled` - disables the ability to collapse property values across configurations
-- `DimensionConfigurationCommandEnabled` - disables the ability to set any dimensions
-- `ResetPropertyValueCommandEnabled` - disables the ability to reset property value
+- `SingleValueConfigurationCommandEnabled` &mdash; disables the ability to collapse property values across configurations
+- `DimensionConfigurationCommandEnabled` &mdash; disables the ability to set any dimensions
+- `ResetPropertyValueCommandEnabled` &mdash; disables the ability to reset property value
 
 An example of this is shown below:
 

--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -97,6 +97,44 @@ If you wish to assign properties to specific categories, you must declare them u
 - `DisplayName` value will appear in group headings and the navigation tree.
 - `Description` is currently unused.
 
+### Property settings commands
+
+Each property can have one or more "configuration commands." These are the commands shown when clicking on the property gear, and include 
+the ability to set dimensions, reset the property values, or use a single value for all configurations.
+
+By default, these configuration commands are enabled if the Property fulfills certain requirements. However, you may explicitly disable 
+one or more by setting any of the following Property editor metadata to false:
+
+- `SingleValueConfigurationCommandEnabled` - disables the ability to collapse property values across configurations
+- `DimensionConfigurationCommandEnabled` - disables the ability to set any dimensions
+- `ResetPropertyValueCommandEnabled` - disables the ability to reset property value
+
+An example of this is shown below:
+
+```xaml
+  <StringProperty Name="DefineConstants" 
+                       DisplayName="Conditional compilation symbols"
+                       Description="Specifies symbols on which to perform conditional compilation."
+                       HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147079"
+                       Category="General">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFileWithInterception"
+                  HasConfigurationCondition="True" />
+    </StringProperty.DataSource>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="MultiStringSelector">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="TypeDescriptorText" Value="Custom symbols" xliff:LocalizedProperties="Value" />
+          <NameValuePair Name="AllowsCustomStrings" Value="True" />
+          <NameValuePair Name="ShouldDisplayEvaluatedPreview" Value="True" />
+          
+          <NameValuePair Name="SingleValueConfigurationCommandEnabled" Value="False" /> <!-- disables the ability to collapse property values across configurations -->
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
+  </StringProperty>
+  ```
+
 ### An example property
 
 Here is a complex example of a string property that demonstrates the majority of features we will discuss below.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -56,7 +56,6 @@
           <NameValuePair Name="TypeDescriptorText" Value="Custom symbols" xliff:LocalizedProperties="Value" />
           <NameValuePair Name="AllowsCustomStrings" Value="True" />
           <NameValuePair Name="ShouldDisplayEvaluatedPreview" Value="True" />
-          
           <NameValuePair Name="SingleValueConfigurationCommandEnabled" Value="False" />
         </ValueEditor.Metadata>
       </ValueEditor>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -56,6 +56,8 @@
           <NameValuePair Name="TypeDescriptorText" Value="Custom symbols" xliff:LocalizedProperties="Value" />
           <NameValuePair Name="AllowsCustomStrings" Value="True" />
           <NameValuePair Name="ShouldDisplayEvaluatedPreview" Value="True" />
+          
+          <NameValuePair Name="SingleValueConfigurationCommandEnabled" Value="False" />
         </ValueEditor.Metadata>
       </ValueEditor>
     </StringProperty.ValueEditors>


### PR DESCRIPTION
Problem: we may have properties where it is not possible/should not be allowable to actually use one of the property configuration commands.

This is a problem, for example, with C# DefineConstants, as the values across dimensions will _always_ vary.

This documents 3 new EditorMetadata properties to allow disabling each kind of command (single value, dimensions, reset property value). Associated with CPS PR (https://devdiv.visualstudio.com/DevDiv/_git/CPS/pullrequest/456951)

Under the new behavior (seen below), you are not allowed to select the top command for DefineConstants

<img width="477" alt="image" src="https://user-images.githubusercontent.com/20359921/223856716-101c9ee3-9c04-49bf-ad81-3da6842ad983.png">

Fixed #8901 