### PR TITLE
Fix SBOM file conflict issue

### DIFF
--- a/setup/Directory.Build.props
+++ b/setup/Directory.Build.props
@@ -26,7 +26,12 @@
     <SBOMFileDestPath>$(VisualStudioSetupInsertionPath)</SBOMFileDestPath>
     <!-- MicroBuild.Plugins.Sbom.targets uses this to set the output path (ManifestDirPath) for the GenerateSBOM target. -->
     <!-- This output, if not separated by a project-specific folder, can hit file conflicts ("manifest.json is being used by another process") because both VSIX extension projects can build in parallel. -->
-    <SbomManifestDirPath>$(OutputPath)Sbom\$(MSBuildProjectName)\</SbomManifestDirPath>
+    <!--
+      Additionally, the SbomBuildDropPath (input directory) is specified as the TargetDir, which is the OutputPath of the projects.
+      If we put this content in the OutputPath, if two GenerateSbom tasks are running at the same time (one per project), we'll also get file conflict issues in accessing the manifest.json, since it is in a sub-directory of the input content.
+      To avoid this issue, we'll put the Sbom directory at the base-level bin directory.
+    -->
+    <SbomManifestDirPath>$(ArtifactsBinDir)Sbom\$(MSBuildProjectName)\</SbomManifestDirPath>
 
     <VsixSourceManifestPath>$(MSBuildProjectDirectory)\source.extension.vsixmanifest</VsixSourceManifestPath>
     <!-- This property indicates that the project is a VS Extension project. The SwixBuild plugin expects this value to be set for the AddSBOM task. -->


### PR DESCRIPTION
### Summary
There is an intermittent build issue where the build fails because SBOM generation fails. The output looks like this:

![image](https://user-images.githubusercontent.com/17788297/233750001-fd3bcb2f-bce8-4135-9dd6-b050545aabe5.png)

From [this build](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7665662&view=logs&j=3de96e8d-b8d1-5108-47b8-f6a54739db67&t=a16cdda0-c78c-5fd9-f5e9-cb04cb362077), looking at the binlog reveals that each `GenerateSbom` task for the 2 projects (`ProjectSystemSetup` and `VisualStudioEditorsSetup`) references the other one's SBOM manifest file. Meaning, the one project's SBOM generation was trying to access the other project's SBOM file while it is being generated.

To remedy this, I moved the SBOM generation up a directory (to the `bin` folder instead of `bin\Dlls`) so that the output of `GenerateSbom` isn't consumed as part of that task for any project generating an SBOM. It looks like this now:

![image](https://user-images.githubusercontent.com/17788297/233749837-960dae71-6778-4e93-8cbb-f101d7a09afb.png)

### Test Build
https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=7666758&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8985)