### PR TITLE
Set the Generate XML Documentation property correctly.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
@@ -8,6 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
 
         private const string DocumentationFileMSBuildProperty = "DocumentationFile";
+        private const string PublishDocumentationFileMSBuildProperty = "PublishDocumentationFile";
         private static readonly string[] s_msBuildPropertyNames = { DocumentationFileMSBuildProperty };
         
         [ImportingConstructor]
@@ -29,6 +30,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 {
                     await defaultProperties.SaveValueIfCurrentlySetAsync(DocumentationFileMSBuildProperty, _temporaryPropertyStorage);
                     await defaultProperties.DeletePropertyAsync(DocumentationFileMSBuildProperty);
+                    await defaultProperties.DeletePropertyAsync(PublishDocumentationFileMSBuildProperty);
                 }
                 else
                 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 }
             }
 
-            return null;
+            return unevaluatedPropertyValue;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -41,7 +41,11 @@
   <BoolProperty Name="GenerateDocumentationFile"
                 DisplayName="Generate XML documentation file"
                 Description="Specifies whether to generate documentation information."
-                Category="General" />
+                Category="General">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
+  </BoolProperty>
 
   <!-- TODO: Condition the visibility on this being a class library -->
   <BoolProperty Name="RegisterForComInterop"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -37,15 +37,31 @@
                   Category="General"
                   Subtype="directory" />
 
-  <!-- TODO: Update this with correct behavior for SDK-style projects -->
   <BoolProperty Name="GenerateDocumentationFile"
                 DisplayName="Generate XML documentation file"
                 Description="Specifies whether to generate documentation information."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2165772"
                 Category="General">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />
     </BoolProperty.DataSource>
   </BoolProperty>
+
+  <StringProperty Name="DocumentationFile"
+                  DisplayName="XML documentation file path"
+                  Description="Optional path for the API documentation file. Leave blank to use the default location."
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147081"
+                  Category="General"
+                  Subtype="file">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Build" "GenerateDocumentationFile" true)</NameValuePair.Value>
+      </NameValuePair>
+    </StringProperty.Metadata>
+  </StringProperty>
 
   <!-- TODO: Condition the visibility on this being a class library -->
   <BoolProperty Name="RegisterForComInterop"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.VisualBasic.xaml
@@ -63,6 +63,20 @@
     </StringProperty.Metadata>
   </StringProperty>
 
+  <BoolProperty Name="PublishDocumentationFile"
+                DisplayName="Publish documentation file"
+                Description="When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true."
+                Category="General">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Build" "GenerateDocumentationFile" true)</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
+
   <!-- TODO: Condition the visibility on this being a class library -->
   <BoolProperty Name="RegisterForComInterop"
                 DisplayName="Register for COM interop"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferovat 32bitovou verzi</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Určuje, jestli vaše spravovaná aplikace zveřejní objekt COM (objekt COM volatelný za běhu), který umožňuje objektu COM pracovat s aplikací.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.cs.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Vlastní konstanty</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Cesta k výstupu sestavení</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Benutzerdefinierte Konstanten</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Buildausgabepfad</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.de.xlf
@@ -52,6 +52,16 @@
         <target state="translated">32-Bit bevorzugen</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Legt fest, ob Ihre verwaltete Anwendung ein COM-Objekt (ein COM-aufrufbarer Wrapper) verfügbar macht, mit dem ein COM-Objekt mit der Anwendung interagieren kann.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Constantes personalizadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Ruta de acceso de salida de la compilación</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.es.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferir 32 bits</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Especifica si la aplicación administrada expondrá un objeto COM (contenedor CCW) que permita que un objeto COM interactúe con la aplicación.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Préférer 32 bits</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Spécifie si votre application managée exposera un objet COM (wrapper pouvant être appelé par COM) qui permet à un objet COM d’interagir avec l’application.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.fr.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Constantes personnalisées</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Créer un chemin de sortie</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Costanti personalizzate</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Percorso dell’output di compilazione</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.it.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferisci 32 bit</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Specifica se l'applicazione gestita esporrà un oggetto COM (un COM-callable wrapper) che consente a un oggetto COM di interagire con l'applicazione.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -52,6 +52,16 @@
         <target state="translated">32 ビットを優先</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">管理対象アプリで COM オブジェクト (COM 呼び出し可能ラッパー) を公開して COM オブジェクトにそのアプリとの対話を可能にするかどうかを指定します。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ja.xlf
@@ -387,6 +387,16 @@
         <target state="translated">カスタム定数</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">ビルド出力パス</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -52,6 +52,16 @@
         <target state="translated">32비트 선호</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">관리되는 애플리케이션이 COM 개체가 애플리케이션과 상호 작용할 수 있도록 하는 COM 개체(COM 호출 가능 래퍼)를 노출할지 여부를 지정합니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ko.xlf
@@ -387,6 +387,16 @@
         <target state="translated">사용자 지정 상수</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">빌드 출력 경로</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Preferuj 32-bitowe</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Określa, czy aplikacja zarządzana uwidacznia obiekt COM (otokę wywoływaną przez COM), która umożliwia interakcję obiektu COM z aplikacją.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pl.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Stałe niestandardowe</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Ścieżka wyjściowa kompilacji</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Constantes personalizadas</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Construir caminho de saída</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Prefira 32 bits</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Especifica se seu aplicativo gerenciado irá expor um objeto COM (um wrapper que pode ser chamado por COM) que permite que um objeto COM interaja com o aplicativo.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -52,6 +52,16 @@
         <target state="translated">Предпочитать 32-разрядный режим</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Указывает, будет ли ваше управляемое приложение предоставлять COM-объект (вызываемую COM-оболочку), позволяющий COM-объекту взаимодействовать с приложением.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.ru.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Пользовательские константы</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Выходной путь сборки</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -52,6 +52,16 @@
         <target state="translated">32 biti tercih et</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">Yönetilen uygulamanız ile bir COM nesnesinin etkileşim kurmasını sağlayan bir COM nesnesinin (COM çağrılabilir sarmalayıcısının) uygulamanız tarafından ortaya çıkarılıp çıkarılmayacağını belirtir.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.tr.xlf
@@ -387,6 +387,16 @@
         <target state="translated">Özel sabitler</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">Derleme çıkış yolu</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -387,6 +387,16 @@
         <target state="translated">自定义常量</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">生成输出路径</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -52,6 +52,16 @@
         <target state="translated">首选 32 位</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">指定托管应用程序是否将公开 COM 对象(可调用 COM 的包装器)，使 COM 对象能够与应用程序交互。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -52,6 +52,16 @@
         <target state="translated">建議使用 32 位元</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|Description">
+        <source>When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</source>
+        <target state="new">When this property is true, the XML documentation file for the project, if one is generated, is included in the publish output for the project. This property defaults to true.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishDocumentationFile|DisplayName">
+        <source>Publish documentation file</source>
+        <target state="new">Publish documentation file</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|RegisterForComInterop|Description">
         <source>Specifies whether your managed application will expose a COM object (a COM-callable wrapper) that enables a COM object to interact with the application.</source>
         <target state="translated">指定您的受管理應用程式是否會公開 COM 物件 (可呼叫 COM 的包裝函式)，讓 COM 物件與應用程式互動。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -387,6 +387,16 @@
         <target state="translated">自訂常數</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|Description">
+        <source>Optional path for the API documentation file. Leave blank to use the default location.</source>
+        <target state="new">Optional path for the API documentation file. Leave blank to use the default location.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|DocumentationFile|DisplayName">
+        <source>XML documentation file path</source>
+        <target state="new">XML documentation file path</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|OutputPath|DisplayName">
         <source>Build output path</source>
         <target state="translated">建置輸出路徑</target>


### PR DESCRIPTION
Fixes the feedback ticket https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1773467

This PR handles the scenario where there is no value to recover and set the `unevaluatedPropertyValue` as the value. I also followed the non-configurable setting that C# has for the same property, but I'm also okay leaving it configurable.

Before: you cannot set the property.
![generate-xml-doc-property-bug](https://user-images.githubusercontent.com/8518253/228368437-e3896be0-fe15-4492-8da9-c1db99494bb8.gif)

After: you can set the property and see it in the project file.
![generate-xml-doc-property-fix](https://user-images.githubusercontent.com/8518253/228368461-16bd9dc9-7dc6-45dc-a6d2-a77ff7f7e943.gif)

Open to discuss: do we want to also bring in the `DocumentationFile` property over to the VB Build property page, so the user sets it. It does have a comment saying that we wanted to remove that property all together, but I'm unsure the reason behind it. https://github.com/dotnet/project-system/blob/18ee5d2985bb0b7f438945f829ff9abf0bbbbbbe/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml#L315-L320

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8944)