### PR TITLE
Replace OutputTypeChecker with IOutputTypeChecker

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         private readonly IRemoteDebuggerAuthenticationService _remoteDebuggerAuthenticationService;
         private readonly Lazy<IProjectHotReloadSessionManager> _hotReloadSessionManager;
         private readonly Lazy<IHotReloadOptionService> _debuggerSettings;
-        private readonly OutputTypeChecker _outputTypeChecker;
+        private readonly IOutputTypeChecker _outputTypeChecker;
 
         [ImportingConstructor]
         public ProjectLaunchTargetsProvider(
@@ -53,7 +53,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IFileSystem fileSystem,
             IEnvironmentHelper environment,
             IActiveDebugFrameworkServices activeDebugFramework,
-            ProjectProperties properties,
+            IOutputTypeChecker outputTypeChecker,
             IProjectThreadingService threadingService,
             IVsUIService<SVsShellDebugger, IVsDebugger10> debugger,
             IRemoteDebuggerAuthenticationService remoteDebuggerAuthenticationService,
@@ -66,13 +66,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             _fileSystem = fileSystem;
             _environment = environment;
             _activeDebugFramework = activeDebugFramework;
+            _outputTypeChecker = outputTypeChecker;
             _threadingService = threadingService;
             _debugger = debugger;
             _remoteDebuggerAuthenticationService = remoteDebuggerAuthenticationService;
             _hotReloadSessionManager = hotReloadSessionManager;
             _debuggerSettings = debuggerSettings;
-
-            _outputTypeChecker = new OutputTypeChecker(properties);
         }
 
         private Task<ConfiguredProject?> GetConfiguredProjectForDebugAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IOutputTypeChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IOutputTypeChecker.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Debug;
+
+/// <summary>
+/// A helper to simplify checking if a project produces a library or executable.
+/// </summary>
+[ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
+internal interface IOutputTypeChecker
+{
+    /// <summary>
+    /// Returns <see langword="true"/> if the project produces a library (e.g. a .dll), and <see langword="false"/>
+    /// otherwise.
+    /// </summary>
+    Task<bool> IsConsoleAsync();
+
+    /// <summary>
+    /// Returns <see langword="true"/> if the project produces an executable (e.g. a .exe), and <see langword="false"/>
+    /// otherwise.
+    /// </summary>
+    Task<bool> IsLibraryAsync();
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/OutputTypeChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/OutputTypeChecker.cs
@@ -2,37 +2,36 @@
 
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
-namespace Microsoft.VisualStudio.ProjectSystem.Debug
+namespace Microsoft.VisualStudio.ProjectSystem.Debug;
+
+internal class OutputTypeChecker
 {
-    internal class OutputTypeChecker
+    private readonly ProjectProperties _properties;
+
+    public OutputTypeChecker(ProjectProperties properties)
     {
-        private readonly ProjectProperties _properties;
+        _properties = properties;
+    }
 
-        public OutputTypeChecker(ProjectProperties properties)
-        {
-            _properties = properties;
-        }
+    public Task<bool> IsLibraryAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Library);
 
-        public Task<bool> IsLibraryAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Library);
+    public Task<bool> IsConsoleAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Exe);
 
-        public Task<bool> IsConsoleAsync() => IsOutputTypeAsync(ConfigurationGeneral.OutputTypeValues.Exe);
+    public async Task<bool> IsOutputTypeAsync(string outputType)
+    {
+        IEnumValue? actualOutputType = await GetEvaluatedOutputTypeAsync();
 
-        public async Task<bool> IsOutputTypeAsync(string outputType)
-        {
-            IEnumValue? actualOutputType = await GetEvaluatedOutputTypeAsync();
+        return actualOutputType is not null && StringComparers.PropertyLiteralValues.Equals(actualOutputType.Name, outputType);
+    }
 
-            return actualOutputType is not null && StringComparers.PropertyLiteralValues.Equals(actualOutputType.Name, outputType);
-        }
+    public virtual async Task<IEnumValue?> GetEvaluatedOutputTypeAsync()
+    {
+        // Used by default Windows debugger to figure out whether to add an extra
+        // pause to end of window when CTRL+F5'ing a console application
+        ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
 
-        public virtual async Task<IEnumValue?> GetEvaluatedOutputTypeAsync()
-        {
-            // Used by default Windows debugger to figure out whether to add an extra
-            // pause to end of window when CTRL+F5'ing a console application
-            ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
+        var actualOutputType = (IEnumValue?)await configuration.OutputType.GetValueAsync();
 
-            var actualOutputType = (IEnumValue?)await configuration.OutputType.GetValueAsync();
-
-            return actualOutputType;
-        }
+        return actualOutputType;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/OutputTypeChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/OutputTypeChecker.cs
@@ -4,10 +4,13 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug;
 
-internal class OutputTypeChecker
+[Export(typeof(IOutputTypeChecker))]
+[AppliesTo(ProjectCapability.DotNet)]
+internal class OutputTypeChecker : IOutputTypeChecker
 {
     private readonly ProjectProperties _properties;
 
+    [ImportingConstructor]
     public OutputTypeChecker(ProjectProperties properties)
     {
         _properties = properties;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IOutputTypeCheckerFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IOutputTypeCheckerFactory.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.VisualStudio.ProjectSystem.Debug;
+
+namespace Microsoft.VisualStudio.ProjectSystem;
+
+internal static class IOutputTypeCheckerFactory
+{
+    public static IOutputTypeChecker Create(bool? isLibrary = false, bool? isConsole = false)
+    {
+        var mock = new Mock<IOutputTypeChecker>();
+
+        if (isLibrary is not null)
+        {
+            mock.Setup(m => m.IsLibraryAsync()).ReturnsAsync(isLibrary.Value);
+        }
+
+        if (isConsole is not null)
+        {
+            mock.Setup(m => m.IsConsoleAsync()).ReturnsAsync(isConsole.Value);
+        }
+
+        return mock.Object;
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -766,7 +766,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 fileSystem!,
                 environment,
                 activeDebugFramework,
-                properties!,
+                new OutputTypeChecker(properties!),
                 threadingService,
                 IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger),
                 remoteDebuggerAuthenticationService,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -1,10 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.Debugger.UI.Interfaces.HotReload;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -173,7 +171,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var activeProfile = new LaunchProfile(
                 name: "MyApplication",
-                commandName: null, 
+                commandName: null,
                 commandLineArgs: "--someArgs",
                 executablePath: @"c:\test\Project\someapp.exe",
                 environmentVariables: ImmutableArray.Create(("var1", "Value1")));
@@ -202,7 +200,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 { "OutDir", outdir }
             };
 
-            var debugger = GetDebugTargetsProvider("exe", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Console, properties);
 
             // Exe relative, no working dir
             await _mockFS.WriteAllTextAsync(@"c:\test\project\bin\test.exe", string.Empty);
@@ -320,7 +318,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            var debugger = GetDebugTargetsProvider("Library", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Library, properties);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -339,7 +337,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            var debugger = GetDebugTargetsProvider("Library", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Library, properties);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -358,7 +356,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            var debugger = GetDebugTargetsProvider("Library", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Library, properties);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -379,7 +377,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             await _mockFS.WriteAllTextAsync(@"C:\library.dll", string.Empty);
 
-            var debugger = GetDebugTargetsProvider("Library", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Library, properties);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -397,7 +395,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             await _mockFS.WriteAllTextAsync(@"C:\library.dll", string.Empty);
 
-            var debugger = GetDebugTargetsProvider("Library", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Library, properties);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -416,7 +414,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            var debugger = GetDebugTargetsProvider("exe", properties);
+            var debugger = GetDebugTargetsProvider(ProjectOutputType.Console, properties);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -438,7 +436,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var scope = IProjectCapabilitiesScopeFactory.Create(capabilities: new string[] { ProjectCapabilities.IntegratedConsoleDebugging });
 
-            var provider = GetDebugTargetsProvider("exe", properties, debugger, scope);
+            var provider = GetDebugTargetsProvider(ProjectOutputType.Console, properties, debugger, scope);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -462,7 +460,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var scope = IProjectCapabilitiesScopeFactory.Create(capabilities: new string[] { ProjectCapabilities.IntegratedConsoleDebugging });
 
-            var provider = GetDebugTargetsProvider("exe", properties, debugger, scope);
+            var provider = GetDebugTargetsProvider(ProjectOutputType.Console, properties, debugger, scope);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -484,7 +482,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 {"TargetFrameworkIdentifier", @".NETFramework"}
             };
 
-            var provider = GetDebugTargetsProvider("exe", properties, debugger);
+            var provider = GetDebugTargetsProvider(ProjectOutputType.Console, properties, debugger);
 
             var activeProfile = new LaunchProfile("Name", "Project");
 
@@ -495,11 +493,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Theory]
-        [InlineData("winexe")]
-        [InlineData("appcontainerexe")]
-        [InlineData("library")]
-        [InlineData("WinMDObj")]
-        public async Task QueryDebugTargetsAsync_NonConsoleAppLaunch_DoesNotIncludeIntegrationConsoleInLaunchOptions(string outputType)
+        [InlineData(ProjectOutputType.Library)]
+        [InlineData(ProjectOutputType.Other)]
+        public async Task QueryDebugTargetsAsync_NonConsoleAppLaunch_DoesNotIncludeIntegrationConsoleInLaunchOptions(ProjectOutputType outputType)
         {
             var debugger = IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: true);
             var properties = new Dictionary<string, string?>
@@ -519,11 +515,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         }
 
         [Theory]
-        [InlineData("winexe")]
-        [InlineData("appcontainerexe")]
-        [InlineData("library")]
-        [InlineData("WinMDObj")]
-        public async Task QueryDebugTargetsAsync_NonConsoleAppLaunchWithNoDebugger_DoesNotWrapInCmd(string outputType)
+        [InlineData(ProjectOutputType.Library)]
+        [InlineData(ProjectOutputType.Other)]
+        public async Task QueryDebugTargetsAsync_NonConsoleAppLaunchWithNoDebugger_DoesNotWrapInCmd(ProjectOutputType outputType)
         {
             var properties = new Dictionary<string, string?>
             {
@@ -600,7 +594,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task CommandLineArgNewLines_AreStripped()
         {
             var provider = GetDebugTargetsProvider(
-                outputType: "dll",
+                outputType: ProjectOutputType.Library,
                 properties: new Dictionary<string, string?>(),
                 debugger: null,
                 scope: null);
@@ -648,7 +642,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task CanBeStartupProject_WhenUsingExecutableCommand_AlwaysTrue()
         {
             var provider = GetDebugTargetsProvider(
-                outputType: "dll",
+                outputType: ProjectOutputType.Library,
                 properties: new Dictionary<string, string?>(),
                 debugger: null,
                 scope: null);
@@ -687,7 +681,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public async Task CanBeStartupProject_WhenUsingProjectCommand_FalseIfRunCommandAndTargetPathNotSpecified()
         {
             var provider = GetDebugTargetsProvider(
-                outputType: "dll",
+                outputType: ProjectOutputType.Library,
                 properties: new Dictionary<string, string?>(),
                 debugger: null,
                 scope: null);
@@ -698,7 +692,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             Assert.False(canBeStartupProject);
         }
 
-        private ProjectLaunchTargetsProvider GetDebugTargetsProvider(string outputType = "exe", Dictionary<string, string?>? properties = null, IVsDebugger10? debugger = null, IProjectCapabilitiesScope? scope = null)
+        private ProjectLaunchTargetsProvider GetDebugTargetsProvider(ProjectOutputType outputType = ProjectOutputType.Console, Dictionary<string, string?>? properties = null, IVsDebugger10? debugger = null, IProjectCapabilitiesScope? scope = null)
         {
             _mockFS.Create(@"c:\test\Project\someapp.exe");
             _mockFS.CreateDirectory(@"c:\test\Project");
@@ -707,9 +701,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             var project = UnconfiguredProjectFactory.Create(fullPath: _ProjectFile);
 
-            var outputTypeEnum = new PageEnumValue(new EnumValue { Name = outputType });
-            var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypeEnum);
-            var projectProperties = ProjectPropertiesFactory.Create(project, data);
+            var outputTypeChecker = outputType switch
+            {
+                ProjectOutputType.Console => IOutputTypeCheckerFactory.Create(isLibrary: false, isConsole: true),
+                ProjectOutputType.Library => IOutputTypeCheckerFactory.Create(isLibrary: true, isConsole: false),
+                ProjectOutputType.Other => IOutputTypeCheckerFactory.Create(isLibrary: false, isConsole: false),
+                _ => throw new InvalidOperationException($"Unexpected {nameof(ProjectOutputType)}: {outputType}")
+            };
 
             properties ??= new Dictionary<string, string?>
             {
@@ -735,7 +733,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 o.Capabilities == capabilitiesScope);
             var environment = IEnvironmentHelperFactory.ImplementGetEnvironmentVariable(_Path);
 
-            return CreateInstance(configuredProject: configuredProject, fileSystem: _mockFS, properties: projectProperties, environment: environment, debugger: debugger);
+            return CreateInstance(configuredProject: configuredProject, fileSystem: _mockFS, typeChecker: outputTypeChecker, environment: environment, debugger: debugger);
         }
 
         private static ProjectLaunchTargetsProvider CreateInstance(
@@ -744,7 +742,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             IFileSystem? fileSystem = null,
             IEnvironmentHelper? environment = null,
             IActiveDebugFrameworkServices? activeDebugFramework = null,
-            ProjectProperties? properties = null,
+            IOutputTypeChecker? typeChecker = null,
             IProjectThreadingService? threadingService = null,
             IVsDebugger10? debugger = null,
             IHotReloadOptionService? hotReloadSettings = null)
@@ -754,6 +752,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             activeDebugFramework ??= IActiveDebugFrameworkServicesFactory.ImplementGetConfiguredProjectForActiveFrameworkAsync(configuredProject);
             threadingService ??= IProjectThreadingServiceFactory.Create();
             debugger ??= IVsDebugger10Factory.ImplementIsIntegratedConsoleEnabled(enabled: false);
+            typeChecker ??= IOutputTypeCheckerFactory.Create();
 
             IUnconfiguredProjectVsServices unconfiguredProjectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(IVsHierarchyFactory.Create);
 
@@ -766,12 +765,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 fileSystem!,
                 environment,
                 activeDebugFramework,
-                new OutputTypeChecker(properties!),
+                typeChecker,
                 threadingService,
                 IVsUIServiceFactory.Create<SVsShellDebugger, IVsDebugger10>(debugger),
                 remoteDebuggerAuthenticationService,
                 new Lazy<IProjectHotReloadSessionManager>(IProjectHotReloadSessionManagerFactory.Create),
                 new Lazy<IHotReloadOptionService>(() => hotReloadSettings ?? IHotReloadOptionServiceFactory.Create()));
+        }
+
+        /// <summary>
+        /// Indicates if the project is a library, console app, or something else.
+        /// </summary>
+        public enum ProjectOutputType
+        {
+            Library,
+            Console,
+            Other
         }
     }
 }


### PR DESCRIPTION
While making other changes I noticed that we were sometimes creating a new `OutputTypeChecker` rather than importing an `IOutputTypeChecker` and letting MEF handle the creation for us. This change defines `IOutputTypeChecker` and updates all of our code to use it.

The main effect is that the tests around the `ProjectLaunchTargetsProvider` have gotten somewhat simpler as we are no longer dealing with the dependencies of `OutputTypeChecker` but can instead create a mock `IOutputTypeChecker` with our desired behavior.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9010)