### PR TITLE
Fix dataflow block name format string in WebMissingWorkloadDetector

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Workloads/WebMissingWorkloadDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Workloads/WebMissingWorkloadDetector.cs
@@ -68,7 +68,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Workloads
             _subscription = new()
             {
                 _webWorkloadDescriptorDataSource.SourceBlock.LinkTo(
-                    DataflowBlockFactory.CreateActionBlock(action, _project.UnconfiguredProject, ProjectFaultSeverity.LimitedFunctionality, nameFormat: $"{nameof(WebMissingWorkloadDetector)} Action: {1}"),
+                    DataflowBlockFactory.CreateActionBlock(action, _project.UnconfiguredProject, ProjectFaultSeverity.LimitedFunctionality, nameFormat: $"{nameof(WebMissingWorkloadDetector)} Action: {{1}}"),
                     linkOptions: DataflowOption.PropagateCompletion),
 
                 ProjectDataSources.JoinUpstreamDataSources(JoinableFactory, _projectFaultHandlerService, _webWorkloadDescriptorDataSource)


### PR DESCRIPTION
This is an interpolated string, so we have to escape the braces in `{1}` to have them passed through.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9054)