### PR TITLE
Annotate MEF part as non-shared

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandler.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         // Typically, adds and removes of files found at evaluation time are also found during a design-time build, with the latter also 
         // including generated files. This forces us to remember what files we've already sent to Roslyn to avoid sending duplicate adds
         // or removes of the same file. Due to design-time builds being significantly slower than evaluations, there are also times where 
-        // many evaluations have occured by the time a design-time build based on a past version of the ConfiguredProject has completed.
+        // many evaluations have occurred by the time a design-time build based on a past version of the ConfiguredProject has completed.
         // This can lead to conflicts.
         //
         // A conflict occurs when evaluation or design-time build adds a item that the other removed, or vice versa. 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
     ///     to the compiler during design-time builds.
     /// </summary>
     [Export(typeof(IWorkspaceUpdateHandler))]
+    [PartCreationPolicy(CreationPolicy.NonShared)]
     internal class CompileItemHandler : AbstractEvaluationCommandLineHandler, IWorkspaceUpdateHandler, IProjectEvaluationHandler, ICommandLineHandler
     {
         private readonly UnconfiguredProject _project;


### PR DESCRIPTION
The language service's `CompileItemHandler` is created multiple times within the unconfigured project &mdash; once per project configuration slice. We annotate it here with an attribute to advertise this fact.

This shouldn't have any impact to the current code as we use an `ExportFactory` to create instances of this part as needed, however annotating it is good practice and makes the type consistent with its peers.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8905)