### PR TITLE
Use updated nameof

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -608,7 +608,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         /// <param name="unescaped">The string to escape.</param>
         /// <param name="toEscape">The characters to escape in the string.</param>
         /// <returns>The escaped string.</returns>
-        [return: NotNullIfNotNull("unescaped")]
+        [return: NotNullIfNotNull(nameof(unescaped))]
         internal static string? EscapeString(string? unescaped, char[] toEscape)
         {
             if (Strings.IsNullOrWhiteSpace(unescaped))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return result;
         }
 
-        [return: NotNullIfNotNull("text")]
+        [return: NotNullIfNotNull(nameof(text))]
         private static string? EscapeMnemonics(string? text)
         {
             return text?.Replace("&", "&&");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/ProjectRuleSnapshotExtensions.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// <summary>
         ///     Gets the value that is associated with the specified rule and property.
         /// </summary>
-        [return: NotNullIfNotNull(parameterName: "defaultValue")]
+        [return: NotNullIfNotNull(parameterName: nameof(defaultValue))]
         public static string? GetPropertyOrDefault(this IImmutableDictionary<string, IProjectRuleSnapshot> snapshots, string ruleName, string propertyName, string? defaultValue)
         {
             Requires.NotNull(snapshots);


### PR DESCRIPTION
A recent version of C# supports using nameof in attributes where the symbol is a parameter of the attributed method. This commit is an automated solution-wide fix of the diagnostic.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8958)