### PR TITLE
Addition of a hot reload notification service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadNotificationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadNotificationService.cs
@@ -2,27 +2,26 @@
 
 using Microsoft.VisualStudio.Threading;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+
+/// <summary>
+/// Mef Export that can be used to be notified when the hot reload state changes for a project
+/// </summary>
+[ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.System, Cardinality = ImportCardinality.ExactlyOne)]
+public interface IProjectHotReloadNotificationService
 {
     /// <summary>
-    /// Mef Export that can be used to be notified when the hot reload state changes for a project
+    /// Subscribe to this event to be notified of changes to a projects hot reload state. 
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.System, Cardinality = ImportCardinality.ExactlyOne)]
-    public interface IProjectHotReloadNotificationService
-    {
-        /// <summary>
-        /// Subscribe to this event to be notified of changes to a projects hot reload state. 
-        /// </summary>
-        event AsyncEventHandler<bool> HotReloadStateChangedAsync;
+    event AsyncEventHandler<bool> HotReloadStateChangedAsync;
 
-        /// <summary>
-        /// The current state of hot reload for the project
-        /// </summary>
-        bool ProjectIsInHotReload{ get; }
+    /// <summary>
+    /// The current state of hot reload for the project
+    /// </summary>
+    bool IsProjectInHotReload{ get; }
 
-        /// <summary>
-        /// Called by project systems when it enters or exits a hot reload session.
-        /// </summary>
-        Task SetHotReloadStateAsync(bool isInHotReload);
-    }
+    /// <summary>
+    /// Called by project systems when it enters or exits a hot reload session.
+    /// </summary>
+    Task SetHotReloadStateAsync(bool isInHotReload);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadNotificationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadNotificationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.Threading;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadNotificationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/IProjectHotReloadNotificationService.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    /// <summary>
+    /// Mef Export that can be used to be notified when the hot reload state changes for a project
+    /// </summary>
+    [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.System, Cardinality = ImportCardinality.ExactlyOne)]
+    public interface IProjectHotReloadNotificationService
+    {
+        /// <summary>
+        /// Subscribe to this event to be notified of changes to a projects hot reload state. 
+        /// </summary>
+        event AsyncEventHandler<bool> HotReloadStateChangedAsync;
+
+        /// <summary>
+        /// The current state of hot reload for the project
+        /// </summary>
+        bool ProjectIsInHotReload{ get; }
+
+        /// <summary>
+        /// Called by project systems when it enters or exits a hot reload session.
+        /// </summary>
+        Task SetHotReloadStateAsync(bool isInHotReload);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadNotificationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadNotificationService.cs
@@ -13,6 +13,7 @@ internal class ProjectHotReloadNotificationService : IProjectHotReloadNotificati
     [ImportingConstructor]
     public ProjectHotReloadNotificationService(UnconfiguredProject _)
     {
+        // Importing UnconfiguredProject to ensure this part is in UnconfiguredProject scope
     }
 
     public event AsyncEventHandler<bool>? HotReloadStateChangedAsync;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadNotificationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadNotificationService.cs
@@ -1,0 +1,40 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+{
+    /// <summary>
+    /// MEF Export that can be used to be notified when a project enters and exits hot reload 
+    /// </summary>
+    [Export(typeof(IProjectHotReloadNotificationService))]
+    internal class ProjectHotReloadNotificationService : IProjectHotReloadNotificationService
+    {
+        [ImportingConstructor]
+        public ProjectHotReloadNotificationService(UnconfiguredProject _)
+        {
+        }
+
+        public event AsyncEventHandler<bool>? HotReloadStateChangedAsync;
+
+        public bool ProjectIsInHotReload { get; private set; }
+
+        public async Task SetHotReloadStateAsync(bool isInHotReload)
+        {
+            ProjectIsInHotReload = isInHotReload;
+
+            var localEvent = HotReloadStateChangedAsync;
+            if (localEvent is not null)
+            {
+                try
+                {
+                    await localEvent.InvokeAsync(this, isInHotReload);
+                }
+                catch (Exception ex)
+                {
+                    System.Diagnostics.Debug.Fail($"HotReloadStartChanged handler threw an exception {ex}");
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadNotificationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadNotificationService.cs
@@ -2,39 +2,39 @@
 
 using Microsoft.VisualStudio.Threading;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
+namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+
+/// <summary>
+/// MEF Export that can be used to be notified when a project enters and exits hot reload 
+/// </summary>
+[Export(typeof(IProjectHotReloadNotificationService))]
+internal class ProjectHotReloadNotificationService : IProjectHotReloadNotificationService
 {
-    /// <summary>
-    /// MEF Export that can be used to be notified when a project enters and exits hot reload 
-    /// </summary>
-    [Export(typeof(IProjectHotReloadNotificationService))]
-    internal class ProjectHotReloadNotificationService : IProjectHotReloadNotificationService
+    [ImportingConstructor]
+    public ProjectHotReloadNotificationService(UnconfiguredProject _)
     {
-        [ImportingConstructor]
-        public ProjectHotReloadNotificationService(UnconfiguredProject _)
+    }
+
+    public event AsyncEventHandler<bool>? HotReloadStateChangedAsync;
+
+    public bool IsProjectInHotReload { get; private set; }
+
+    public async Task SetHotReloadStateAsync(bool isInHotReload)
+    {
+        IsProjectInHotReload = isInHotReload;
+
+        var localEvent = HotReloadStateChangedAsync;
+        if (localEvent is not null)
         {
-        }
-
-        public event AsyncEventHandler<bool>? HotReloadStateChangedAsync;
-
-        public bool ProjectIsInHotReload { get; private set; }
-
-        public async Task SetHotReloadStateAsync(bool isInHotReload)
-        {
-            ProjectIsInHotReload = isInHotReload;
-
-            var localEvent = HotReloadStateChangedAsync;
-            if (localEvent is not null)
+            try
             {
-                try
-                {
-                    await localEvent.InvokeAsync(this, isInHotReload);
-                }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.Fail($"HotReloadStartChanged handler threw an exception {ex}");
-                }
+                await localEvent.InvokeAsync(this, isInHotReload);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.Fail($"HotReloadStartChanged handler threw an exception {ex}");
             }
         }
     }
 }
+

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -369,12 +369,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                         }
                     }
                 }
-
-                // No more sessions removes the project from hot reload mode
-                if (_activeSessions.Count == 0)
-                {
-                    await _projectHotReloadNotificationService.Value.SetHotReloadStateAsync(isInHotReload: false);
-                }
             }
             catch (Exception ex)
             {
@@ -388,6 +382,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                         HotReloadDiagnosticErrorLevel.Error
                     ),
                     cancellationToken);
+            }
+            finally
+            {
+                // No more sessions removes the project from hot reload mode
+                if (_activeSessions.Count == 0)
+                {
+                    await _projectHotReloadNotificationService.Value.SetHotReloadStateAsync(isInHotReload: false);
+                }
             }
 
             return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -18,6 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
         private readonly IActiveDebugFrameworkServices _activeDebugFrameworkServices;
         private readonly Lazy<IProjectHotReloadAgent> _projectHotReloadAgent;
         private readonly Lazy<IHotReloadDiagnosticOutputService> _hotReloadDiagnosticOutputService;
+        private readonly Lazy<IProjectHotReloadNotificationService> _projectHotReloadNotificationService;
 
         // Protect the state from concurrent access. For example, our Process.Exited event
         // handler may run on one thread while we're still setting up the session on
@@ -37,7 +38,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             IProjectFaultHandlerService projectFaultHandlerService,
             IActiveDebugFrameworkServices activeDebugFrameworkServices,
             Lazy<IProjectHotReloadAgent> projectHotReloadAgent,
-            Lazy<IHotReloadDiagnosticOutputService> hotReloadDiagnosticOutputService)
+            Lazy<IHotReloadDiagnosticOutputService> hotReloadDiagnosticOutputService,
+            Lazy<IProjectHotReloadNotificationService> projectHotReloadNotificationService)
             : base(threadingService.JoinableTaskContext)
         {
             _project = project;
@@ -45,6 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             _activeDebugFrameworkServices = activeDebugFrameworkServices;
             _projectHotReloadAgent = projectHotReloadAgent;
             _hotReloadDiagnosticOutputService = hotReloadDiagnosticOutputService;
+            _projectHotReloadNotificationService = projectHotReloadNotificationService;
         }
 
         public async Task ActivateSessionAsync(int processId, bool runningUnderDebugger, string projectName)
@@ -123,6 +126,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 {
                     await _pendingSessionState.Session.StartSessionAsync(runningUnderDebugger, cancellationToken: default);
                     _activeSessions.Add(processId, _pendingSessionState);
+
+                    // Addition of the first session, puts the project in hot reload mode
+                    if (_activeSessions.Count == 1)
+                    {
+                        await _projectHotReloadNotificationService.Value.SetHotReloadStateAsync(isInHotReload: true);
+                    }
                 }
 
                 _pendingSessionState = null;
@@ -359,6 +368,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                             hotReloadState.Process.Kill();
                         }
                     }
+                }
+
+                // No more sessions removes the project from hot reload mode
+                if (_activeSessions.Count == 0)
+                {
+                    await _projectHotReloadNotificationService.Value.SetHotReloadStateAsync(isInHotReload: false);
                 }
             }
             catch (Exception ex)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -354,6 +354,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 
             using AsyncSemaphore.Releaser semaphoreReleaser = await _semaphore.EnterAsync();
 
+            int sessionCountOnEntry = _activeSessions.Count;
+
             try
             {
                 if (_activeSessions.Remove(hotReloadState.Process.Id))
@@ -386,7 +388,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             finally
             {
                 // No more sessions removes the project from hot reload mode
-                if (_activeSessions.Count == 0)
+                if (sessionCountOnEntry == 1 && _activeSessions.Count == 0)
                 {
                     await _projectHotReloadNotificationService.Value.SetHotReloadStateAsync(isInHotReload: false);
                 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.HotReloadStateChangedAsync -> Microsoft.VisualStudio.Threading.AsyncEventHandler<bool>!
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.ProjectIsInHotReload.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.SetHotReloadStateAsync(bool isInHotReload) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,4 +1,4 @@
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.HotReloadStateChangedAsync -> Microsoft.VisualStudio.Threading.AsyncEventHandler<bool>!
-Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.ProjectIsInHotReload.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.IsProjectInHotReload.get -> bool
 Microsoft.VisualStudio.ProjectSystem.VS.HotReload.IProjectHotReloadNotificationService.SetHotReloadStateAsync(bool isInHotReload) -> System.Threading.Tasks.Task!

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadNotificationServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectHotReloadNotificationServiceFactory.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS
+{
+    internal static class IProjectHotReloadNotificationServiceFactory
+    {
+        public static IProjectHotReloadNotificationService Create()
+        {
+            var mock = new Mock<IProjectHotReloadNotificationService>();
+
+            return mock.Object;
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
@@ -175,7 +175,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
                 IProjectFaultHandlerServiceFactory.Create(),
                 activeDebugFrameworkServices,
                 new Lazy<IProjectHotReloadAgent>(() => IProjectHotReloadAgentFactory.Create()),
-                new Lazy<IHotReloadDiagnosticOutputService>(() => IHotReloadDiagnosticOutputServiceFactory.Create(outputServiceCallback)));
+                new Lazy<IHotReloadDiagnosticOutputService>(() => IHotReloadDiagnosticOutputServiceFactory.Create(outputServiceCallback)),
+                new Lazy<IProjectHotReloadNotificationService>(() => IProjectHotReloadNotificationServiceFactory.Create()));
 
             return manager;
         }


### PR DESCRIPTION
- The CSS hot reload system needs a way to know when the project system has entered hot reload mode - has at least one active hot reload session, and when it the project is no longer in hot reload mode. Currently the CSS hot reload system runs autonomously, but there is a desire to have it honor the hot reload button. In order to support this, it needs to register and unregister itself as a hot reload agent which requires knowing when the project has entered and exited hot reload mode.
- I added an IProjectHotReloadNotificationService interface to support this. It is exported by the managed project system and has a method to set the current hot reload state of the project and has an AsyncEvent which consumers can listen for changes in hot reload state. 
- The CSS hot reload subsystem which supports CSS hot reload across all project types, uses this event to register and unregister itself as a hot reload agent.
- It is up to the individual project system implementations to consume this interface and set the hot reload state
- I modified the hot reload session manager in the managed project system to do this for its hot reload scenarios


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8923)