### PR TITLE
Add Validate for VS insertion branch name

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -141,7 +141,7 @@ stages:
       timeoutInMinutes: 2
       steps:
       # See: https://stackoverflow.com/a/30524983/294804
-      - powershell: if (-not (git ls-remote --heads https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS $(InsertionVSBranch))) { Write-Error "The branch name '$(InsertionVSBranch)' is not valid." }
+      - powershell: if (-not (git ls-remote --heads https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS $(InsertionVSBranch))) { Write-Host "The branch name '$(InsertionVSBranch)' is not valid."; exit 1 }
         displayName: Validate VS Insertion Branch Name
 
 - stage: Build

--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -129,6 +129,21 @@ parameters:
 ###################################################################################################################################################################
 
 stages:
+# Validate the insertion branch name when necessary.
+- ${{ if eq(parameters.CreateInsertion, true) }}:
+  - stage: Validate
+    displayName: Validate
+    variables:
+      InsertionVSBranch: ${{ parameters.InsertionVSBranch }}
+    jobs:
+    - job: ValidateInsertionInput
+      displayName: Validate Insertion Input
+      timeoutInMinutes: 2
+      steps:
+      # See: https://stackoverflow.com/a/30524983/294804
+      - powershell: if (-not (git ls-remote --heads https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS $(InsertionVSBranch))) { Write-Error "The branch name '$(InsertionVSBranch)' is not valid." }
+        displayName: Validate VS Insertion Branch Name
+
 - stage: Build
   displayName: Build
   variables:
@@ -139,6 +154,9 @@ stages:
     # Auto-injects the CodeQL task.
     # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
     Codeql.SkipTaskAutoInjection: false
+  # When manually running an insertion, this allows us to validate the insertion branch name prior to building.
+  ${{ if eq(parameters.CreateInsertion, true) }}:
+    dependsOn: Validate
   jobs:
   - template: templates/build-official-release.yml
 


### PR DESCRIPTION
Requested by: @drewnoakes

## Description
When doing a manual insertion (non-scheduled), you can set which VS branch you want to insert into. The field for this is just a `string`. If you input the VS branch name incorrectly, you won't know it until the entire build and all compliance checks finish, when it goes to run the *Insertion* stage. It'll fail saying that the remote branch doesn't exist. To have a slightly less stressful process, I've added a stage called *Validate* that only runs when doing these manual insertions. This stage will check to see that the VS insertion branch name you provided is valid. This stage runs prior to the main *Build* stage. If it fails, it'll fail the rest of build, and let you know much, much earlier than it would previously.

## Test Builds
- Failure Test: input `bacon-in-the-house` as branch name: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7474679&view=results
- Success Test: input `dev/miyanni/tagger-test` as branch name: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7474709&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8922)