### PR TITLE
Add VS Extension Project items to UpToDate check mechanism

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -87,6 +87,7 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9FBD7EF2-9449-486D-9FDD-FA56160AA8BB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{19725D6F-4690-412B-934A-FC48D752B802}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -115,6 +116,7 @@ Global
 		{469B50E9-FE67-459E-8AFA-44CBE523DBF6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49705330-A4F5-47EA-BB10-3B783CE91AEA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{369DCA0F-A079-4D0C-8B32-53879199B681}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/docs/up-to-date-check.md
+++ b/docs/up-to-date-check.md
@@ -45,6 +45,12 @@ Note that changes to inputs **must** result in changes to outputs. If this rule 
 have a timestamp after all outputs, which leads the up-to-date check to consider the project out-of-date after building
 indefinitely. This can lead to longer build times.
 
+For the targets above, you can update the `DependsOn` attribute by setting these properties respectively:
+
+- `CollectUpToDateCheckInputDesignTimeDependsOn`
+- `CollectUpToDateCheckOutputDesignTimeDependsOn`
+- `CollectUpToDateCheckBuiltDesignTimeDependsOn`
+
 ### Grouping inputs and outputs into sets
 
 For some advanced scenarios, it's necessary to partition inputs and outputs into groups and consider each separately.

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -40,4 +40,25 @@
     <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
   </Target>
 
+  <!--
+    The properties and targets below will add the VSIXSourceItems (files that go in the VSIX) and the VSIX file itself to the item group that tracks when files are up-to-date.
+    This ensures that these files are recognized in VS to force the VS Extension Project to build when the files are changed, such as prior to debugging.
+  -->
+  <PropertyGroup Condition="'$(IsVsixProject)' == 'true'">
+    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);AddUpToDateCheckVSIXSourceItems</CollectUpToDateCheckInputDesignTimeDependsOn>
+    <CollectUpToDateCheckOutputDesignTimeDependsOn>$(CollectUpToDateCheckOutputDesignTimeDependsOn);AddUpToDateCheckTargetVsixContainer</CollectUpToDateCheckOutputDesignTimeDependsOn>
+  </PropertyGroup>
+
+  <Target Name="AddUpToDateCheckVSIXSourceItems" DependsOnTargets="GetVsixSourceItems" Condition="'$(IsVsixProject)' == 'true'">
+    <ItemGroup>
+      <UpToDateCheckInput Include="@(VSIXSourceItem)" Set="VsixItems" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AddUpToDateCheckTargetVsixContainer" Condition="'$(IsVsixProject)' == 'true'">
+    <ItemGroup>
+      <UpToDateCheckOutput Include="$(TargetVsixContainer)" Set="VsixItems" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -437,7 +437,7 @@
   <!-- This target collects all the resolved references that are used to actually compile. -->
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(CollectUpToDateCheckInputDesignTimeDependsOn)' == ''">
     <CollectUpToDateCheckInputDesignTimeDependsOn>CompileDesignTime</CollectUpToDateCheckInputDesignTimeDependsOn>
     <!-- F# projects do not have the ResolveCodeAnalysisRuleSet target. -->
     <CollectUpToDateCheckInputDesignTimeDependsOn Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'">$(CollectUpToDateCheckInputDesignTimeDependsOn);ResolveCodeAnalysisRuleSet</CollectUpToDateCheckInputDesignTimeDependsOn>
@@ -453,12 +453,20 @@
     </ItemGroup>
   </Target>
 
-  <!-- This target collects all the extra outputs for the up to date check. -->
-  <Target Name="CollectUpToDateCheckOutputDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckOutput)" />
+  <PropertyGroup Condition="'$(CollectUpToDateCheckOutputDesignTimeDependsOn)' == ''">
+    <CollectUpToDateCheckOutputDesignTimeDependsOn>CompileDesignTime</CollectUpToDateCheckOutputDesignTimeDependsOn>
+  </PropertyGroup>
 
+  <!-- This target collects all the extra outputs for the up to date check. -->
+  <Target Name="CollectUpToDateCheckOutputDesignTime" DependsOnTargets="$(CollectUpToDateCheckOutputDesignTimeDependsOn)" Returns="@(UpToDateCheckOutput)" />
+
+  <PropertyGroup Condition="'$(CollectUpToDateCheckBuiltDesignTimeDependsOn)' == ''">
+    <CollectUpToDateCheckBuiltDesignTimeDependsOn>CompileDesignTime</CollectUpToDateCheckBuiltDesignTimeDependsOn>
+  </PropertyGroup>
+ 
   <!-- This target collects all the things built by the project for the up to date check. -->
   <!-- See CopyFileToOutputDirectory target -->
-  <Target Name="CollectUpToDateCheckBuiltDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(UpToDateCheckBuilt)">
+  <Target Name="CollectUpToDateCheckBuiltDesignTime" DependsOnTargets="$(CollectUpToDateCheckBuiltDesignTimeDependsOn)" Returns="@(UpToDateCheckBuilt)">
     <ItemGroup>
       <!-- Assembly output, bin and obj -->
       <UpToDateCheckBuilt Condition="'$(CopyBuildOutputToOutputDirectory)' != 'false' and '$(SkipCopyBuildProduct)' != 'true'" Include="$(TargetPath)" />


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/8912

## Description
The scenario being addressed here is when you make a change in our product code and then attempted to debug in Visual Studio. Without telling the things to explicitly build, it would not build our *Setup* projects (`ProjectSystemSetup`/`VisualStudioEditorsSetup`). Therefore, it wasn't creating or deploying a new VSIX package into the experimental hive and your changes were not present there.

## Solution
After investigation with Drew, it was determined that the inputs into the VSIX and the package itself needed to be tracked as UpToDate items. The changes to get this working properly:
- Updated `Microsoft.Managed.DesignTime.targets` to allow changing the defined `DependsOn` for the targets that collect the UpToDate items
- Added targets for adding `@(VSIXSourceItem)` to UpToDate inputs and `$(TargetVsixContainer)` to UpToDate outputs
  - **Note**: We are doing this within our repo, but these changes should be added to the VsSDK directly.
- Added the `Deploy` target to our solution configuration for the *Setup* projects

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8977)