### PR TITLE
Fix early signalling of loaded state

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _solutionService = solutionService;
         }
 
-        [ProjectAutoLoad(completeBy: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
+        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectFactoryCompleted)]
         [AppliesTo(ProjectCapability.DotNet)]
         public Task OnProjectFactoryCompleted()
         {


### PR DESCRIPTION
Fixes [AB#1810458](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1810458)

(Thanks @lifengl for reporting this issue.)

Our `UnconfiguredProjectTasksService` class listens for project factory completion and signals this to other components that may wait on that status.

The class uses `[ProjectAutoLoad]` to receive this notification from CPS, however it was asking to be notified _before_ the project factory completed rather than _after_.

One identified consequence of this is that the `SDKVersionTelemetryServiceComponent` class would wake up earlier than intended, request `ActiveConfiguredProjectProperties`, then immediately block. This makes a thread-pool thread unavailable for other productive work during project/solution load.

The fix here is to modify the `[ProjectAutoLoad]` registration so we are notified _after_ the project factory completes.

I've reviewed components impacted by this change and believe the change to be safe.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8993)