### PR TITLE
Add NuGet retry for PR build

### DIFF
--- a/eng/pipelines/templates/build-pull-request.yml
+++ b/eng/pipelines/templates/build-pull-request.yml
@@ -21,6 +21,12 @@ jobs:
   # Runs the full build of the projects in the repository. See Build.proj for details.
   - script: $(Build.SourcesDirectory)/build.cmd /v:normal /p:Configuration=$(BuildConfiguration) /p:CIBuild=true
     displayName: Build All Projects
+    env:
+      # This allows NuGet to retry in situations related to "automatic retry for untrusted root failures."
+      # We are experiencing issues with NuGet package restoration stating, "The author primary signature validity period has expired."
+      # Details on this issue can be found here: https://github.com/dotnet/arcade/issues/13070
+      # Variable reference: https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu3028#retry-untrusted-root-failures
+      NUGET_EXPERIMENTAL_CHAIN_BUILD_RETRY_POLICY: 3,1000
 
   ###################################################################################################################################################################
   # PUBLISH BUILD

--- a/eng/scripts/GetInsertionPRDescription.ps1
+++ b/eng/scripts/GetInsertionPRDescription.ps1
@@ -61,7 +61,7 @@ if(-Not $previousShaShort -or $previousShaShort -eq $currentShaShort)
   {
     $description += 'Previous VS insertion commit is the same as current.'
     $description += ''
-    $description += 'THIS INSERTION CAN BE SAFELY ABORTED.'
+    $description += 'THIS INSERTION CAN BE SAFELY ABANDONED.'
   }
 
   Write-Host "=== DESCRIPTION ===$([Environment]::Newline)$([Environment]::Newline)$($description -join [Environment]::Newline)"


### PR DESCRIPTION
This is the same fix as done in this PR: https://github.com/dotnet/project-system/pull/8983

- Adds the NuGet retry environment variable for PR build pipeline
  - Linked PR above was for the Official build pipeline
- Minor word change on insertion description condition
  - More accurate to use "abandon" since that is the name of the state used in AzDO

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/8999)