### PR TITLE
Update the VS Bootstrapper task version

### DIFF
--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -116,7 +116,7 @@ jobs:
   # - MicroBuildSigningPlugin: uses signjson.exe to sign the manifests
   # - MicroBuildSwixPlugin: uses vsman.exe and sets the environment variable ManifestPublishUrl
   # Documentation: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/643/How-to-Build-a-Bootstrapper
-  - task: MicroBuildBuildVSBootstrapper@2
+  - task: MicroBuildBuildVSBootstrapper@3
     displayName: Build VS Bootstrapper
     inputs:
       bootstrapperCoreVersion: latest


### PR DESCRIPTION
## Summary
The VS Bootstrapper task has had an acquisition issue recently. To fix it, it needed to make a breaking change; thus, updating the task version. This PR updates the task version and causes the task to work properly again. Looks like the Bootstrapper.json is the same, except with an added `QBuildSessionId` value.

## Successful Test Run
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7797012&view=results

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9036)