### PR TITLE
Substitution only matches valid MSBuild property names

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -5,10 +5,6 @@ using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    /// <summary>
-    /// Token replacer can be imported to replace all the msbuild property and environment variable tokens in an ILaunchProfile or
-    /// in an individual string
-    /// </summary>
     [Export(typeof(IDebugTokenReplacer))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     internal class DebugTokenReplacer : IDebugTokenReplacer
@@ -28,11 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         // Regular expression string to extract $(sometoken) elements from a string
         private static readonly Regex s_matchTokenRegex = new(@"\$\((?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
 
-        /// <summary>
-        /// Walks the profile and returns a new one where all the tokens have been replaced. Tokens can consist of
-        /// environment variables (%var%), or any msbuild property $(msbuildproperty). Environment variables are
-        /// replaced first, followed by msbuild properties.
-        /// </summary>
         public async Task<ILaunchProfile> ReplaceTokensInProfileAsync(ILaunchProfile profile)
         {
             return await LaunchProfile.ReplaceTokensAsync(
@@ -40,11 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 str => ReplaceTokensInStringAsync(str, expandEnvironmentVars: true));
         }
 
-        /// <summary>
-        /// Replaces the tokens and environment variables in a single string. If expandEnvironmentVars
-        /// is true, they are expanded first before replacement happens. If the rawString is null or empty
-        /// it is returned as is.
-        /// </summary>
         public Task<string> ReplaceTokensInStringAsync(string rawString, bool expandEnvironmentVars)
         {
             if (string.IsNullOrWhiteSpace(rawString))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -21,8 +21,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private IActiveDebugFrameworkServices ActiveDebugFrameworkService { get; }
         private IProjectAccessor ProjectAccessor { get; }
 
-        // Regular expression string to extract $(sometoken) elements from a string
-        private static readonly Regex s_matchTokenRegex = new(@"\$\((?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
+        /// <summary>
+        /// Regular expression to match MSBuild <c>$(Property)</c> elements in a string.
+        /// </summary>
+        /// <remarks>
+        /// Valid MSBuild property names begin with an uppercase or lowercase letter or underscore (_);
+        /// valid subsequent characters include alphanumeric characters (letters or digits), underscore, and hyphen (-).
+        /// </remarks>
+        private static readonly Regex s_matchTokenRegex = new(@"\$\((?<token>[a-z_][a-z0-9_-]*)\)", RegexOptions.IgnoreCase);
 
         public async Task<ILaunchProfile> ReplaceTokensInProfileAsync(ILaunchProfile profile)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDebugTokenReplacer.cs
@@ -3,14 +3,32 @@
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>
-    /// Given an ILaunchProfile, it will enumerate the items and do replacement on the each string
-    /// entry.
+    /// Replaces tokens of form <c>%VAR%</c> with their environment variable value, and of form
+    /// <c>$(Property)</c> with the active configured project's MSBuild evaluation values.
     /// </summary>
+    /// <remarks>
+    /// Supports token substitution in <see cref="ILaunchProfile"/> data via <see cref="ReplaceTokensInProfileAsync"/>,
+    /// but can also substitute individual strings via <see cref="ReplaceTokensInStringAsync"/>.
+    /// </remarks>
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     public interface IDebugTokenReplacer
     {
+        /// <summary>
+        /// Walks the profile and returns a new one where all the tokens have been replaced. Tokens can consist of
+        /// environment variables (<c>%VAR%</c>), or any MSBuild property (<c>$(Property)</c>).
+        /// </summary>
+        /// <remarks>
+        /// Environment variables are replaced first, followed by MSBuild properties.
+        /// </remarks>
         Task<ILaunchProfile> ReplaceTokensInProfileAsync(ILaunchProfile profile);
 
+        /// <summary>
+        /// Replaces the tokens and environment variables in a single string. If expandEnvironmentVars
+        /// is true, they are expanded first before replacement happens.
+        /// </summary>
+        /// <remarks>
+        /// If <paramref name="rawString"/> is <see langword="null"/> or empty, it is returned as is.
+        /// </remarks>
         Task<string> ReplaceTokensInStringAsync(string rawString, bool expandEnvironmentVars);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -8,9 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         private readonly Dictionary<string, string> _envVars = new(StringComparer.OrdinalIgnoreCase)
         {
-            { "%env1%","envVariable1" },
-            { "%env2%","envVariable2" },
-            { "%env3%","$(msbuildProperty6)" }
+            { "%env1%", "envVariable1" },
+            { "%env2%", "envVariable2" },
+            { "%env3%", "$(msbuildProperty6)" }
         };
 
         private readonly Mock<IEnvironmentHelper> _envHelper;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -66,6 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [InlineData("this is msbuild: $(UnknownMsbuildProperty) %env1%",                "this is msbuild:  envVariable1", true)]
         [InlineData("this is msbuild: $(UnknownMsbuildProperty) %Unknown%",             "this is msbuild:  %Unknown%", true)]
         [InlineData("this is msbuild: %env3% $(msbuildProperty2) $(msbuildProperty3)",  "this is msbuild: Property6 Property2 Property3", true)]
+        [InlineData("this is msbuild: $(123) $(invalid.name) $( ooo )",                 "this is msbuild: $(123) $(invalid.name) $( ooo )", true)]
         [InlineData(null, null, true)]
         [InlineData(" ", " ", true)]
         public async Task ReplaceTokensInStringTests(string input, string expected, bool expandEnvVars)


### PR DESCRIPTION
Relates to #8906 

This PR restricts the values we would match in launch profiles when substituting MSBuild property values to only valid MSBuild property names.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8907)