### PR TITLE
Replace fault with assertion

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
@@ -203,7 +203,7 @@ internal sealed class MSBuildDependencyCollection
 
                 void PopulateMissingBuildData()
                 {
-                    Assumes.True(missingBuildCount >= 0);
+                    System.Diagnostics.Debug.Assert(missingBuildCount >= 0, "At least one missing build data is expected.");
 
                     if (missingBuildCount == 0)
                     {


### PR DESCRIPTION
Fixes [AB#1820857](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1820857)

While this case is unexpected, it's not worth faulting the dataflow and therefore the project in this case. This change replaces a throw with an assert in debug builds.

This is a workaround for a state that's not well understood yet, but getting this in for 17.7p2 will unblock some folks that don't need to be blocked.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9042)