### PR TITLE
Make load event checkpoint explicit

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsLoader.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             _targetBlock = DataflowBlockFactory.CreateActionBlock<IProjectVersionedValue<IConfigurationGroup<ProjectConfiguration>>>(OnActiveConfigurationsChangedAsync, project, ProjectFaultSeverity.LimitedFunctionality);
         }
 
-        [ProjectAutoLoad(ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
+        [ProjectAutoLoad(startAfter: ProjectLoadCheckpoint.ProjectInitialCapabilitiesEstablished)]
         // NOTE we use the language service capability here to prevent loading configurations of shared projects.
         [AppliesTo(ProjectCapability.DotNetLanguageService)]
         public Task InitializeAsync()


### PR DESCRIPTION
While investigating #8993 I noticed this instance was not made explicit. Making it so helps avoid confusion about when this will be called.

There's no change in behaviour here.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8994)