### PR TITLE
Localization: Reuse existing PR if available

### DIFF
--- a/eng/pipelines/templates/generate-localization.yml
+++ b/eng/pipelines/templates/generate-localization.yml
@@ -41,6 +41,7 @@ jobs:
       patVariable: $(dn-bot-ceapex-package-r)
       isCreatePrSelected: true
       isAutoCompletePrSelected: false
+      isShouldReusePrSelected: true
 
   ###################################################################################################################################################################
   # PUBLISH ARTIFACTS

--- a/eng/pipelines/templates/generate-localization.yml
+++ b/eng/pipelines/templates/generate-localization.yml
@@ -27,6 +27,7 @@ jobs:
 
   # Runs the localization process on the resource files provided within LocProject.json.
   # Details for the process can be found here: https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task
+  # YAML reference: https://dev.azure.com/ceapex/CEINTL/_git/OneLocBuild?_a=contents&version=GBmain&path=/src/OneLocBuildTaskExtension/OneLocBuildTask/task.json
   - task: OneLocBuild@2
     displayName: Run OneLocBuild
     inputs:


### PR DESCRIPTION
This allows the OneLocBuild task to automatically reused existing localization PRs instead of continually creating new ones. Communication about this flag was sent out on 10/25/2021, but I misunderstood the communication around it, believing it was an Arcade-only feature. My bad.

Reference of change in Arcade: https://github.com/dotnet/arcade/pull/8095/files