### PR TITLE
Add NuGetAudit properties to NuGet nominations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -53,6 +53,14 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="NuGetAudit"
+                  ReadOnly="True"
+                  Visible="False" />
+
+  <StringProperty Name="NuGetAuditLevel"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="NuGetLockFilePath"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
NuGet recently added a feature to warn about packages with known vulerabilities on restore. We need two more project properties for this feature to work.

NuGet.Client feature implementation: https://github.com/NuGet/NuGet.Client/pull/5136
Feature spec: https://github.com/NuGet/Home/blob/dev/proposed/2022/vulnerabilities-in-restore.md

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8988)