### PR TITLE
Add support for reporting operations via telemetry

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryOperation.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryOperation.cs
@@ -1,40 +1,39 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-namespace Microsoft.VisualStudio.Telemetry
+namespace Microsoft.VisualStudio.Telemetry;
+
+/// <summary>
+/// <para>
+///     Represents an operation with associated start and end events. An <see cref="ITelemetryOperation"/>
+///     is started by calling <see cref="ITelemetryService.BeginOperation(string)"/>.
+/// </para>
+/// <para>
+///     This type implements <see cref="IDisposable"/> to ensure that operations are completed and reported,
+///     but consumers must also call <see cref="End(TelemetryResult)"/> to report the success or failure of
+///     the operation.
+/// </para>
+/// </summary>
+internal interface ITelemetryOperation : IDisposable
 {
     /// <summary>
-    /// <para>
-    ///     Represents an operation with associated start and end events. An <see cref="ITelemetryOperation"/>
-    ///     is started by calling <see cref="ITelemetryService.BeginOperation(string)"/>.
-    /// </para>
-    /// <para>
-    ///     This type implements <see cref="IDisposable"/> to ensure that operations are completed and reported,
-    ///     but consumers must also call <see cref="End(TelemetryResult)"/> to report the success or failure of
-    ///     the operation.
-    /// </para>
+    ///     Associates the given properties with the "end" event of the operation.
     /// </summary>
-    internal interface ITelemetryOperation : IDisposable
-    {
-        /// <summary>
-        ///     Associates the given properties with the "end" event of the operation.
-        /// </summary>
-        /// <param name="properties">
-        ///     An <see cref="IEnumerable{T}"/> of property names and values.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="properties"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="properties"/> is contains no elements.
-        /// </exception>
-        void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties);
+    /// <param name="properties">
+    ///     An <see cref="IEnumerable{T}"/> of property names and values.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="properties"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="properties"/> is contains no elements.
+    /// </exception>
+    void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties);
 
-        /// <summary>
-        ///     Ends the operation and reports the result.
-        /// </summary>
-        /// <param name="result">
-        ///     A <see cref="TelemetryResult"/> value indicating the result of the operation.
-        /// </param>
-        void End(TelemetryResult result);
-    }
+    /// <summary>
+    ///     Ends the operation and reports the result.
+    /// </summary>
+    /// <param name="result">
+    ///     A <see cref="TelemetryResult"/> value indicating the result of the operation.
+    /// </param>
+    void End(TelemetryResult result);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryOperation.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryOperation.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.Telemetry
+{
+    /// <summary>
+    /// <para>
+    ///     Represents an operation with associated start and end events. An <see cref="ITelemetryOperation"/>
+    ///     is started by calling <see cref="ITelemetryService.BeginOperation(string)"/>.
+    /// </para>
+    /// <para>
+    ///     This type implements <see cref="IDisposable"/> to ensure that operations are completed and reported,
+    ///     but consumers must also call <see cref="End(TelemetryResult)"/> to report the success or failure of
+    ///     the operation.
+    /// </para>
+    /// </summary>
+    internal interface ITelemetryOperation : IDisposable
+    {
+        /// <summary>
+        ///     Associates the given properties with the "end" event of the operation.
+        /// </summary>
+        /// <param name="properties">
+        ///     An <see cref="IEnumerable{T}"/> of property names and values.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="properties"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="properties"/> is contains no elements.
+        /// </exception>
+        void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties);
+
+        /// <summary>
+        ///     Ends the operation and reports the result.
+        /// </summary>
+        /// <param name="result">
+        ///     A <see cref="TelemetryResult"/> value indicating the result of the operation.
+        /// </param>
+        void End(TelemetryResult result);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
@@ -4,6 +4,42 @@ using Microsoft.VisualStudio.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
+    /// <summary>
+    /// <para>
+    ///     Represents an operation with associated start and end events. An <see cref="ITelemetryOperation"/>
+    ///     is started by calling <see cref="ITelemetryService.BeginOperation(string)"/>.
+    /// </para>
+    /// <para>
+    ///     This type implements <see cref="IDisposable"/> to ensure that operations are completed and reported,
+    ///     but consumers must also call <see cref="End(TelemetryResult)"/> to report the success or failure of
+    ///     the operation.
+    /// </para>
+    /// </summary>
+    internal interface ITelemetryOperation : IDisposable
+    {
+        /// <summary>
+        ///     Associates the given properties with the "end" event of the operation.
+        /// </summary>
+        /// <param name="properties">
+        ///     An <see cref="IEnumerable{T}"/> of property names and values.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="properties"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="properties"/> is contains no elements.
+        /// </exception>
+        void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties);
+
+        /// <summary>
+        ///     Ends the operation and reports the result.
+        /// </summary>
+        /// <param name="result">
+        ///     A <see cref="TelemetryResult"/> value indicating the result of the operation.
+        /// </param>
+        void End(TelemetryResult result);
+    }
+    
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface ITelemetryService
     {
@@ -79,6 +115,25 @@ namespace Microsoft.VisualStudio.Telemetry
         ///     <paramref name="properties"/> is contains no elements.
         /// </exception>
         void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties);
+
+        /// <summary>
+        ///     Begins an operation with a recorded duration. Consumers must call <see cref="ITelemetryOperation.End(TelemetryResult)"/>
+        ///     on the returned <see cref="ITelemetryOperation"/> to signal the end of the operation and post the
+        ///     telemetry events.
+        /// </summary>
+        /// <param name="eventName">
+        ///     The name of the event to associate with this operation.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///     <paramref name="eventName"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="eventName"/> is an empty string ("").
+        /// </exception>
+        /// <returns>
+        ///     An <see cref="ITelemetryOperation"/> representing the operation. 
+        /// </returns>
+        ITelemetryOperation BeginOperation(string eventName);
 
         /// <summary>
         /// Hashes personally identifiable information for telemetry consumption.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
@@ -2,108 +2,107 @@
 
 using Microsoft.VisualStudio.ProjectSystem;
 
-namespace Microsoft.VisualStudio.Telemetry
+namespace Microsoft.VisualStudio.Telemetry;
+
+[ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+internal interface ITelemetryService
 {
-    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
-    internal interface ITelemetryService
-    {
-        /// <summary>
-        ///     Posts an event with the specified event name.
-        /// </summary>
-        /// <param name="eventName">
-        ///     The name of the event.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="eventName"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="eventName"/> is an empty string ("").
-        /// </exception>
-        void PostEvent(string eventName);
+    /// <summary>
+    ///     Posts an event with the specified event name.
+    /// </summary>
+    /// <param name="eventName">
+    ///     The name of the event.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="eventName"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="eventName"/> is an empty string ("").
+    /// </exception>
+    void PostEvent(string eventName);
 
-        /// <summary>
-        ///     Posts an event with the specified event name and property with the
-        ///     specified name and value.
-        /// </summary>
-        /// <param name="eventName">
-        ///     The name of the event.
-        /// </param>
-        /// <param name="propertyName">
-        ///     The name of the property.
-        /// </param>
-        /// <param name="propertyValue">
-        ///     The value of the property.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="eventName"/> is <see langword="null"/>.
-        ///     <para>
-        ///         -or-
-        ///     </para>
-        ///     <paramref name="propertyName"/> is <see langword="null"/>.
-        ///     <para>
-        ///         -or-
-        ///     </para>
-        ///     <paramref name="propertyValue"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="eventName"/> is an empty string ("").
-        ///     <para>
-        ///         -or
-        ///     </para>
-        ///     <paramref name="propertyName"/> is an empty string ("").
-        /// </exception>
-        void PostProperty(string eventName, string propertyName, object propertyValue);
+    /// <summary>
+    ///     Posts an event with the specified event name and property with the
+    ///     specified name and value.
+    /// </summary>
+    /// <param name="eventName">
+    ///     The name of the event.
+    /// </param>
+    /// <param name="propertyName">
+    ///     The name of the property.
+    /// </param>
+    /// <param name="propertyValue">
+    ///     The value of the property.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="eventName"/> is <see langword="null"/>.
+    ///     <para>
+    ///         -or-
+    ///     </para>
+    ///     <paramref name="propertyName"/> is <see langword="null"/>.
+    ///     <para>
+    ///         -or-
+    ///     </para>
+    ///     <paramref name="propertyValue"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="eventName"/> is an empty string ("").
+    ///     <para>
+    ///         -or
+    ///     </para>
+    ///     <paramref name="propertyName"/> is an empty string ("").
+    /// </exception>
+    void PostProperty(string eventName, string propertyName, object propertyValue);
 
-        /// <summary>
-        ///     Posts an event with the specified event name and properties with the
-        ///     specified names and values.
-        /// </summary>
-        /// <param name="eventName">
-        ///     The name of the event.
-        /// </param>
-        /// <param name="properties">
-        ///     An <see cref="IEnumerable{T}"/> of property names and values.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="eventName"/> is <see langword="null"/>.
-        ///     <para>
-        ///         -or-
-        ///     </para>
-        ///     <paramref name="properties"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="eventName"/> is an empty string ("").
-        ///     <para>
-        ///         -or-
-        ///     </para>
-        ///     <paramref name="properties"/> is contains no elements.
-        /// </exception>
-        void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties);
+    /// <summary>
+    ///     Posts an event with the specified event name and properties with the
+    ///     specified names and values.
+    /// </summary>
+    /// <param name="eventName">
+    ///     The name of the event.
+    /// </param>
+    /// <param name="properties">
+    ///     An <see cref="IEnumerable{T}"/> of property names and values.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="eventName"/> is <see langword="null"/>.
+    ///     <para>
+    ///         -or-
+    ///     </para>
+    ///     <paramref name="properties"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="eventName"/> is an empty string ("").
+    ///     <para>
+    ///         -or-
+    ///     </para>
+    ///     <paramref name="properties"/> is contains no elements.
+    /// </exception>
+    void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties);
 
-        /// <summary>
-        ///     Begins an operation with a recorded duration. Consumers must call <see cref="ITelemetryOperation.End(TelemetryResult)"/>
-        ///     on the returned <see cref="ITelemetryOperation"/> to signal the end of the operation and post the
-        ///     telemetry events.
-        /// </summary>
-        /// <param name="eventName">
-        ///     The name of the event to associate with this operation.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="eventName"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="eventName"/> is an empty string ("").
-        /// </exception>
-        /// <returns>
-        ///     An <see cref="ITelemetryOperation"/> representing the operation. 
-        /// </returns>
-        ITelemetryOperation BeginOperation(string eventName);
+    /// <summary>
+    ///     Begins an operation with a recorded duration. Consumers must call <see cref="ITelemetryOperation.End(TelemetryResult)"/>
+    ///     on the returned <see cref="ITelemetryOperation"/> to signal the end of the operation and post the
+    ///     telemetry events.
+    /// </summary>
+    /// <param name="eventName">
+    ///     The name of the event to associate with this operation.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="eventName"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///     <paramref name="eventName"/> is an empty string ("").
+    /// </exception>
+    /// <returns>
+    ///     An <see cref="ITelemetryOperation"/> representing the operation. 
+    /// </returns>
+    ITelemetryOperation BeginOperation(string eventName);
 
-        /// <summary>
-        /// Hashes personally identifiable information for telemetry consumption.
-        /// </summary>
-        /// <param name="value">Value to hashed.</param>
-        /// <returns>Hashed value.</returns>
-        string HashValue(string value);
-    }
+    /// <summary>
+    /// Hashes personally identifiable information for telemetry consumption.
+    /// </summary>
+    /// <param name="value">Value to hashed.</param>
+    /// <returns>Hashed value.</returns>
+    string HashValue(string value);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ITelemetryService.cs
@@ -4,42 +4,6 @@ using Microsoft.VisualStudio.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Telemetry
 {
-    /// <summary>
-    /// <para>
-    ///     Represents an operation with associated start and end events. An <see cref="ITelemetryOperation"/>
-    ///     is started by calling <see cref="ITelemetryService.BeginOperation(string)"/>.
-    /// </para>
-    /// <para>
-    ///     This type implements <see cref="IDisposable"/> to ensure that operations are completed and reported,
-    ///     but consumers must also call <see cref="End(TelemetryResult)"/> to report the success or failure of
-    ///     the operation.
-    /// </para>
-    /// </summary>
-    internal interface ITelemetryOperation : IDisposable
-    {
-        /// <summary>
-        ///     Associates the given properties with the "end" event of the operation.
-        /// </summary>
-        /// <param name="properties">
-        ///     An <see cref="IEnumerable{T}"/> of property names and values.
-        /// </param>
-        /// <exception cref="ArgumentNullException">
-        ///     <paramref name="properties"/> is <see langword="null"/>.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        ///     <paramref name="properties"/> is contains no elements.
-        /// </exception>
-        void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties);
-
-        /// <summary>
-        ///     Ends the operation and reports the result.
-        /// </summary>
-        /// <param name="result">
-        ///     A <see cref="TelemetryResult"/> value indicating the result of the operation.
-        /// </param>
-        void End(TelemetryResult result);
-    }
-    
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface ITelemetryService
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
@@ -8,6 +8,9 @@ namespace Microsoft.VisualStudio.Telemetry;
 [Export(typeof(ITelemetryService))]
 internal class ManagedTelemetryService : ITelemetryService
 {
+    private const string EventNamePrefix = "vs/projectsystem/managed/";
+    private const string PropertyNamePrefix = "vs.projectsystem.managed.";
+
     public void PostEvent(string eventName)
     {
         Requires.NotNullOrEmpty(eventName);
@@ -56,11 +59,11 @@ internal class ManagedTelemetryService : ITelemetryService
     private void PostTelemetryEvent(TelemetryEvent telemetryEvent)
     {
 #if DEBUG
-        Assumes.True(telemetryEvent.Name.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
+        Assumes.True(telemetryEvent.Name.StartsWith(EventNamePrefix, StringComparisons.TelemetryEventNames));
 
         foreach (string propertyName in telemetryEvent.Properties.Keys)
         {
-            Assumes.True(propertyName.StartsWith("vs.projectsystem.managed.", StringComparisons.TelemetryEventNames));
+            Assumes.True(propertyName.StartsWith(PropertyNamePrefix, StringComparisons.TelemetryEventNames));
         }
 #endif
 
@@ -77,7 +80,7 @@ internal class ManagedTelemetryService : ITelemetryService
         Requires.NotNullOrEmpty(eventName);
         
 #if DEBUG
-        Assumes.True(eventName.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
+        Assumes.True(eventName.StartsWith(EventNamePrefix, StringComparisons.TelemetryEventNames));
 #endif
         return new TelemetryOperation(TelemetryService.DefaultSession.StartOperation(eventName));            
     }
@@ -125,7 +128,7 @@ internal class ManagedTelemetryService : ITelemetryService
 #if DEBUG
             foreach ((string propertyName, _) in properties)
             {
-                Assumes.True(propertyName.StartsWith("vs.projectsystem.managed.", StringComparisons.TelemetryEventNames));
+                Assumes.True(propertyName.StartsWith(PropertyNamePrefix, StringComparisons.TelemetryEventNames));
             }
 #endif
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
@@ -21,7 +21,7 @@ internal class ManagedTelemetryService : ITelemetryService
         Requires.NotNullOrEmpty(propertyName);
         Requires.NotNull(propertyValue);
 
-        var telemetryEvent = new TelemetryEvent(eventName);
+        TelemetryEvent telemetryEvent = new(eventName);
         telemetryEvent.Properties.Add(propertyName, propertyValue);
 
         PostTelemetryEvent(telemetryEvent);
@@ -32,7 +32,7 @@ internal class ManagedTelemetryService : ITelemetryService
         Requires.NotNullOrEmpty(eventName);
         Requires.NotNullOrEmpty(properties);
 
-        var telemetryEvent = new TelemetryEvent(eventName);
+        TelemetryEvent telemetryEvent = new(eventName);
         AddPropertiesToEvent(properties, telemetryEvent);
 
         PostTelemetryEvent(telemetryEvent);
@@ -91,7 +91,7 @@ internal class ManagedTelemetryService : ITelemetryService
         }
 
         byte[] inputBytes = Encoding.UTF8.GetBytes(value);
-        using var cryptoServiceProvider = new SHA256CryptoServiceProvider();
+        using SHA256CryptoServiceProvider cryptoServiceProvider = new();
         return BitConverter.ToString(cryptoServiceProvider.ComputeHash(inputBytes));
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
@@ -8,8 +8,10 @@ namespace Microsoft.VisualStudio.Telemetry;
 [Export(typeof(ITelemetryService))]
 internal class ManagedTelemetryService : ITelemetryService
 {
+#if DEBUG
     private const string EventNamePrefix = "vs/projectsystem/managed/";
     private const string PropertyNamePrefix = "vs.projectsystem.managed.";
+#endif
 
     public void PostEvent(string eventName)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
@@ -3,134 +3,133 @@
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Microsoft.VisualStudio.Telemetry
+namespace Microsoft.VisualStudio.Telemetry;
+
+[Export(typeof(ITelemetryService))]
+internal class ManagedTelemetryService : ITelemetryService
 {
-    [Export(typeof(ITelemetryService))]
-    internal class ManagedTelemetryService : ITelemetryService
+    public void PostEvent(string eventName)
     {
-        public void PostEvent(string eventName)
+        Requires.NotNullOrEmpty(eventName);
+
+        PostTelemetryEvent(new TelemetryEvent(eventName));
+    }
+
+    public void PostProperty(string eventName, string propertyName, object propertyValue)
+    {
+        Requires.NotNullOrEmpty(eventName);
+        Requires.NotNullOrEmpty(propertyName);
+        Requires.NotNull(propertyValue);
+
+        var telemetryEvent = new TelemetryEvent(eventName);
+        telemetryEvent.Properties.Add(propertyName, propertyValue);
+
+        PostTelemetryEvent(telemetryEvent);
+    }
+
+    public void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties)
+    {
+        Requires.NotNullOrEmpty(eventName);
+        Requires.NotNullOrEmpty(properties);
+
+        var telemetryEvent = new TelemetryEvent(eventName);
+        AddPropertiesToEvent(properties, telemetryEvent);
+
+        PostTelemetryEvent(telemetryEvent);
+    }
+
+    private static void AddPropertiesToEvent(IEnumerable<(string propertyName, object propertyValue)> properties, TelemetryEvent telemetryEvent)
+    {
+        foreach ((string propertyName, object propertyValue) in properties)
         {
-            Requires.NotNullOrEmpty(eventName);
-
-            PostTelemetryEvent(new TelemetryEvent(eventName));
-        }
-
-        public void PostProperty(string eventName, string propertyName, object propertyValue)
-        {
-            Requires.NotNullOrEmpty(eventName);
-            Requires.NotNullOrEmpty(propertyName);
-            Requires.NotNull(propertyValue);
-
-            var telemetryEvent = new TelemetryEvent(eventName);
-            telemetryEvent.Properties.Add(propertyName, propertyValue);
-
-            PostTelemetryEvent(telemetryEvent);
-        }
-
-        public void PostProperties(string eventName, IEnumerable<(string propertyName, object propertyValue)> properties)
-        {
-            Requires.NotNullOrEmpty(eventName);
-            Requires.NotNullOrEmpty(properties);
-
-            var telemetryEvent = new TelemetryEvent(eventName);
-            AddPropertiesToEvent(properties, telemetryEvent);
-
-            PostTelemetryEvent(telemetryEvent);
-        }
-
-        private static void AddPropertiesToEvent(IEnumerable<(string propertyName, object propertyValue)> properties, TelemetryEvent telemetryEvent)
-        {
-            foreach ((string propertyName, object propertyValue) in properties)
+            if (propertyValue is ComplexPropertyValue complexProperty)
             {
-                if (propertyValue is ComplexPropertyValue complexProperty)
-                {
-                    telemetryEvent.Properties.Add(propertyName, new TelemetryComplexProperty(complexProperty.Data));
-                }
-                else
-                {
-                    telemetryEvent.Properties.Add(propertyName, propertyValue);
-                }
+                telemetryEvent.Properties.Add(propertyName, new TelemetryComplexProperty(complexProperty.Data));
+            }
+            else
+            {
+                telemetryEvent.Properties.Add(propertyName, propertyValue);
             }
         }
+    }
 
-        private void PostTelemetryEvent(TelemetryEvent telemetryEvent)
+    private void PostTelemetryEvent(TelemetryEvent telemetryEvent)
+    {
+#if DEBUG
+        Assumes.True(telemetryEvent.Name.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
+
+        foreach (string propertyName in telemetryEvent.Properties.Keys)
+        {
+            Assumes.True(propertyName.StartsWith("vs.projectsystem.managed.", StringComparisons.TelemetryEventNames));
+        }
+#endif
+
+        PostEventToSession(telemetryEvent);
+    }
+
+    protected virtual void PostEventToSession(TelemetryEvent telemetryEvent)
+    {
+        TelemetryService.DefaultSession.PostEvent(telemetryEvent);
+    }
+
+    public ITelemetryOperation BeginOperation(string eventName)
+    {
+        Requires.NotNullOrEmpty(eventName);
+        
+#if DEBUG
+        Assumes.True(eventName.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
+#endif
+        return new TelemetryOperation(TelemetryService.DefaultSession.StartOperation(eventName));            
+    }
+
+    public string HashValue(string value)
+    {
+        // Don't hash PII for internal users since we don't need to.
+        if (TelemetryService.DefaultSession.IsUserMicrosoftInternal)
+        {
+            return value;
+        }
+
+        byte[] inputBytes = Encoding.UTF8.GetBytes(value);
+        using var cryptoServiceProvider = new SHA256CryptoServiceProvider();
+        return BitConverter.ToString(cryptoServiceProvider.ComputeHash(inputBytes));
+    }
+
+    private class TelemetryOperation : ITelemetryOperation
+    {
+        private readonly TelemetryScope<OperationEvent> _scope;
+
+        public TelemetryOperation(TelemetryScope<OperationEvent> scope)
+        {
+            _scope = scope;
+        }
+
+        public void Dispose()
         {
 #if DEBUG
-            Assumes.True(telemetryEvent.Name.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
+            Assumes.True(_scope.IsEnd, $"Failed to call '{nameof(ITelemetryOperation.End)}' on {nameof(ITelemetryOperation)} instance.");
+#endif
 
-            foreach (string propertyName in telemetryEvent.Properties.Keys)
+            _scope.End(TelemetryResult.None);
+        }
+
+        public void End(TelemetryResult result)
+        {
+            _scope.End(result);
+        }
+
+        public void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties)
+        {
+            Requires.NotNullOrEmpty(properties);
+            
+#if DEBUG
+            foreach ((string propertyName, _) in properties)
             {
                 Assumes.True(propertyName.StartsWith("vs.projectsystem.managed.", StringComparisons.TelemetryEventNames));
             }
 #endif
 
-            PostEventToSession(telemetryEvent);
-        }
-
-        protected virtual void PostEventToSession(TelemetryEvent telemetryEvent)
-        {
-            TelemetryService.DefaultSession.PostEvent(telemetryEvent);
-        }
-
-        public ITelemetryOperation BeginOperation(string eventName)
-        {
-            Requires.NotNullOrEmpty(eventName);
-            
-#if DEBUG
-            Assumes.True(eventName.StartsWith("vs/projectsystem/managed/", StringComparisons.TelemetryEventNames));
-#endif
-            return new TelemetryOperation(TelemetryService.DefaultSession.StartOperation(eventName));            
-        }
-
-        public string HashValue(string value)
-        {
-            // Don't hash PII for internal users since we don't need to.
-            if (TelemetryService.DefaultSession.IsUserMicrosoftInternal)
-            {
-                return value;
-            }
-
-            byte[] inputBytes = Encoding.UTF8.GetBytes(value);
-            using var cryptoServiceProvider = new SHA256CryptoServiceProvider();
-            return BitConverter.ToString(cryptoServiceProvider.ComputeHash(inputBytes));
-        }
-
-        private class TelemetryOperation : ITelemetryOperation
-        {
-            private readonly TelemetryScope<OperationEvent> _scope;
-
-            public TelemetryOperation(TelemetryScope<OperationEvent> scope)
-            {
-                _scope = scope;
-            }
-
-            public void Dispose()
-            {
-#if DEBUG
-                Assumes.True(_scope.IsEnd, $"Failed to call '{nameof(ITelemetryOperation.End)}' on {nameof(ITelemetryOperation)} instance.");
-#endif
-
-                _scope.End(TelemetryResult.None);
-            }
-
-            public void End(TelemetryResult result)
-            {
-                _scope.End(result);
-            }
-
-            public void SetProperties(IEnumerable<(string propertyName, object propertyValue)> properties)
-            {
-                Requires.NotNullOrEmpty(properties);
-                
-#if DEBUG
-                foreach ((string propertyName, _) in properties)
-                {
-                    Assumes.True(propertyName.StartsWith("vs.projectsystem.managed.", StringComparisons.TelemetryEventNames));
-                }
-#endif
-
-                AddPropertiesToEvent(properties, _scope.EndEvent);
-            }
+            AddPropertiesToEvent(properties, _scope.EndEvent);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Telemetry/ManagedTelemetryServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Telemetry/ManagedTelemetryServiceTests.cs
@@ -170,6 +170,28 @@ namespace Microsoft.VisualStudio.Telemetry
             Assert.Contains(new KeyValuePair<string, object>(TelemetryPropertyName.DesignTimeBuildComplete.Targets, "Compile"), result.Properties);
         }
 
+        [Fact]
+        public void BeginOperation_NullAsEventName_ThrowsArgumentNull()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentNullException>("eventName", () =>
+            {
+                _ = service.BeginOperation(null!);
+            });
+        }
+
+        [Fact]
+        public void BeginOperation_EmptyAsEventName_ThrowsArgument()
+        {
+            var service = CreateInstance();
+
+            Assert.Throws<ArgumentException>("eventName", () =>
+            {
+                _ = service.BeginOperation(string.Empty);
+            });
+        }
+
         private static ManagedTelemetryService CreateInstance(Action<TelemetryEvent>? action = null)
         {
             if (action is null)


### PR DESCRIPTION
Our `ITelemetryService` offers various helper methods to simplify interactions with the VS telemetry system, such as a `PostProperty` method to post an event with a single property.

This change adds support for operations with associated start and end events. Calling `BeginOperation` marks the start of the operation and returns an `ITelemetryOperation` representing it. From there, consumers can call `SetProperties` to associate properties with the "end" event, and `End(TelemetryResult)` to mark the end of the event with a corresponding result (e.g. success, failure, canceled, etc.).

`ITelemetryOperation` derives from `IDisposable` as a way to help ensure the operation is posted to the telemetry system even if the consumer forgets to call `End`, and in debug builds the `Dispose` method will throw an exception if this happens.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8921)