### PR TITLE
Don't switch to UI thread to check feature flags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IIncrementalBuildFailureReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IIncrementalBuildFailureReporter.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
         /// </remarks>
         /// <param name="cancellationToken">A token whose cancellation marks lost interest in the result of this task.</param>
         /// <returns>A task that resolves to <see langword="true"/> if this reporter is currently enabled, otherwise <see langword="false"/>.</returns>
-        Task<bool> IsEnabledAsync(CancellationToken cancellationToken);
+        ValueTask<bool> IsEnabledAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///   Reports an incremental build failure for the project in the current scope.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureOutputWindowReporter.cs
@@ -15,14 +15,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
     internal sealed class IncrementalBuildFailureOutputWindowReporter : IIncrementalBuildFailureReporter
     {
         private readonly UnconfiguredProject _project;
-        private readonly IVsUIService<SVsFeatureFlags, IVsFeatureFlags> _featureFlagsService;
+        private readonly IVsService<SVsFeatureFlags, IVsFeatureFlags> _featureFlagsService;
         private readonly IVsUIService<SVsOutputWindow, IVsOutputWindow> _outputWindow;
         private readonly IProjectSystemOptions _projectSystemOptions;
 
         [ImportingConstructor]
         public IncrementalBuildFailureOutputWindowReporter(
             UnconfiguredProject project,
-            IVsUIService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService,
+            IVsService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService,
             IVsUIService<SVsOutputWindow, IVsOutputWindow> outputWindow,
             IProjectSystemOptions projectSystemOptions)
         {
@@ -42,9 +42,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                 return true;
             }
 
-            await _project.Services.ThreadingPolicy.SwitchToUIThread(cancellationToken);
-
-            IVsFeatureFlags featureFlagsService = _featureFlagsService.Value;
+            IVsFeatureFlags featureFlagsService = await _featureFlagsService.GetValueAsync(cancellationToken);
 
             return featureFlagsService.IsFeatureEnabled(FeatureFlagNames.EnableIncrementalBuildFailureOutputLogging, defaultValue: false);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureTelemetryReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/Diagnostics/IncrementalBuildFailureTelemetryReporter.cs
@@ -13,16 +13,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
     [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
     internal sealed class IncrementalBuildFailureTelemetryReporter : IIncrementalBuildFailureReporter
     {
-        private readonly UnconfiguredProject _project;
-        private readonly IVsUIService<SVsFeatureFlags, IVsFeatureFlags> _featureFlagsService;
+        private readonly IVsService<SVsFeatureFlags, IVsFeatureFlags> _featureFlagsService;
         private bool _hasBeenReported;
 
         [ImportingConstructor]
         public IncrementalBuildFailureTelemetryReporter(
-            UnconfiguredProject project,
-            IVsUIService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService)
+            UnconfiguredProject _, // scoping
+            IVsService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService)
         {
-            _project = project;
             _featureFlagsService = featureFlagsService;
         }
 
@@ -35,9 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build.Diagnostics
                 return false;
             }
 
-            await _project.Services.ThreadingPolicy.SwitchToUIThread(cancellationToken);
-
-            IVsFeatureFlags featureFlagsService = _featureFlagsService.Value;
+            IVsFeatureFlags featureFlagsService = await _featureFlagsService.GetValueAsync(cancellationToken);
 
             return featureFlagsService.IsFeatureEnabled(FeatureFlagNames.EnableIncrementalBuildFailureTelemetry, defaultValue: false);
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FeatureFlagNames.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FeatureFlagNames.cs
@@ -21,4 +21,9 @@ internal static class FeatureFlagNames
     /// Enables incremental build to report build failures.
     /// </summary>
     public const string EnableIncrementalBuildFailureTelemetry = "ManagedProjectSystem.EnableIncrementalBuildFailureTelemetry";
+
+    /// <summary>
+    /// When this feature flag is enabled, build diagnostics will be published by CPS and should not be passed to Roslyn.
+    /// </summary>
+    public const string LspPullDiagnosticsFeatureFlagName = "Lsp.PullDiagnostics";
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -74,11 +74,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             await settingsManager.SetValueAsync(name, value, isMachineLocal: false);
         }
 
-        public async Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken)
+        public ValueTask<bool> IsNuGetRestoreCycleDetectionEnabledAsync(CancellationToken cancellationToken)
+        {
+            return IsFlagEnabledAsync(FeatureFlagNames.EnableNuGetRestoreCycleDetection, defaultValue: false, cancellationToken);
+        }
+
+        public ValueTask<bool> IsIncrementalBuildFailureOutputLoggingEnabledAsync(CancellationToken cancellationToken)
+        {
+            return IsFlagEnabledAsync(FeatureFlagNames.EnableIncrementalBuildFailureOutputLogging, defaultValue: false, cancellationToken);
+        }
+
+        public ValueTask<bool> IsIncrementalBuildFailureTelemetryEnabledAsync(CancellationToken cancellationToken)
+        {
+            return IsFlagEnabledAsync(FeatureFlagNames.EnableIncrementalBuildFailureTelemetry, defaultValue: false, cancellationToken);
+        }
+
+        public ValueTask<bool> IsLspPullDiagnosticsEnabledAsync(CancellationToken cancellationToken)
+        {
+            return IsFlagEnabledAsync(FeatureFlagNames.LspPullDiagnosticsFeatureFlagName, defaultValue: false, cancellationToken);
+        }
+
+        private async ValueTask<bool> IsFlagEnabledAsync(string featureName, bool defaultValue, CancellationToken cancellationToken)
         {
             IVsFeatureFlags featureFlags = await _featureFlagsService.GetValueAsync(cancellationToken);
 
-            return featureFlags.IsFeatureEnabled(FeatureFlagNames.EnableNuGetRestoreCycleDetection, defaultValue: false);
+            return featureFlags.IsFeatureEnabled(featureName, defaultValue);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -18,18 +18,16 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         internal const string SkipAnalyzersForImplicitlyTriggeredBuildSettingKey = "TextEditor.SkipAnalyzersForImplicitlyTriggeredBuilds";
 
         private readonly IVsService<ISettingsManager> _settingsManager;
-        private readonly IVsUIService<SVsFeatureFlags, IVsFeatureFlags> _featureFlagsService;
-        private readonly IProjectThreadingService _threadingService;
+        private readonly IVsService<SVsFeatureFlags, IVsFeatureFlags> _featureFlagsService;
 
         [ImportingConstructor]
         public ProjectSystemOptions(
             IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManager,
-            IVsUIService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService,
+            IVsService<SVsFeatureFlags, IVsFeatureFlags> featureFlagsService,
             IProjectThreadingService threadingService)
         {
             _settingsManager = settingsManager;
             _featureFlagsService = featureFlagsService;
-            _threadingService = threadingService;
         }
 
         public Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken)
@@ -78,11 +76,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
 
         public async Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken)
         {
-            await _threadingService.SwitchToUIThread(cancellationToken);
+            IVsFeatureFlags featureFlags = await _featureFlagsService.GetValueAsync(cancellationToken);
 
-            IVsFeatureFlags featureFlagsService = _featureFlagsService.Value;
-
-            return featureFlagsService.IsFeatureEnabled(FeatureFlagNames.EnableNuGetRestoreCycleDetection, defaultValue: false);
+            return featureFlags.IsFeatureEnabled(FeatureFlagNames.EnableNuGetRestoreCycleDetection, defaultValue: false);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -53,6 +53,21 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <summary>
         ///     Gets a value indicating if the project system should attempt to detect cycles in the NuGet restore process.
         /// </summary>
-        Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken);
+        ValueTask<bool> IsNuGetRestoreCycleDetectionEnabledAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Gets whether incremental build failure detection should write to the output window when failures are detected.
+        /// </summary>
+        ValueTask<bool> IsIncrementalBuildFailureOutputLoggingEnabledAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Gets whether incremental build failure detection should send telemetry.
+        /// </summary>
+        ValueTask<bool> IsIncrementalBuildFailureTelemetryEnabledAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Gets whether LSP pull diagnostics are enabled.
+        /// </summary>
+        ValueTask<bool> IsLspPullDiagnosticsEnabledAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreCycleDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreCycleDetector.cs
@@ -53,7 +53,7 @@ internal sealed class PackageRestoreCycleDetector(
 
     public async Task<bool> IsCycleDetectedAsync(Hash hash, CancellationToken cancellationToken)
     {
-        if (!await _projectSystemOptions.GetDetectNuGetRestoreCyclesAsync(cancellationToken))
+        if (!await _projectSystemOptions.IsNuGetRestoreCycleDetectionEnabledAsync(cancellationToken))
         {
             // Cycle detection has been disabled. Take no further action.
             return false;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
@@ -49,7 +49,7 @@ public sealed class PackageRestoreCycleDetectorTests
         var project = UnconfiguredProjectFactory.CreateWithActiveConfiguredProjectProvider(IProjectThreadingServiceFactory.Create());
 
         var projectSystemOptions = new Mock<IProjectSystemOptions>();
-        projectSystemOptions.Setup(o => o.GetDetectNuGetRestoreCyclesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(isEnabled);
+        projectSystemOptions.Setup(o => o.IsNuGetRestoreCycleDetectionEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync(isEnabled);
 
         var telemetryService = new Mock<ITelemetryService>();
         var nonModelNotificationService = new Mock<INonModalNotificationService>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.Build.Framework;
-using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Shell.Interop;
 
@@ -352,13 +351,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         {
             workspaceWriter ??= IWorkspaceWriterFactory.Create();
 
-            var featureFlagServiceMock = new Mock<IVsFeatureFlags>();
-            featureFlagServiceMock.Setup(m => m.IsFeatureEnabled(LanguageServiceErrorListProvider.LspPullDiagnosticsFeatureFlagName, false)).Returns(lspPullDiagnosticsFeatureFlag);
-            var vsFeatureFlagsServiceService = new Mock<IVsService<SVsFeatureFlags, IVsFeatureFlags>>();
-            vsFeatureFlagsServiceService.Setup(m => m.GetValueAsync(It.IsAny<CancellationToken>())).Returns(Task.FromResult(featureFlagServiceMock.Object));
+            var projectSystemOptions = new Mock<IProjectSystemOptions>();
+            projectSystemOptions.Setup(m => m.IsLspPullDiagnosticsEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync(lspPullDiagnosticsFeatureFlag);
+
             var joinableTaskContext = IProjectThreadingServiceFactory.Create().JoinableTaskContext.Context;
 
-            var provider = new LanguageServiceErrorListProvider(UnconfiguredProjectFactory.Create(), workspaceWriter, vsFeatureFlagsServiceService.Object, joinableTaskContext);
+            var provider = new LanguageServiceErrorListProvider(UnconfiguredProjectFactory.Create(), workspaceWriter, projectSystemOptions.Object, joinableTaskContext);
 
             return provider;
         }


### PR DESCRIPTION
Fixes [AB#1825661](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1825661)

The `IVsFeatureFlags` service is free threaded. We don't need to switch to the UI thread in order to call into it.

This removes three such switches and converts our imports from `IVsUIService` to `IVsService` accordingly.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9061)