### PR TITLE
Enable splash screen properties for VB WinForms projects.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -6,7 +6,6 @@ Imports System.ComponentModel
 Imports System.IO
 Imports System.Reflection
 Imports System.Runtime.InteropServices
-
 Imports EnvDTE
 
 Imports Microsoft.VisualStudio.Designer.Interfaces
@@ -229,8 +228,8 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                 Else
                     Debug.Fail("Unexpected MyApplication.ShutdownMode")
                 End If
-                
-                If IsTargetingDotNetCore(DirectCast(GetService(GetType(IVsHierarchy)), IVsHierarchy))
+
+                If IsTargetingDotNetCore(DirectCast(GetService(GetType(IVsHierarchy)), IVsHierarchy)) Then
                     '    Me.HighDpiMode = HighDpiMode.xxx
                     Dim HighDpiValue As String
                     Select Case MyApplication.HighDpiMode
@@ -249,7 +248,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     End Select
                     AddFieldAssignment(Constructor, HighDpiModeFieldName, HighDpiModeFieldName, HighDpiValue)
                 End If
-                    
+
                 GeneratedType.Members.Add(Constructor)
 
                 If MyApplication.MainFormNoRootNS <> String.Empty Then
@@ -331,7 +330,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                     End If
                 End If
 
-                If MyApplication.MinimumSplashScreenDisplayTime <> String.Empty Then
+                If IsNumeric(MyApplication.MinimumSplashScreenDisplayTime) Then
                     ' GENERATED CODE:
                     ' Protected Overrides Function OnInitialize(commandLineArgs As System.Collections.ObjectModel.ReadOnlyCollection(Of String)) As Boolean
                     '    Me.MinimumSplashScreenDisplayTime = 5000

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationCodeGenerator.vb
@@ -40,6 +40,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Const EnableVisualStylesFieldName As String = "EnableVisualStyles"
         Private Const SaveMySettingsOnExitFieldName As String = "SaveMySettingsOnExit"
         Private Const SplashScreenFieldName As String = "SplashScreen"
+        Private Const MinimumSplashScreenDisplayTimeFieldName As String = "MinimumSplashScreenDisplayTime"
         Private Const HighDpiModeFieldName As String = "HighDpiMode"
 
         Private Const HighDpiMode_DpiUnaware = "DpiUnaware"
@@ -329,6 +330,37 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                         GeneratedType.Members.Add(OnCreateSplashScreen)
                     End If
                 End If
+
+                If MyApplication.MinimumSplashScreenDisplayTime <> String.Empty Then
+                    ' GENERATED CODE:
+                    ' Protected Overrides Function OnInitialize(commandLineArgs As System.Collections.ObjectModel.ReadOnlyCollection(Of String)) As Boolean
+                    '    Me.MinimumSplashScreenDisplayTime = 5000
+                    '    Return MyBase.OnInitialize(commandLineArgs)
+                    ' End Function
+                    '
+                    Dim OnInitialize As New CodeMemberMethod With {
+                        .Attributes = MemberAttributes.Override Or MemberAttributes.Family,
+                        .ReturnType = New CodeTypeReference(GetType(Boolean)),
+                        .Name = "OnInitialize"
+                    }
+                    AddAttribute(OnInitialize, DebuggerStepThroughAttribute, True)
+                    Dim commandLineArgs As New CodeParameterDeclarationExpression With {
+                                            .Name = "commandLineArgs",
+                                            .Type = New CodeTypeReference(GetType(ObjectModel.ReadOnlyCollection(Of String)))
+                                        }
+                    OnInitialize.Parameters.Add(commandLineArgs)
+                    AddFieldPrimitiveAssignment(OnInitialize, MinimumSplashScreenDisplayTimeFieldName, MyApplication.MinimumSplashScreenDisplayTime)
+                    Dim MyBaseOnInitialize As New CodeMethodInvokeExpression With {
+                                            .Method = New CodeMethodReferenceExpression With {
+                                                .MethodName = "OnInitialize",
+                                                .TargetObject = New CodeBaseReferenceExpression()
+                                            }
+                                        }
+                    MyBaseOnInitialize.Parameters.Add(New CodeArgumentReferenceExpression("commandLineArgs"))
+                    OnInitialize.Statements.Add(New CodeMethodReturnStatement(MyBaseOnInitialize))
+                    GeneratedType.Members.Add(OnInitialize)
+                End If
+
                 ' Add our class to the namespace...
                 MyNamespace.Types.Add(GeneratedType)
 

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _enableVisualStyles As Boolean
         Private _authenticationMode As Integer
         Private _splashScreenNoRootNS As String 'Splash screen to use (without the root namespace)
-        Private _minimumSplashScreenDisplayTime As String
+        Private _minimumSplashScreenDisplayTime As Integer
         Private _saveMySettingsOnExit As Boolean 'Whether to save My.Settings on shutdown
         Private _highDpiMode As Integer
 
@@ -107,7 +107,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Set
         End Property
 
-        Public Property MinimumSplashScreenDisplayTime As String
+        Public Property MinimumSplashScreenDisplayTime As Integer
             Get
                 Return _minimumSplashScreenDisplayTime
             End Get

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationData.vb
@@ -22,6 +22,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _enableVisualStyles As Boolean
         Private _authenticationMode As Integer
         Private _splashScreenNoRootNS As String 'Splash screen to use (without the root namespace)
+        Private _minimumSplashScreenDisplayTime As String
         Private _saveMySettingsOnExit As Boolean 'Whether to save My.Settings on shutdown
         Private _highDpiMode As Integer
 
@@ -102,6 +103,16 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             End Get
             Set
                 _splashScreenNoRootNS = value
+                IsDirty = True
+            End Set
+        End Property
+
+        Public Property MinimumSplashScreenDisplayTime As String
+            Get
+                Return _minimumSplashScreenDisplayTime
+            End Get
+            Set
+                _minimumSplashScreenDisplayTime = Value
                 IsDirty = True
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
@@ -34,6 +34,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             WriteElementStringRaw("EnableVisualStyles", "", Xml.XmlConvert.ToString(CType(o.EnableVisualStyles, Boolean)))
             WriteElementStringRaw("AuthenticationMode", "", Xml.XmlConvert.ToString(CType(o.AuthenticationMode, Integer)))
             WriteElementString("SplashScreen", "", o.SplashScreenNoRootNS)
+            WriteElementStringRaw("MinimumSplashScreenDisplayTime", "", Xml.XmlConvert.ToString(CType(o.MinimumSplashScreenDisplayTime, Integer)))
             WriteElementStringRaw("SaveMySettingsOnExit", "", Xml.XmlConvert.ToString(CType(o.SaveMySettingsOnExit, Boolean)))
             WriteElementStringRaw("HighDpiMpde", "", Xml.XmlConvert.ToString(CType(o.HighDpiMode, Boolean)))
             WriteEndElement(o)
@@ -96,7 +97,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
             Dim o As MyApplicationData
             o = New MyApplicationData()
-            Dim paramsRead(9) As Boolean
+            Dim paramsRead(10) As Boolean
 
             While Reader.MoveToNextAttribute()
                 If Not IsXmlnsAttribute(Reader.Name) Then
@@ -156,6 +157,10 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
                         o.HighDpiMode = Xml.XmlConvert.ToInt32(Reader.ReadElementString())
                         paramsRead(9) = True
 
+                    ElseIf Not paramsRead(10) AndAlso Reader.LocalName = _id14_MinimumSplashScreenDisplayTime AndAlso Reader.NamespaceURI = _id2_Item Then
+                        o.MinimumSplashScreenDisplayTime = Xml.XmlConvert.ToInt32(Reader.ReadElementString())
+                        paramsRead(10) = True
+
                     Else
                         UnknownNode(CType(o, Object))
                     End If
@@ -205,6 +210,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private _id8_AuthenticationMode As String
         Private _id12_SaveMySettingsOnExit As String
         Private _id13_HighDpiMode As String
+        Private _id14_MinimumSplashScreenDisplayTime As String
 
         Protected Overrides Sub InitIDs()
 
@@ -231,6 +237,8 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             _id12_SaveMySettingsOnExit = Reader.NameTable.Add("SaveMySettingsOnExit")
 
             _id13_HighDpiMode = Reader.NameTable.Add("HighDpiMode")
+
+            _id14_MinimumSplashScreenDisplayTime = Reader.NameTable.Add("MinimumSplashScreenDisplayTime")
         End Sub 'InitIDs 
 
         Private _publicMethods As Hashtable

--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationProperties.vb
@@ -87,6 +87,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         ' ApplicationType = 9 ' OBSOLETE
         SaveMySettingsOnExit = 10
         HigDpiMode = 11
+        MinimumSplashScreenDisplayTime = 12
     End Enum
 
     ''' <summary>
@@ -105,6 +106,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         <DispId(MyAppDISPIDs.AuthenticationMode)> Property AuthenticationMode As Integer
         <DispId(MyAppDISPIDs.SplashScreen)> Property SplashScreen As String
         ' <DispId(MyAppDISPIDs.ApplicationType)> Property ApplicationType() As Integer ' OBSOLETE
+        <DispId(MyAppDISPIDs.MinimumSplashScreenDisplayTime)> Property MinimumSplashScreenDisplayTime As Integer
         <DispId(MyAppDISPIDs.SaveMySettingsOnExit)> Property SaveMySettingsOnExit As Boolean
         <DispId(MyAppDISPIDs.HigDpiMode)> Property HighDpiMode As Integer
     End Interface
@@ -194,6 +196,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
         Private Const PROPNAME_SaveMySettingsOnExit As String = "SaveMySettingsOnExit"
         Private Const PROPNAME_AuthenticationMode As String = "AuthenticationMode"
         Private Const PROPNAME_SplashScreen As String = "SplashScreen"
+        Private Const PROPNAME_MinimumSplashScreenDisplayTime As String = "MinimumSplashScreenDisplayTime"
         Private Const PROPNAME_HighDpiMode As String = "HighDpiMode"
 
         Private _projectHierarchy As IVsHierarchy
@@ -591,6 +594,21 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
 
                     'Notify users of property change
                     OnPropertyChanged(PROPNAME_SplashScreen)
+                End If
+            End Set
+        End Property
+
+        Friend Property MinimumSplashScreenDisplayTime As Integer Implements IVsMyApplicationProperties.MinimumSplashScreenDisplayTime
+            Get
+                Return _myAppData.MinimumSplashScreenDisplayTime
+            End Get
+            Set
+                If _myAppData.MinimumSplashScreenDisplayTime <> Value Then
+                    CheckOutDocData()
+                    _myAppData.MinimumSplashScreenDisplayTime = Value
+                    FlushToDocData()
+                    'Notify users of property change
+                    OnPropertyChanged(PROPNAME_MinimumSplashScreenDisplayTime)
                 End If
             End Set
         End Property

--- a/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.Editors/PublicAPI.Shipped.txt
@@ -1085,3 +1085,5 @@ Shared My.Resources.GeneralOptionPageResources.General_MultiTargetingSettings_Ti
 Shared My.Resources.GeneralOptionPageResources.General_PreferSingleTargetBuildsOnLaunchDescription() -> String
 Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode() -> Integer
 Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.HighDpiMode(Value As Integer) -> Void
+Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.MinimumSplashScreenDisplayTime() -> Integer
+Microsoft.VisualStudio.Editors.MyApplication.IVsMyApplicationProperties.MinimumSplashScreenDisplayTime(Value As Integer) -> Void

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else
             {
-                return GetPropertyValueAsync(propertyName);
+                return GetPropertyValueAsync(propertyName, defaultProperties);
             }
         }
 
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else
             {
-                return GetPropertyValueAsync(propertyName);
+                return GetPropertyValueAsync(propertyName, defaultProperties);
             }
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return null;
         }
 
-        private async Task<string> GetPropertyValueAsync(string propertyName)
+        private async Task<string> GetPropertyValueAsync(string propertyName, IProjectProperties defaultProperties)
         {
             string value = propertyName switch
             {
@@ -293,6 +293,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
                 };
             }
+            else if (propertyName == SplashScreen)
+            {
+                string rootNamespace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
+                value = rootNamespace + "." + value;
+            }
 
             return value;
         }
@@ -317,6 +322,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     "AfterAllFormsClose" => "1",
                     _ => unevaluatedPropertyValue
                 };
+            }
+            else if (propertyName == SplashScreen && !string.IsNullOrEmpty(unevaluatedPropertyValue))
+            {
+                string rootNamespace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
+                unevaluatedPropertyValue = unevaluatedPropertyValue.Replace(rootNamespace + ".", string.Empty);
             }
 
             await (propertyName switch 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else
             {
-                return await SetPropertyValueAsync(propertyName, unevaluatedPropertyValue, defaultProperties);
+                return await SetPropertyValueAsync(propertyName, unevaluatedPropertyValue);
             }     
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else
             {
-                return GetPropertyValueAsync(propertyName, defaultProperties);
+                return GetPropertyValueAsync(propertyName);
             }
         }
 
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else
             {
-                return GetPropertyValueAsync(propertyName, defaultProperties);
+                return GetPropertyValueAsync(propertyName);
             }
         }
 
@@ -254,7 +254,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return null;
         }
 
-        private async Task<string> GetPropertyValueAsync(string propertyName, IProjectProperties defaultProperties)
+        private async Task<string> GetPropertyValueAsync(string propertyName)
         {
             string value = propertyName switch
             {
@@ -297,7 +297,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return value;
         }
 
-        private async Task<string?> SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties)
+        private async Task<string?> SetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue)
         {
             // ValueProvider needs to convert string enums to valid values to be saved.
             if (propertyName == AuthenticationMode)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -293,11 +293,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => throw new InvalidOperationException($"Invalid value '{value}' for '{propertyName}' property.")
                 };
             }
-            else if (propertyName == SplashScreen)
-            {
-                string rootNamespace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
-                value = rootNamespace + "." + value;
-            }
 
             return value;
         }
@@ -322,11 +317,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     "AfterAllFormsClose" => "1",
                     _ => unevaluatedPropertyValue
                 };
-            }
-            else if (propertyName == SplashScreen && !string.IsNullOrEmpty(unevaluatedPropertyValue))
-            {
-                string rootNamespace = await defaultProperties.GetEvaluatedPropertyValueAsync("RootNamespace");
-                unevaluatedPropertyValue = unevaluatedPropertyValue.Replace(rootNamespace + ".", string.Empty);
             }
 
             await (propertyName switch 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -88,12 +88,14 @@ internal class SplashScreenEnumProvider : IDynamicEnumValuesProvider
             {
                 enumValues.AddRange(entryPoints.Select(ep =>
                 {
+                    // These values are saved to the myapp file, where they are later used by the MyApplicationCodeGenerator to generate the Designer.vb file that contains the actual code.
+                    // The code generator expects the name of the splash screen value (just the name without the namespace nor the extension) to be passed to it,
+                    // so we get it from the ep.Name (i.e. SplashScreen1), and for the display name we use the fully qualified name (i.e. MyApplication.SplashScreen1.vb).
                     string displayName = ep.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
                     return new PageEnumValue(new EnumValue { Name = ep.Name, DisplayName = displayName });
                 }));
             }
 
-            // Test: change in the startup object value refreshes the splash screen enum value list.
             // Remove selected startup object (if any) from the list, as a user should not be able to select it again.
             ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
             object? startupObjectObject = await configuration.StartupObject.GetValueAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.LanguageServices;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic;
+
+[ExportDynamicEnumValuesProvider("SplashScreenEnumProvider")]
+[AppliesTo(ProjectCapability.VisualBasic)]
+internal class SplashScreenEnumProvider : IDynamicEnumValuesProvider
+{
+    private readonly Workspace _workspace;
+    private readonly UnconfiguredProject _unconfiguredProject;
+
+    public SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace, UnconfiguredProject unconfiguredProject)
+    {
+        _workspace = workspace;
+        _unconfiguredProject = unconfiguredProject;
+    }
+
+    public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
+    {
+        // We only include a value representing the "not set" state if requested. This is
+        // because the old property pages explicitly add the "(Not set)" value at the UI
+        // layer; the new property pages do not have that option and so the value must come
+        // from the enum provider.
+        // When this project system no longer needs to support the old property pages we can
+        // remove this and always include the "(Not set)" value.
+        bool includeEmptyValue = options?.Any(pair =>
+            pair.Name == "IncludeEmptyValue"
+            && bool.TryParse(pair.Value, out bool optionValue)
+            && optionValue) ?? false;
+
+        return Task.FromResult<IDynamicEnumValuesGenerator>(new StartupObjectsEnumGenerator(_workspace, _unconfiguredProject, includeEmptyValue, true));
+    }
+}
+
+internal class SplashScreenEnumGenerator : IDynamicEnumValuesGenerator
+{
+    public bool AllowCustomValues => false;
+    private readonly Workspace _workspace;
+    private readonly UnconfiguredProject _unconfiguredProject;
+    private readonly bool _includeEmptyValue;
+    private readonly bool _searchForEntryPointsInFormsOnly;
+
+    public SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly)
+    {
+        _workspace = workspace;
+        _unconfiguredProject = unconfiguredProject;
+        _includeEmptyValue = includeEmptyValue;
+        _searchForEntryPointsInFormsOnly = searchForEntryPointsInFormsOnly;
+    }
+
+
+    public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
+    {
+        Project? project = _workspace.CurrentSolution.Projects.FirstOrDefault(p => PathHelper.IsSamePath(p.FilePath!, _unconfiguredProject.FullPath));
+        if (project is null)
+        {
+            return Array.Empty<IEnumValue>();
+        }
+
+        Compilation? compilation = await project.GetCompilationAsync();
+        if (compilation is null)
+        {
+            // Project does not support compilations
+            return Array.Empty<IEnumValue>();
+        }
+
+        List<IEnumValue> enumValues = new();
+        if (_includeEmptyValue)
+        {
+            enumValues.Add(new PageEnumValue(new EnumValue { Name = "", DisplayName = VSResources.StartupObjectNotSet }));
+        }
+
+        IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();
+        IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, _searchForEntryPointsInFormsOnly);
+        if (entryPoints is not null)
+        {
+            enumValues.AddRange(entryPoints.Select(ep =>
+            {
+                string name = ep.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted));
+                return new PageEnumValue(new EnumValue { Name = name, DisplayName = name });
+            }));
+        }
+
+        return enumValues;
+    }
+
+    public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
+    {
+        var value = new PageEnumValue(new EnumValue { Name = userSuppliedValue, DisplayName = userSuppliedValue });
+        return Task.FromResult<IEnumValue?>(value);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -226,6 +226,9 @@
     </BoolProperty.DataSource>
   </BoolProperty>
 
+  <StringProperty Name="StartupObject"
+                  Visible="False" />
+
   <StringProperty Name="SupportedMyApplicationTypes"
                   ReadOnly="True"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -211,8 +211,7 @@
                        Description="Sets the form to be used as a splash screen for the application."
                        HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195177"
                        Category="ApplicationFramework"
-                       EnumProvider="StartupObjectsEnumProvider"
-                       Visible="False">
+                       EnumProvider="SplashScreenEnumProvider">
     <DynamicEnumProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
@@ -235,8 +234,7 @@
                 DisplayName="Minimum splash screen display time"
                 Description="Sets the minimum length of time, in milliseconds, for which the splash screen is displayed."
                 HelpUrl="https://go.microsoft.com/fwlink/?linkid=2195289"
-                Category="ApplicationFramework"
-                Visible="False">
+                Category="ApplicationFramework">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />


### PR DESCRIPTION
Addresses #8286, part of #8766, [AB#1565607](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1565607)

This PR:
- makes the splash screen properties visible
- creates a `IDynamicEnumProvider` for the splash screen property, where it gets the valid entry points from the `IEntryPointFinderService`.
- saves the splash screen property as the name of the entry point, without any namespaces, as that's the way the myapp file needs it to generate the code for the Designer (in contrast to the C# way we do it for the `StartupObject` property.)
- tracks the `StartupObject` in the `ConfigurationGeneral` xaml rule to later be used in the `IDynamicEnumValuesGenerator` to remove the selected value (if any) from the splash screen enum value list.

**Pending:**
I'll add some unit tests to ensure edge cases are considered.
- Test: change in the startup object value refreshes the splash screen enum value list.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8945)