### PR TITLE
Fix FUTDC solution cache population for DevBox

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
@@ -9,36 +9,54 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     [Export(typeof(IUpToDateCheckHost))]
     internal sealed class UpToDateCheckHost : IUpToDateCheckHost
     {
-        private readonly IVsUIService<SVsShell, IVsShell> _vsShell;
+        private readonly IVsUIService<IVsShell> _vsShell;
+        private readonly IVsUIService<IVsAppCommandLine> _vsAppCommandLine;
         private readonly JoinableTaskContext _joinableTaskContext;
 
         private bool? _hasDesignTimeBuild;
 
         [ImportingConstructor]
-        public UpToDateCheckHost(IVsUIService<SVsShell, IVsShell> vsShell, JoinableTaskContext joinableTaskContext)
+        public UpToDateCheckHost(IVsUIService<SVsShell, IVsShell> vsShell, IVsUIService<SVsAppCommandLine, IVsAppCommandLine> vsAppCommandLine, JoinableTaskContext joinableTaskContext)
         {
             _vsShell = vsShell;
+            _vsAppCommandLine = vsAppCommandLine;
             _joinableTaskContext = joinableTaskContext;
         }
 
         public async ValueTask<bool> HasDesignTimeBuildsAsync(CancellationToken cancellationToken)
         {
-            if (_hasDesignTimeBuild is null)
+            _hasDesignTimeBuild ??= await ComputeValueAsync();
+
+            return _hasDesignTimeBuild.Value;
+
+            async ValueTask<bool> ComputeValueAsync()
             {
                 await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
 
-                // If VS is running in command line mode, design-time builds do not occur
-                if (ErrorHandler.Succeeded(_vsShell.Value.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object resultObj)) && resultObj is bool result)
+                if (ErrorHandler.Succeeded(_vsAppCommandLine.Value.GetOption("populateSolutionCache", out int populateSolutionCachePresent, out string _)))
                 {
-                    _hasDesignTimeBuild = !result;
+                    if (populateSolutionCachePresent != 0)
+                    {
+                        // Design time builds are available when running with /populateSolutionCache.
+                        return true;
+                    }
                 }
-                else
-                {
-                    _hasDesignTimeBuild = false;
-                }
-            }
 
-            return _hasDesignTimeBuild.Value;
+                if (ErrorHandler.Succeeded(_vsShell.Value.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object value)))
+                {
+                    if (value is bool isInCommandLineMode)
+                    {
+                        // Design-time builds do not occur in command line mode, other than with /populateSolutionCache (checked earlier).
+                        return !isInCommandLineMode;
+                    }
+                }
+
+                // We shouldn't reach this point.
+                System.Diagnostics.Debug.Fail($"{nameof(UpToDateCheckHost)}.{nameof(HasDesignTimeBuildsAsync)} was unable to determine result reliably.");
+
+                // Assume we don't have design-time builds, to prevent hangs from waiting for snapshot data that will never arrive.
+                return false;
+            }
         }
     }
 }


### PR DESCRIPTION
When running `devenv <sln> /populateSolutionCache /build`, the FUTDC should produce its cache file such that the first build using the generated caches is considered up-to-date.

The FUTDC has historically disabled itself when running in command line mode. Historically command line mode has not run any design-time builds, and therefore no FUTDC snapshot data becomes available. The FUTDC would avoid waiting for snapshots when it detected command line mode is active.

Solution cache population is now an exception to this. It's a form of command line mode for where design-time builds do run, and for which we do want the FUTDC to run in full.

This change teaches the `UpToDateCheckHost.HasDesignTimeBuildsAsync` method about the `/populateSolutionCache` command line argument, so that the `.futdcache.v2` file is correctly populated in this mode.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8992)