### PR TITLE
Debug subsystem tidying

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -31,8 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
                     return Task.FromResult(GetEnumeratorEnumValues(curSnapshot));
                 }
 
-                ICollection<IEnumValue> emptyCollection = new List<IEnumValue>();
-                return Task.FromResult(emptyCollection);
+                return Task.FromResult<ICollection<IEnumValue>>(Array.Empty<IEnumValue>());
             }, threadingService.JoinableTaskFactory);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
@@ -23,16 +22,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             Requires.NotNull(profileProvider);
             Requires.NotNull(threadingService);
 
-            _listedValues = new AsyncLazy<ICollection<IEnumValue>>(delegate
-            {
-                ILaunchSettings? curSnapshot = profileProvider.CurrentSnapshot;
-                if (curSnapshot is not null)
+            _listedValues = new AsyncLazy<ICollection<IEnumValue>>(
+                () =>
                 {
-                    return Task.FromResult(GetEnumeratorEnumValues(curSnapshot));
-                }
+                    ILaunchSettings? snapshot = profileProvider.CurrentSnapshot;
 
-                return Task.FromResult<ICollection<IEnumValue>>(Array.Empty<IEnumValue>());
-            }, threadingService.JoinableTaskFactory);
+                    ICollection<IEnumValue> values = snapshot is null
+                        ? Array.Empty<IEnumValue>()
+                        : GetEnumeratorEnumValues(snapshot);
+
+                    return Task.FromResult(values);
+                },
+                threadingService.JoinableTaskFactory);
         }
 
         public Task<ICollection<IEnumValue>> GetListedValuesAsync()
@@ -51,16 +52,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             .FirstOrDefault(v => LaunchProfile.IsSameProfileName(v.Name, userSuppliedValue));
         }
 
-        internal static ICollection<IEnumValue> GetEnumeratorEnumValues(ILaunchSettings launchSettings)
+        internal static ImmutableArray<IEnumValue> GetEnumeratorEnumValues(ILaunchSettings launchSettings)
         {
-            var result = new Collection<IEnumValue>(
-            (
-                from profile in launchSettings.Profiles
-                let value = new EnumValue { Name = profile.Name, DisplayName = EscapeMnemonics(profile.Name) }
-                select (IEnumValue)new PageEnumValue(value)).ToList()
-            );
+            ImmutableArray<IEnumValue>.Builder builder = ImmutableArray.CreateBuilder<IEnumValue>(initialCapacity: launchSettings.Profiles.Count);
 
-            return result;
+            builder.AddRange(launchSettings.Profiles.Select(ToEnumValue));
+
+            return builder.MoveToImmutable();
+
+            static IEnumValue ToEnumValue(ILaunchProfile profile)
+            {
+                var enumValue = new EnumValue { Name = profile.Name, DisplayName = EscapeMnemonics(profile.Name) };
+
+                return new PageEnumValue(enumValue);
+            }
         }
 
         [return: NotNullIfNotNull("text")]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -51,11 +51,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             .FirstOrDefault(v => LaunchProfile.IsSameProfileName(v.Name, userSuppliedValue));
         }
 
-        internal static ICollection<IEnumValue> GetEnumeratorEnumValues(ILaunchSettings profiles)
+        internal static ICollection<IEnumValue> GetEnumeratorEnumValues(ILaunchSettings launchSettings)
         {
             var result = new Collection<IEnumValue>(
             (
-                from profile in profiles.Profiles
+                from profile in launchSettings.Profiles
                 let value = new EnumValue { Name = profile.Name, DisplayName = EscapeMnemonics(profile.Name) }
                 select (IEnumValue)new PageEnumValue(value)).ToList()
             );

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -16,9 +16,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     {
         private readonly AsyncLazy<ICollection<IEnumValue>> _listedValues;
 
-        /// <summary>
-        /// Create a new instance of the class.
-        /// </summary>
         internal DebugProfileEnumValuesGenerator(
             ILaunchSettingsProvider profileProvider,
             IProjectThreadingService threadingService)
@@ -39,25 +36,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }, threadingService.JoinableTaskFactory);
         }
 
-        /// <summary>
-        /// See <see cref="IDynamicEnumValuesGenerator"/>
-        /// </summary>
         public Task<ICollection<IEnumValue>> GetListedValuesAsync()
         {
             return _listedValues.GetValueAsync();
         }
 
-        /// <summary>
-        /// See <see cref="IDynamicEnumValuesGenerator"/>
-        /// </summary>
         public bool AllowCustomValues
         {
             get { return false; }
         }
 
-        /// <summary>
-        /// See <see cref="IDynamicEnumValuesGenerator"/>
-        /// </summary>
         public async Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
         {
             return (await _listedValues.GetValueAsync())

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -48,8 +48,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         public async Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
         {
-            return (await _listedValues.GetValueAsync())
-            .FirstOrDefault(v => LaunchProfile.IsSameProfileName(v.Name, userSuppliedValue));
+            ICollection<IEnumValue> enumValues = await _listedValues.GetValueAsync();
+
+            return enumValues.FirstOrDefault(v => LaunchProfile.IsSameProfileName(v.Name, userSuppliedValue));
         }
 
         internal static ImmutableArray<IEnumValue> GetEnumeratorEnumValues(ILaunchSettings launchSettings)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -10,6 +10,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
     [ProjectSystemContract(ProjectSystemContractScope.UnconfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     public interface ILaunchSettingsProvider
     {
+        /// <summary>
+        /// Link to this source block to be notified when the snapshot is changed.
+        /// </summary>
         /// <remarks>
         /// If the <see cref="ILaunchSettings"/> provided by this block are going to feed
         /// into another data flow block, strongly consider using <see cref="IVersionedLaunchSettingsProvider"/>
@@ -17,11 +20,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         /// </remarks>
         IReceivableSourceBlock<ILaunchSettings> SourceBlock { get; }
 
+        /// <summary>
+        /// Gets the current launch settings snapshot, or <see langword="null"/> if it is not yet available.
+        /// </summary>
         ILaunchSettings? CurrentSnapshot { get; }
 
         [Obsolete("Use ILaunchSettingsProvider2.GetLaunchSettingsFilePathAsync instead.")]
         string LaunchSettingsFile { get; }
 
+        /// <summary>
+        /// Returns the active profile. Equivalent to <c>CurrentSnapshot?.ActiveProfile</c>.
+        /// </summary>
         ILaunchProfile? ActiveProfile { get; }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ILaunchSettingsProvider.cs
@@ -53,8 +53,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         /// <summary>
         /// Adds the given profile to the list and saves to disk. If a profile with the same
-        /// name exists (case sensitive), it will be replaced with the new profile. If addToFront is
-        /// true the profile will be the first one in the list. This is useful since quite often callers want
+        /// name exists (case sensitive), it will be replaced with the new profile. If <paramref name="addToFront"/> is
+        /// <see langword="true"/> the profile will be the first one in the list. This is useful since quite often callers want
         /// their just added profile to be listed first in the start menu.
         /// </summary>
         Task AddOrUpdateProfileAsync(ILaunchProfile profile, bool addToFront);
@@ -65,19 +65,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         Task RemoveProfileAsync(string profileName);
 
         /// <summary>
-        /// Adds or updates the global settings represented by settingName. Saves the
+        /// Adds or updates the global settings represented by <paramref name="settingName"/>. Saves the
         /// updated settings to disk. Note that the settings object must be serializable.
         /// </summary>
         Task AddOrUpdateGlobalSettingAsync(string settingName, object settingContent);
 
         /// <summary>
-        /// Removes the specified global setting and saves the settings to disk
+        /// Removes the specified global setting and saves the settings to disk.
         /// </summary>
         Task RemoveGlobalSettingAsync(string settingName);
 
         /// <summary>
-        /// Sets the active profile. This just sets the property it does not validate that the setting matches an
-        /// existing profile
+        /// Sets the active profile. This just sets the property; it does not validate that the setting matches an
+        /// existing profile.
         /// </summary>
         Task SetActiveProfileAsync(string profileName);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
@@ -178,5 +178,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         {
             return string.Equals(name1, name2, StringComparisons.LaunchProfileNames);
         }
+
+        public override string ToString()
+        {
+            return $"Name={Name ?? "<null>"}, Command={CommandName ?? "<null>"}";
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -167,7 +167,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
         /// <summary>
         /// The LaunchSettingsProvider sinks 2 sets of information:
-        /// 1. Changes to the launchsettings.json file on disk
+        /// 1. Changes to the launchSettings.json file on disk
         /// 2. Changes to the ActiveDebugProfile property in the .user file
         /// </summary>
         protected override void Initialize()
@@ -465,7 +465,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Helper to check out the debugsettings.json file
+        /// Helper to check out the launchSettings.json file.
         /// </summary>
         protected async Task CheckoutSettingsFileAsync()
         {
@@ -905,7 +905,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         }
 
         /// <summary>
-        /// Helper retrieves the current snapshot and if there were errors in the launchsettings.json file
+        /// Helper retrieves the current snapshot and if there were errors in the launchSettings.json file
         /// or there isn't a snapshot, it throws an error. There should always be a snapshot of some kind returned.
         /// </summary>
         private async Task<ILaunchSettings> GetSnapshotThrowIfErrorsAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -119,15 +119,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Obsolete("Use GetLaunchSettingsFilePathAsync instead.")]
         public string LaunchSettingsFile => _commonProjectServices.ThreadingService.ExecuteSynchronously(GetLaunchSettingsFilePathAsync);
 
-        /// <summary>
-        /// Returns the active profile. Looks up the value of the ActiveProfile property. If the value doesn't match the
-        /// any of the profiles, the first one is returned
-        /// </summary>
         public ILaunchProfile? ActiveProfile => CurrentSnapshot?.ActiveProfile;
 
-        /// <summary>
-        /// Link to this source block to be notified when the snapshot is changed.
-        /// </summary>
         IReceivableSourceBlock<ILaunchSettings> ILaunchSettingsProvider.SourceBlock
         {
             get
@@ -137,10 +130,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             }
         }
 
-        /// <summary>
-        /// IDebugProfileProvider
-        /// Access to the current set of profile information
-        /// </summary>
         public ILaunchSettings CurrentSnapshot
         {
             get


### PR DESCRIPTION
Some refactoring and tidy ups made while watching the showcase.

The biggest change here is the simplification of the dataflow source in [DebugProfileDebugTargetGenerator](https://github.com/dotnet/project-system/commit/c5c1c533a9a25a5dc0f8dc04bda72d6224597060), which deletes a bunch of code and avoids registering the data source.

Other than that, reduced allocations, improved docs, formatting.

Easiest to review commit-by-commit.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8959)