### PR TITLE
Validate that value is an integer or empty.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -320,7 +320,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
             else if (propertyName == MinimumSplashScreenDisplayTime)
             {
-                if (int.TryParse(unevaluatedPropertyValue, out int value))
+                if (short.TryParse(unevaluatedPropertyValue, out short value))
                 {
                     if (value < 0)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -318,6 +318,27 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     _ => unevaluatedPropertyValue
                 };
             }
+            else if (propertyName == MinimumSplashScreenDisplayTime)
+            {
+                if (int.TryParse(unevaluatedPropertyValue, out int value))
+                {
+                    if (value < 0)
+                    {
+                        // Convert negative value to positive.
+                        unevaluatedPropertyValue = (-value).ToString();
+                    }
+                }
+                else
+                {
+                    if (string.IsNullOrEmpty(unevaluatedPropertyValue))
+                    {
+                        // If we get an empty string, we just want to clear the value.
+                        await _myAppXmlFileAccessor.SetMinimumSplashScreenDisplayTimeAsync(null);
+                    }
+
+                    return null;
+                }
+            }
 
             await (propertyName switch 
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppDocument.cs
@@ -27,12 +27,15 @@ internal class MyAppDocument
         return element.Value;
     }
 
-    public void SetProperty(string propertyName, string propertyValue)
+    public void SetProperty(string propertyName, string? propertyValue)
     {
         XElement element = _doc.Root.Element(propertyName);
 
         if (element is not null)
+        {
+            propertyValue ??= string.Empty;
             element.Value = propertyValue;
+        }
         else
         {
             element = new XElement(propertyName, propertyValue);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -176,5 +176,5 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
 
     public async Task<int?> GetMinimumSplashScreenDisplayTimeAsync() => await GetIntPropertyValueAsync(MinimumSplashScreenDisplayTimeProperty);
 
-    public async Task SetMinimumSplashScreenDisplayTimeAsync(int value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value.ToString());
+    public async Task SetMinimumSplashScreenDisplayTimeAsync(int? value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value.ToString());
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -176,5 +176,5 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
 
     public async Task<int?> GetMinimumSplashScreenDisplayTimeAsync() => await GetIntPropertyValueAsync(MinimumSplashScreenDisplayTimeProperty);
 
-    public async Task SetMinimumSplashScreenDisplayTimeAsync(int? value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value.ToString());
+    public async Task SetMinimumSplashScreenDisplayTimeAsync(int? value) => await SetPropertyAsync(MinimumSplashScreenDisplayTimeProperty, value?.ToString());
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/MyAppFileAccessor.cs
@@ -103,7 +103,7 @@ internal class MyAppFileAccessor : IMyAppFileAccessor, IDisposable
         return _myAppDocument;
     }
 
-    private async Task SetPropertyAsync(string propertyName, string value)
+    private async Task SetPropertyAsync(string propertyName, string? value)
     {
         MyAppDocument? myAppDocument = await TryGetMyAppFileAsync();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -2,7 +2,10 @@
 <!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
 <Rule Name="Application"
       OverrideMode="Extend"
-      xmlns="http://schemas.microsoft.com/build/2009/properties">
+      xmlns="http://schemas.microsoft.com/build/2009/properties"
+      xmlns:xliff="https://github.com/dotnet/xliff-tasks"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      mc:Ignorable="xliff">
 
   <Rule.Categories>
     <Category Name="ApplicationFramework"
@@ -250,7 +253,7 @@
       <ValueEditor EditorType="String">
         <ValueEditor.Metadata>
           <NameValuePair Name="EvaluatedValueValidationRegex" Value="^\d*$" />
-          <NameValuePair Name="EvaluatedValueFailedValidationMessage" Value="This property must be an integer number." />
+          <NameValuePair Name="EvaluatedValueFailedValidationMessage" Value="This property must be an integer number." xliff:LocalizedProperties="Value" />
         </ValueEditor.Metadata>
       </ValueEditor>
     </StringProperty.ValueEditors>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -246,6 +246,14 @@
         </NameValuePair.Value>
       </NameValuePair>
     </StringProperty.Metadata>
+    <StringProperty.ValueEditors>
+      <ValueEditor EditorType="String">
+        <ValueEditor.Metadata>
+          <NameValuePair Name="EvaluatedValueValidationRegex" Value="^\d*$" />
+          <NameValuePair Name="EvaluatedValueFailedValidationMessage" Value="This property must be an integer number." />
+        </ValueEditor.Metadata>
+      </ValueEditor>
+    </StringProperty.ValueEditors>
   </StringProperty>
 
   <DynamicEnumProperty Name="StartupURI"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Minimální doba zobrazení úvodní obrazovky</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Minimale Anzeigezeit für Begrüßungsbildschirm</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Tiempo mínimo de visualización de la pantalla de presentación</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Durée minimale d’affichage de l’écran de démarrage</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Tempo minimo di visualizzazione della schermata iniziale</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -217,6 +217,11 @@
         <target state="translated">スプラッシュス クリーンの最短表示時間</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -217,6 +217,11 @@
         <target state="translated">최소 시작 화면 표시 시간</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Minimalny czas wyświetlania ekranu powitalnego</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Tempo mínimo de exibição da tela inicial</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Минимальное время отображения экрана-заставки</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -217,6 +217,11 @@
         <target state="translated">Giriş ekranı görüntüleme süresi alt sınırı</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -217,6 +217,11 @@
         <target state="translated">最短初始屏幕显示时间</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -217,6 +217,11 @@
         <target state="translated">啟動顯示畫面顯示時間下限</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|MinimumSplashScreenDisplayTime|ValueEditors|ValueEditor|Metadata|EvaluatedValueFailedValidationMessage|Value">
+        <source>This property must be an integer number.</source>
+        <target state="new">This property must be an integer number.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/WinForms/IMyAppFileAccessor.cs
@@ -106,5 +106,5 @@ internal interface IMyAppFileAccessor
     /// <summary>
     /// Sets the current value of property in the myapp file.
     /// </summary>
-    Task SetMinimumSplashScreenDisplayTimeAsync(int minimumSplashScreenDisplayTime);
+    Task SetMinimumSplashScreenDisplayTimeAsync(int? minimumSplashScreenDisplayTime);
 }


### PR DESCRIPTION
Fixes [AB#1803253](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1803253).

This PR adds a validation to the `MinimumSplashScreenDisplayTime` property is an integer or is empty. It uses the `ValueEditor` to opt into value validation, and if it fails it shows the validation message.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8995)