### PR TITLE
Reduce allocations in PublishItemsOutputGroupProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishItemsOutputGroupProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishItemsOutputGroupProvider.cs
@@ -9,72 +9,45 @@ namespace Microsoft.VisualStudio.ProjectSystem.Build
     [Order(Order.Default)]
     internal class PublishItemsOutputGroupProvider : IOutputGroupProvider
     {
+        private const string PublishItemsOutputGroupTargetName = "PublishItemsOutputGroup";
+
         /// <summary>
-        /// List of well known output groups names and their associated target and description
+        /// Collection containing a single "publish items" output group.
+        /// This is a singleton instance, shared across all projects/configurations.
         /// </summary>
-        private static readonly ImmutableHashSet<IOutputGroup> s_outputGroups = ImmutableHashSet.Create<IOutputGroup>()
-            .Add(NewGroup("PublishItems", "PublishItemsOutputGroup", Resources.OutputGroupPublishItemsDisplayName, Resources.OutputGroupPublishItemsDescription));
+        private static readonly ImmutableHashSet<IOutputGroup> s_outputGroups = ImmutableHashSet.Create<IOutputGroup>(
+            new OutputGroup(
+                name: "PublishItems",
+                targetName: PublishItemsOutputGroupTargetName,
+                displayName: Resources.OutputGroupPublishItemsDisplayName,
+                description: Resources.OutputGroupPublishItemsDescription,
+                items: ImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>>.Empty,
+                successful: false));
 
         private readonly AsyncLazy<IImmutableSet<IOutputGroup>> _outputGroups;
-        private readonly IProjectAccessor _projectAccessor;
-        private readonly ConfiguredProject _configuredProject;
 
         [ImportingConstructor]
-        internal PublishItemsOutputGroupProvider(IProjectAccessor projectAccessor, ConfiguredProject configuredProject, IProjectThreadingService projectThreadingService)
+        internal PublishItemsOutputGroupProvider(
+            IProjectAccessor projectAccessor,
+            ConfiguredProject configuredProject,
+            IProjectThreadingService projectThreadingService)
         {
-            _projectAccessor = projectAccessor;
-            _configuredProject = configuredProject;
-            _outputGroups = new AsyncLazy<IImmutableSet<IOutputGroup>>(GetOutputGroupMetadataAsync, projectThreadingService.JoinableTaskFactory);
-        }
+            _outputGroups = new AsyncLazy<IImmutableSet<IOutputGroup>>(
+                GetOutputGroupMetadataAsync,
+                projectThreadingService.JoinableTaskFactory);
 
-        public Task<IImmutableSet<IOutputGroup>> OutputGroups
-        {
-            get { return _outputGroups.GetValueAsync(); }
-        }
-
-        /// <summary>
-        /// Gets a collection of names of targets in this project.
-        /// </summary>
-        /// <returns>Collection of the names of targets in this project.</returns>
-        private Task<ImmutableHashSet<string>> GetProjectTargetsAsync()
-        {
-            return _projectAccessor.OpenProjectForReadAsync(_configuredProject, project =>
-                project.Targets.Keys.ToImmutableHashSet(StringComparers.TargetNames));
-        }
-
-        /// <summary>
-        /// Produces a set of output groups that is a subset of all well known output groups.
-        /// </summary>
-        /// <returns>Set of all known output groups.</returns>
-        private async Task<IImmutableSet<IOutputGroup>> GetOutputGroupMetadataAsync()
-        {
-            // Start with the comment set of output groups.
-            ImmutableHashSet<IOutputGroup> result = s_outputGroups;
-
-            // Remove any well known output group for which no target is defined.
-            ImmutableHashSet<string> targets = await GetProjectTargetsAsync();
-            foreach (IOutputGroup outputGroup in result)
+            async Task<IImmutableSet<IOutputGroup>> GetOutputGroupMetadataAsync()
             {
-                if (!targets.Contains(outputGroup.TargetName))
-                {
-                    result = result.Remove(outputGroup);
-                }
+                bool hasPublishItemsTarget = await projectAccessor.OpenProjectForReadAsync(
+                    configuredProject,
+                    project => project.Targets.ContainsKey(PublishItemsOutputGroupTargetName));
+
+                return hasPublishItemsTarget
+                    ? s_outputGroups
+                    : ImmutableHashSet<IOutputGroup>.Empty;
             }
-
-            return result;
         }
 
-        /// <summary>
-        /// Creates a new output group with metadata only.
-        /// </summary>
-        /// <param name="name">Output group name.</param>
-        /// <param name="targetName">Output group target name.</param>
-        /// <param name="displayName">Output group display name.</param>
-        /// <param name="description">Optional output group description.</param>
-        /// <return>New <see cref="IOutputGroup"/>.</return>
-        private static IOutputGroup NewGroup(string name, string targetName, string displayName, string description)
-        {
-            return new OutputGroup(name, targetName, displayName, description, ImmutableList<KeyValuePair<string, IImmutableDictionary<string, string>>>.Empty, false);
-        }
+        public Task<IImmutableSet<IOutputGroup>> OutputGroups => _outputGroups.GetValueAsync();
     }
 }


### PR DESCRIPTION
This class would take a project read lock, copy every MSBuild target name into an `ImmutableHashSet<string>`, then release the lock. Later it would check whether a single item existed in that collection, then free the collection.

For a simple console app there were 500 such targets. `ImmutableHashSet<>` builds a tree structure internally, which is particularly inefficient. This would run for every configuration of every project.

This change rewrites the class to just query the project for the target it wants, eliminating the collection allocation entirely, and holding the read lock on the project for a shorter time.

---

Prior code in the debugger:

![image](https://github.com/dotnet/project-system/assets/350947/4b7e8ae2-3145-4909-8b26-f2e44ae571fc)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9037)