### PR TITLE
Exclude unused assembly references from DTB data

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -408,6 +408,22 @@
   </Target>
 
   <Target
+      Name="ResolveAssemblyReferencesDesignTime2"
+      Returns="@(_ResolvedDesignTimeAssemblyReference)"
+      DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences">
+
+    <!-- ResolveAssemblyReferencesDesignTime filters ReferencePath items to exclude P2P references, but we also want to filter out
+         references from PackageReferences and FrameworkReferences. In both cases, the NuGetPackageId metadata is populated,
+         so we use it to filter our such assemblies. https://github.com/dotnet/msbuild/issues/8623 -->
+    <ItemGroup>
+      <_ResolvedDesignTimeAssemblyReference
+        Include="@(ReferencePath)"
+        Condition="'%(ReferencePath.ReferenceSourceTarget)' == 'ResolveAssemblyReference' and '%(ReferencePath.NuGetPackageId)' == ''" />
+    </ItemGroup>
+
+  </Target>
+
+  <Target
     Name="ResolveFrameworkReferencesDesignTime"
     Returns="@(ResolvedFrameworkReference)"
     DependsOnTargets="ResolveFrameworkReferences" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -50,7 +50,7 @@
   <!--
     Locate the appropriate localized xaml resources based on the language ID or name.
 
-    The logic here matches the resource manager sufficiently to handle the fixed set of 
+    The logic here matches the resource manager sufficiently to handle the fixed set of
     possible VS languages and directories on disk.
 
     We cannot respect the exact probe order of the resource manager as this has to evaluate statically
@@ -144,7 +144,7 @@
     ProjectSubscriptionService - Rules that are invisible except for purposes of programmatic subscribing to project data.
     Invisible                  - A special rule catalog for purposes of programmatic subscribing to project data.
     BrowseObject               - Rules that describe properties that appear in the Properties tool window while an item is selected in Solution Explorer.
-    ConfiguredBrowseObject     - Rules that describe configured project properties. This context currently only supports the Xaml rule to define 
+    ConfiguredBrowseObject     - Rules that describe configured project properties. This context currently only supports the Xaml rule to define
                                  configuration related project level properties.-->
 
   <!-- Common Project System rules that override rules defined in msbuild. These are exact copy of the rules defined in msbuild. -->
@@ -195,7 +195,7 @@
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)Resource.xaml">
       <Context>File</Context>
     </PropertyPageSchema>
-    
+
     <PropertyPageSchema Include="$(ManagedXamlNeutralResourcesDirectory)PackageVersion.xaml">
       <Context>File</Context>
     </PropertyPageSchema>
@@ -367,7 +367,7 @@
   </ItemGroup>
 
   <!--
-    EmbeddedFiles are source files to be embedded to the PDB. 
+    EmbeddedFiles are source files to be embedded to the PDB.
     We need to set Visible to false in order to not display duplicate entries in project UI.
   -->
   <ItemDefinitionGroup>
@@ -379,7 +379,7 @@
   <!-- Targets -->
 
   <!-- For a newly created project with no packages restored, Design time build complains that there is no ResolvePackageDependenciesDesignTime
-       target, that is available only after restoring the .Net Core SDK targets. This No-op target will satisfy the check and will get overriden
+       target, that is available only after restoring the .NET Core SDK targets. This No-op target will satisfy the check and will get overriden
        once the actual targets are available after package restore-->
   <Target Name="ResolvePackageDependenciesDesignTime" />
   <Target Name="CollectSDKReferencesDesignTime" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
@@ -25,7 +25,7 @@
                   SourceOfDefaultValue="AfterContext" />
     </StringListProperty.DataSource>
   </StringListProperty>
-  
+
   <StringProperty Name="BrowsePath"
                   ReadOnly="True"
                   Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Dependencies/ResolvedAssemblyReference.xaml
@@ -8,7 +8,7 @@
   <Rule.DataSource>
     <DataSource HasConfigurationCondition="False"
                 ItemType="Reference"
-                MSBuildTarget="ResolveAssemblyReferencesDesignTime"
+                MSBuildTarget="ResolveAssemblyReferencesDesignTime2"
                 Persistence="ResolvedReference"
                 SourceOfDefaultValue="AfterContext"
                 SourceType="TargetResults" />


### PR DESCRIPTION
Fixes #8952

Previously we used the `ResolveAssemblyReferencesDesignTime` target to obtain resolved assembly reference items, to help populate the "Assemblies" node of the "Dependencies" tree. These resolved items mark the unresolved `Reference` items as correctly resolved.

Any item in this target's output that does not match a `Reference` item is ignored.

It turns out that assemblies resolved from framework and package references were being included in this target's output, and then ignored by the only code that consumes them (the dependencies tree). For a .NET 7.0 project, this is ~160 items, each with 17 metadata name/value pairs. This data bloats the `ProjectInstance` and is retained by CPS in its snapshots.

This change creates a replacement for the MSBuild target within our own design-time targets that will filter those items out during the build, so they don't take up space and don't require any avoidable processing by the dependencies tree.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8953)