### PR TITLE
Embed "ProjectReference" item rule for NuGet restore

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -157,6 +157,17 @@
       <DataAccess>None</DataAccess>
       <RuleInjection>None</RuleInjection>
     </XamlPropertyRule>
+    <Compile Update="ProjectSystem\Rules\EvaluatedProjectReference.cs">
+      <DependentUpon>EvaluatedProjectReference.xaml</DependentUpon>
+    </Compile>
+    <XamlPropertyRule Include="ProjectSystem\Rules\EvaluatedProjectReference.xaml">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <XlfInput>false</XlfInput>
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+      <DataAccess>None</DataAccess>
+      <RuleInjection>None</RuleInjection>
+    </XamlPropertyRule>
 
     <!-- SDK Reference -->
     <Compile Update="ProjectSystem\Rules\Dependencies\SdkReference.xaml.cs">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             IImmutableDictionary<string, string> properties = update.GetSnapshotOrEmpty(NuGetRestore.SchemaName).Properties;
             IProjectRuleSnapshot frameworkReferences = update.GetSnapshotOrEmpty(CollectedFrameworkReference.SchemaName);
             IProjectRuleSnapshot packageDownloads = update.GetSnapshotOrEmpty(CollectedPackageDownload.SchemaName);
-            IProjectRuleSnapshot projectReferences = update.GetSnapshotOrEmpty(ProjectReference.SchemaName);
+            IProjectRuleSnapshot projectReferences = update.GetSnapshotOrEmpty(EvaluatedProjectReference.SchemaName);
             IProjectRuleSnapshot packageReferences = update.GetSnapshotOrEmpty(CollectedPackageReference.SchemaName);
             IProjectRuleSnapshot packageVersions = update.GetSnapshotOrEmpty(CollectedPackageVersion.SchemaName);
             IProjectRuleSnapshot toolReferences = update.GetSnapshotOrEmpty(DotNetCliToolReference.SchemaName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EvaluatedProjectReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EvaluatedProjectReference.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    internal partial class EvaluatedProjectReference
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EvaluatedProjectReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/EvaluatedProjectReference.xaml
@@ -1,0 +1,145 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
+<Rule Name="EvaluatedProjectReference"
+      PageTemplate="generic"
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
+
+  <!--
+  Captures ProjectReference items from evaluation for use in Solution Restore.
+
+  NOTE this rule is identical to ProjectReference.xaml, however it is embedded to allow use in other
+  scenarios, such as C++/CLI projects, where our on-disk rule files are not available at run-time.
+  We are currently unable to embed localized rule files (and ProjectReference is used as a browse
+  object, and therefore must be localized.)
+  -->
+
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="ProjectReference"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <StringListProperty Name="Aliases"
+                      Separator=","
+                      Visible="False">
+    <StringListProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ProjectReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringListProperty.DataSource>
+  </StringListProperty>
+
+  <StringProperty Name="BrowsePath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ProjectReference"
+                  PersistedName="Identity"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="Private"
+                Visible="False">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ProjectReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <BoolProperty Name="CopyLocalSatelliteAssemblies"
+                Visible="False" />
+
+  <StringProperty Name="Culture"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="Description"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="EmbedInteropTypes"
+                Visible="False">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="ProjectReference"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
+
+  <StringProperty Name="ExcludeAssets"
+                  Visible="False"/>
+
+  <StringProperty Name="Identity"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="{}{Identity}"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="IncludeAssets"
+                  Visible="False" />
+
+  <StringProperty Name="IsImplicitlyDefined"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="LinkLibraryDependencies"
+                Visible="False" />
+
+  <StringProperty Name="PrivateAssets"
+                  Visible="False" />
+
+  <StringProperty Name="Project"
+                  Visible="False" />
+
+  <StringProperty Name="ProjectFileFullPath"
+                  Visible="False"
+                  ReadOnly="True">
+    <StringProperty.DataSource>
+      <DataSource ItemType="ProjectReference"
+                  PersistedName="FullPath"
+                  Persistence="Intrinsic"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="ReferencedProjectIdentifier"
+                  Visible="False" />
+
+  <BoolProperty Name="ReferenceOutputAssembly"
+                Visible="False" />
+
+  <StringProperty Name="ResolvedPath"
+                  ReadOnly="True"
+                  Visible="False">
+    <StringProperty.DataSource>
+      <DataSource PersistedName="Identity"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="UseLibraryDependencyInputs"
+                Visible="False" />
+
+  <StringProperty Name="Version"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <BoolProperty Name="Visible"
+                ReadOnly="True"
+                Visible="False" />
+
+  <BoolProperty Name="TreatAsUsed"
+                ReadOnly="True"
+                Visible="False" />
+
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -198,4 +198,8 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="WindowsTargetPlatformMinVersion"
+                  ReadOnly="True"
+                  Visible="False" />
+
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
@@ -112,6 +112,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
         private static class PackageRestoreRules
         {
             /// <summary>
+            ///     Represents the evaluated <c>ProjectReference</c> items that are passed to restore.
+            /// </summary>
+            [ExportRule(nameof(EvaluatedProjectReference), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapabilities.PackageReferences)]
+            [Order(Order.Default)]
+            public static int EvaluatedProjectReferenceRule;
+
+            /// <summary>
             ///     Represents the design-time build items containing CLI tool references (legacy) that are passed to restore.
             /// </summary>
             [ExportRule(nameof(DotNetCliToolReference), PropertyPageContexts.ProjectSubscriptionService)]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/Snapshots/RestoreBuilderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/Snapshots/RestoreBuilderTests.cs
@@ -21,7 +21,7 @@ public class RestoreBuilderTests
             """
                 {
                     "CurrentState": {
-                        "ProjectReference": {
+                        "EvaluatedProjectReference": {
                             "Items" : {}
                         },
                         "PackageReference": {
@@ -296,7 +296,7 @@ public class RestoreBuilderTests
             """
                 {
                     "CurrentState": {
-                        "ProjectReference": {
+                        "EvaluatedProjectReference": {
                             "Items" : {
                                 "..\\Project\\Project1.csproj" : {
                                     "ProjectFileFullPath" : "C:\\Solution\\Project\\Project1.csproj",


### PR DESCRIPTION
Fixes #8930.

C++/CLI projects use our NuGet restore/nomination code, without providing all our on-disk rules. The prior code required a non-embedded `ProjectReference` rule, which would work for .NET projects, but not for C++/CLI where the rule would not be found. Running with `set CPS_DiagnosticRuntime=1` would output to the "Project" pane of the Output window:

```
CPS Warning: 25816 :
Rule 'ProjectReference' was not resolved when it is subscribed through the ProjectJointSubscriptionService.
CPS Error: 25816 :
Generating snapshot for rule "ProjectReference" failed because the rule was missing from the project.
```

This commit creates a new `EvaluatedProjectReference` rule which _is_ embedded, and uses that in the NuGet restore code. The _Evaluated_ prefix is meant as an analog to _Collected_, where the latter represents items collected from a design-time build.

This continues work done in #6532.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8934)