### PR TITLE
Update version number when tagging PRs.

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -107,7 +107,7 @@
           {
             "name": "addMilestone",
             "parameters": {
-              "milestoneName": "17.6"
+              "milestoneName": "17.7"
             }
           }
         ],

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.6",
+  "version": "17.7",
   "cloudBuild": {
     "setAllVariables": true
   }


### PR DESCRIPTION
Noticed we are tagging merged PRs as 17.6 with the msftbot.
This updates it to tag it as 17.7; it also updates our version.json file.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8965)