### PR TITLE
Remove dependency on the project tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -3,7 +3,6 @@
 using System.Threading.Tasks.Dataflow;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Threading.Tasks;
 
@@ -35,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         private const string ErrorProfileErrorMessageSettingsKey = "ErrorString";
 
         private readonly UnconfiguredProject _project;
-        private readonly IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> _appDesignerSpecialFileProvider;
+        private readonly IActiveConfiguredValue<ProjectProperties?> _projectProperties;
         private readonly IProjectFaultHandlerService _projectFaultHandler;
         private readonly AsyncLazy<string> _launchSettingsFilePath;
         private readonly IUnconfiguredProjectServices _projectServices;
@@ -60,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             IFileSystem fileSystem,
             IUnconfiguredProjectCommonServices commonProjectServices,
             IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
-            IActiveConfiguredValue<IAppDesignerFolderSpecialFileProvider?> appDesignerSpecialFileProvider,
+            IActiveConfiguredValue<ProjectProperties?> projectProperties,
             IProjectFaultHandlerService projectFaultHandler,
             JoinableTaskContext joinableTaskContext)
             : base(projectServices, synchronousDisposal: false, registerDataSource: false)
@@ -79,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             DefaultLaunchProfileProviders = new OrderPrecedenceImportCollection<IDefaultLaunchProfileProvider>(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst, project);
 
             _projectSubscriptionService = projectSubscriptionService;
-            _appDesignerSpecialFileProvider = appDesignerSpecialFileProvider;
+            _projectProperties = projectProperties;
             _projectFaultHandler = projectFaultHandler;
             _launchSettingsFilePath = new AsyncLazy<string>(GetLaunchSettingsFilePathNoCacheAsync, commonProjectServices.ThreadingService.JoinableTaskFactory);
 
@@ -894,12 +893,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // even though it can change over the lifetime of the project. We should fix this and convert to using dataflow
             // see: https://github.com/dotnet/project-system/issues/2316.
 
-            string? folder = null;
-            if (_appDesignerSpecialFileProvider.Value is not null)
-                folder = await _appDesignerSpecialFileProvider.Value.GetFileAsync(SpecialFiles.AppDesigner, SpecialFileFlags.FullPath);
-
-            if (folder is null)  // AppDesigner capability not present, or the project has set AppDesignerFolder to empty
-                folder = Path.GetDirectoryName(_commonProjectServices.Project.FullPath);
+            // Default to the project directory if we're not able to get the AppDesigner folder.
+            string folder = Path.GetDirectoryName(_commonProjectServices.Project.FullPath);
+            
+            if (_projectProperties.Value is not null)
+            {
+                AppDesigner appDesignerProperties = await _projectProperties.Value.GetAppDesignerPropertiesAsync();
+                if (await appDesignerProperties.FolderName.GetValueAsync() is string appDesignerFolderName)
+                {
+                    folder = Path.Combine(folder, appDesignerFolderName);
+                }
+            }
 
             return Path.Combine(folder, LaunchSettingsFilename);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyPagesCatalogFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IPropertyPagesCatalogFactory.cs
@@ -47,7 +47,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return catalog;
         }
 
-        private static IProperty CreateProperty(string name, object value, List<object>? setValues = null)
+        private static IProperty CreateProperty(string name, object? value, List<object>? setValues = null)
         {
             var property = new Mock<IProperty>();
             property.SetupGet(o => o.Name)
@@ -56,8 +56,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
             property.Setup(o => o.GetValueAsync())
                     .ReturnsAsync(value);
 
-            property.As<IEvaluatedProperty>().Setup(p => p.GetEvaluatedValueAtEndAsync()).ReturnsAsync(value.ToString());
-            property.As<IEvaluatedProperty>().Setup(p => p.GetEvaluatedValueAsync()).ReturnsAsync(value.ToString());
+            property.As<IEvaluatedProperty>().Setup(p => p.GetEvaluatedValueAtEndAsync()).ReturnsAsync(value?.ToString() ?? string.Empty);
+            property.As<IEvaluatedProperty>().Setup(p => p.GetEvaluatedValueAsync()).ReturnsAsync(value?.ToString() ?? string.Empty);
 
             if (setValues is not null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return Create(UnconfiguredProjectFactory.Create());
         }
 
-        public static ProjectProperties Create(string category, string propertyName, string value)
+        public static ProjectProperties Create(string category, string propertyName, string? value)
         {
             var data = new PropertyPageData(category, propertyName, value);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertyPageData.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PropertyPageData.cs
@@ -4,7 +4,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal class PropertyPageData
     {
-        public PropertyPageData(string category, string propertyName, object value, List<object>? setValues = null)
+        public PropertyPageData(string category, string propertyName, object? value, List<object>? setValues = null)
         {
             Category = category;
             PropertyName = propertyName;
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         public string Category { get; }
         public string PropertyName { get; }
-        public object Value { get; }
+        public object? Value { get; }
         public List<object> SetValues { get; }
     }
 }


### PR DESCRIPTION
Fixes [AB#1815584](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1815584).

The `LaunchSettingsProvider` looks for the launchSettings.json file within the project's "app designer" folder, and so to read the file it needs to find the location of that folder on disk. Ultimately this is controlled by the "AppDesignerFolder" property in MSBuild. In the case of C# this defaults to "Properties"; for VB it is called "My Project".

Currently the `LaunchSettingsProvider` does not read this property directly. Instead, it imports the `IAppDesignerFolderSpecialFileProvider`, and the implementation of that (`AppDesignerFolderSpecialFileProvider`) utilizes project tree. It searches the project tree for certain flags denoting the app designer folder; these flags were previously set by the `AppDesignerFolderProjectTreePropertiesProvider`. It is that type that makes use of the underlying MSBuild property values.

These extra levels of abstraction add cost and complexity without, as best I can tell, buying us much in the way of functionality. As it stands we can't determine the path to the launchSettings.json until the project tree has been created by CPS and updated by the `AppDesignerFolderProjectTreePropertiesProvider`, and in some cases we may force the creation of the project tree where it is otherwise not needed.

In this change we cut out the middle layers and go directly to the MSBuild properties via the `ProjectProperties` type.

Note that this does not correct other, long-standing issues with this code. Notably we will retrieve the path once and cache it, and as such will not react to any project changes that might change the location of the app designer folder. To do that would require significant rework to acquire the app designer folder path through a dataflow, which would also require that changes to how we manage the file watcher on the launchSettings.json. That work is already tracked by #2316.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9014)