### PR TITLE
Consolidate and extend documentation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs
@@ -5,10 +5,6 @@ using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
-    /// <summary>
-    /// Token replacer can be imported to replace all the msbuild property and environment variable tokens in an ILaunchProfile or
-    /// in an individual string
-    /// </summary>
     [Export(typeof(IDebugTokenReplacer))]
     [AppliesTo(ProjectCapability.LaunchProfiles)]
     internal class DebugTokenReplacer : IDebugTokenReplacer
@@ -28,11 +24,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         // Regular expression string to extract $(sometoken) elements from a string
         private static readonly Regex s_matchTokenRegex = new(@"\$\((?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
 
-        /// <summary>
-        /// Walks the profile and returns a new one where all the tokens have been replaced. Tokens can consist of
-        /// environment variables (%var%), or any msbuild property $(msbuildproperty). Environment variables are
-        /// replaced first, followed by msbuild properties.
-        /// </summary>
         public async Task<ILaunchProfile> ReplaceTokensInProfileAsync(ILaunchProfile profile)
         {
             return await LaunchProfile.ReplaceTokensAsync(
@@ -40,11 +31,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                 str => ReplaceTokensInStringAsync(str, expandEnvironmentVars: true));
         }
 
-        /// <summary>
-        /// Replaces the tokens and environment variables in a single string. If expandEnvironmentVars
-        /// is true, they are expanded first before replacement happens. If the rawString is null or empty
-        /// it is returned as is.
-        /// </summary>
         public Task<string> ReplaceTokensInStringAsync(string rawString, bool expandEnvironmentVars)
         {
             if (string.IsNullOrWhiteSpace(rawString))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDebugTokenReplacer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IDebugTokenReplacer.cs
@@ -3,14 +3,36 @@
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>
-    /// Given an ILaunchProfile, it will enumerate the items and do replacement on the each string
-    /// entry.
+    /// Replaces tokens of form <c>%VAR%</c> with their environment variable value, and of form
+    /// <c>$(MSBuildExpression)</c> with the evaluated expression via the active configured project.
     /// </summary>
+    /// <remarks>
+    /// Intended for token substitution in <see cref="ILaunchProfile"/> data. Custom launch profile
+    /// providers may import this component to perform such substitutions.
+    /// </remarks>
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     public interface IDebugTokenReplacer
     {
+        /// <summary>
+        /// Returns a copy of <paramref name="profile"/> where all tokens have been replaced.
+        /// Tokens can consist of environment variables (<c>%VAR%</c>), or MSBuild expressions (<c>$(Property)</c>).
+        /// </summary>
+        /// <remarks>
+        /// Environment variables are replaced first, followed by MSBuild properties.
+        /// </remarks>
         Task<ILaunchProfile> ReplaceTokensInProfileAsync(ILaunchProfile profile);
 
+        /// <summary>
+        /// Replaces the MSBuild expressions and (optionally) environment variables in <paramref name="rawString"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// If <paramref name="expandEnvironmentVars"/> is <see langword="true"/>, environment variables are substituted. Environment variables are substituted before MSBuild expressions.
+        /// </para>
+        /// <para>
+        /// If <paramref name="rawString"/> is <see langword="null"/> or empty, it is returned as is.
+        /// </para>
+        /// </remarks>
         Task<string> ReplaceTokensInStringAsync(string rawString, bool expandEnvironmentVars);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -8,9 +8,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         private readonly Dictionary<string, string> _envVars = new(StringComparer.OrdinalIgnoreCase)
         {
-            { "%env1%","envVariable1" },
-            { "%env2%","envVariable2" },
-            { "%env3%","$(msbuildProperty6)" }
+            { "%env1%", "envVariable1" },
+            { "%env2%", "envVariable2" },
+            { "%env3%", "$(msbuildProperty6)" }
         };
 
         private readonly Mock<IEnvironmentHelper> _envHelper;


### PR DESCRIPTION
Contains the documentation changes from #8907 (which is being abandoned).

Moves documentation to the interface, which is public, rather than on the implementation. The IDE will show inherited documentation within the implementation anyway.

Also update some of the text to be more helpful.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8914)