### PR TITLE
Minor fixes in TargetFramework validation.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -213,7 +213,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return targetFrameworkAlias;
         }
 
-        private static bool IsNetCore5OrHigher(string? targetFrameworkAlias)
+        private static bool IsNetCore5OrHigher(string targetFrameworkAlias)
         {
             // Ideally, we want to use the TargetFrameworkIdentifier and TargetFrameworkVersion;
             // however, in this case the target framework properties we have are for the currently set value,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -336,6 +336,9 @@
 
   <BoolProperty Name="UseWindowsForms"
                 Visible="False" />
+  
+  <BoolProperty Name="UseWinUI"
+                Visible="False" />
 
   <BoolProperty Name="UseWPF"
                 Visible="False" />


### PR DESCRIPTION
Fixes #8931 and [AB#1430819](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1430819). 

This PR:
- Parses the `TargetFrameworkAlias` property into a double and check if it's higher than 5.0 (instead of doing a string comparison).
- Includes the `UseWinUI` property when validating when to add the `-windows` platform value to the `TargetFramework` value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8968)