### PR TITLE
Refine regex flags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/IVsHierarchyItemExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
         /// <returns><see langword="true"/> if the target was found, otherwise <see langword="false"/>.</returns>
         public static bool TryFindTarget(this IVsHierarchyItem item, [NotNullWhen(returnValue: true)] out string? target)
         {
-            s_targetFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.TargetNode) + @"\b)(?=.*\$TFM:(?<target>[^ ]+)\b).*$", RegexOptions.Compiled);
+            s_targetFlagsRegex ??= new Regex(@"^(?=.*\b" + nameof(DependencyTreeFlags.TargetNode) + @"\b)(?=.*\$TFM:(?<target>[^ ]+)\b).*$", RegexOptions.Compiled | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant);
 
             for (IVsHierarchyItem? parent = item; parent is not null; parent = parent.Parent)
             {


### PR DESCRIPTION
Adds two `RegexOptions` flags to a `Regex` instance:

1. **Only capture explicit groups in regex**
   We only need to read out our named group. Capturing data about other groups is wasteful. https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options#explicit-captures-only

2. **Match with invariant culture**
   For this pattern we do not need to take cultures into account when matching. https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options#compare-using-the-invariant-culture

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8970)