### PR TITLE
Add new ExcludedAssetsFlow metadata for asset control

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPackageReference.xaml
@@ -65,4 +65,7 @@
                 ReadOnly="True"
                 Visible="False" />
 
+  <BoolProperty Name="ExcludedAssetsFlow"
+                ReadOnly="true"
+                Visible="false" />
 </Rule>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/project-system/issues/8989

Needed for https://github.com/NuGet/NuGet.Client/pull/4976, spec is [here](https://github.com/NuGet/Home/blob/1af7f2779f52f1f22e4858bdeaa25f9623cf94c8/proposed/2022/PrivateAssetIndepdentFromExcludeAsset.md).

We're going to add new optional metadata `ExcludedAssetsFlow`, allowed values are incase sensitive `true`, `false`.

For example:
Not included: `<PackageReference Include="PackageA" />`
Included set false:`<PackageReference Include="PackageA" ExcludedAssetsFlow="false"/>`
Included set true: `<PackageReference Include="PackageA" PrivateAssets="Runtime;Compile" ExcludedAssetsFlow="true" IncludeAssets = "none"/>`

Technically first 2 are same thing, but for 3rd case we do additional calculation.

