### PR TITLE
Avoid multiple calls to TelemetryScope.End

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/ManagedTelemetryService.cs
@@ -114,8 +114,10 @@ internal class ManagedTelemetryService : ITelemetryService
 #if DEBUG
             Assumes.True(_scope.IsEnd, $"Failed to call '{nameof(ITelemetryOperation.End)}' on {nameof(ITelemetryOperation)} instance.");
 #endif
-
-            _scope.End(TelemetryResult.None);
+            if (!_scope.IsEnd)
+            {
+                _scope.End(TelemetryResult.None);
+            }
         }
 
         public void End(TelemetryResult result)


### PR DESCRIPTION
`TelemetryOperation` implements `IDisposable` so we can guarantee that `TelemetryScope.End` is called even if not explicitly done so in code. However, we should call it in `Dispose` if it has already been called elsewhere.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8924)