### PR TITLE
Work around empty build data snapshot bug

### DIFF
--- a/src/Common/BannedSymbols.txt
+++ b/src/Common/BannedSymbols.txt
@@ -99,6 +99,8 @@ M:System.Diagnostics.Debugger.Launch(); This should not be used in production co
 
 T:Microsoft.VisualStudio.ProjectSystem.ActiveConfiguredProject`1; Use IActiveConfiguredValue<T>, and handle when Value returns null.
 
+T:Microsoft.VisualStudio.ProjectSystem.IDataWithOriginalSource`1;Use ProjectRuleSnapshotExtensions.GetOrderedItems/TryGetOrderedItems instead.
+
 T:System.Runtime.Serialization.Formatters.Binary.BinaryFormatter;Use a preferred alternative: https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide#preferred-alternatives
 
 T:System.Composition.ImportAttribute; Use System.ComponentModel.Composition.ImportAttribute instead

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -427,12 +427,8 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
                 void SetContextCommandLine()
                 {
-                    var orderedSource = projectChange.After.Items as IDataWithOriginalSource<KeyValuePair<string, IImmutableDictionary<string, string>>>;
-
-                    Assumes.NotNull(orderedSource);
-
-                    // Pass command line to Roslyn
-                    Context.SetOptions(orderedSource.SourceData.Select(pair => pair.Key).ToImmutableArray());
+                    // Pass command line to Roslyn, preserving their original order.
+                    Context.SetOptions(projectChange.After.GetOrderedItems().Select(pair => pair.Key).ToImmutableArray());
                 }
 
                 void InvokeCommandLineUpdateHandlers()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -509,7 +509,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 var itemsByKindBySet = new Dictionary<string, Dictionary<string, HashSet<string>>>(BuildUpToDateCheck.SetNameComparer);
 
-                foreach ((string item, IImmutableDictionary<string, string> metadata) in TryGetOrderedData(projectChangeDescription.After.Items))
+                foreach ((string item, IImmutableDictionary<string, string> metadata) in projectChangeDescription.After.TryGetOrderedItems())
                 {
                     if (metadataPredicate is not null && !metadataPredicate(metadata))
                     {
@@ -538,17 +538,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                         pair => pair.Key,
                         pair => pair.Value.ToImmutableArray()),
                     BuildUpToDateCheck.SetNameComparer);
-
-                static IEnumerable<KeyValuePair<string, IImmutableDictionary<string, string>>> TryGetOrderedData(IImmutableDictionary<string, IImmutableDictionary<string, string>> items)
-                {
-                    if (items is IDataWithOriginalSource<KeyValuePair<string, IImmutableDictionary<string, string>>> dataWithOriginalSource)
-                        return dataWithOriginalSource.SourceData;
-
-                    // We couldn't obtain ordered items for some reason.
-                    // This is not a big problem, so just return the items in whatever order
-                    // the backing collection from CPS models them in.
-                    return items;
-                }
 
                 void AddItem(string setName, string kindName, string item)
                 {


### PR DESCRIPTION
Fixes [AB#1761872](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1761872)

CPS build data generally implements the `IDataWithOriginalSource<T>` interface, allowing us to obtain items in their actual order.

There is a bug in CPS where when a snapshot is empty, it might not implement this interface. We would assert that the interface was present and throw.

This change does two things:

1. Permit an empty snapshot to not implement this interface, which should work around the bug.
2. Ban direct use of the `IDataWithOriginalSource<T>` interface and require all use to go through one of two new extension methods that handle these scenarios properly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8956)