### PR TITLE
Avoid default cancellation token on interface

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -32,32 +32,32 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             _threadingService = threadingService;
         }
 
-        public Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default)
+        public Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken)
         {
             return GetSettingValueOrDefaultAsync(FastUpToDateEnabledSettingKey, defaultValue: true, cancellationToken);
         }
 
-        public Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default)
+        public Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken)
         {
             return GetSettingValueOrDefaultAsync(FastUpToDateLogLevelSettingKey, defaultValue: LogLevel.None, cancellationToken);
         }
 
-        public Task<bool> GetUseDesignerByDefaultAsync(string designerCategory, bool defaultValue, CancellationToken cancellationToken = default)
+        public Task<bool> GetUseDesignerByDefaultAsync(string designerCategory, bool defaultValue, CancellationToken cancellationToken)
         {
             return GetSettingValueOrDefaultAsync(UseDesignerByDefaultSettingKey + "\\" + designerCategory, defaultValue, cancellationToken);
         }
 
-        public Task SetUseDesignerByDefaultAsync(string designerCategory, bool value, CancellationToken cancellationToken = default)
+        public Task SetUseDesignerByDefaultAsync(string designerCategory, bool value, CancellationToken cancellationToken)
         {
             return SetSettingValueAsync(UseDesignerByDefaultSettingKey + "\\" + designerCategory, value, cancellationToken);
         }
 
-        public Task<bool> GetSkipAnalyzersForImplicitlyTriggeredBuildAsync(CancellationToken cancellationToken = default)
+        public Task<bool> GetSkipAnalyzersForImplicitlyTriggeredBuildAsync(CancellationToken cancellationToken)
         {
             return GetSettingValueOrDefaultAsync(SkipAnalyzersForImplicitlyTriggeredBuildSettingKey, defaultValue: true, cancellationToken);
         }
 
-        public Task<bool> GetPreferSingleTargetBuildsForStartupProjectsAsync(CancellationToken cancellationToken = default)
+        public Task<bool> GetPreferSingleTargetBuildsForStartupProjectsAsync(CancellationToken cancellationToken)
         {
             return GetSettingValueOrDefaultAsync(PreferSingleTargetBuildsForStartupProjects, defaultValue: true, cancellationToken);
         }
@@ -76,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             await settingsManager.SetValueAsync(name, value, isMachineLocal: false);
         }
 
-        public async Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken = default)
+        public async Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken)
         {
             await _threadingService.SwitchToUIThread(cancellationToken);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -54,12 +54,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
 
             CancellationToken cancellationToken = _projectAsynchronousTasksService.UnloadCancellationToken;
 
-            IProjectSpecificEditorInfo? editor = await GetDefaultEditorAsync(documentMoniker);
-            if (editor is null)
-                return null;
+            (IProjectSpecificEditorInfo? editor, SubTypeDescriptor ? descriptor)
+                = await (GetDefaultEditorAsync(documentMoniker), GetSubTypeDescriptorAsync(documentMoniker, cancellationToken));
 
-            SubTypeDescriptor? descriptor = await GetSubTypeDescriptorAsync(documentMoniker, cancellationToken);
-            if (descriptor is null)
+            if (editor is null || descriptor is null)
                 return null;
 
             bool isDefaultEditor = await _options.Value.GetUseDesignerByDefaultAsync(descriptor.SubType, descriptor.UseDesignerByDefault, cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <value>
         ///     <see langword="true"/> if the project fast up to date check is enabled; otherwise, <see langword="false"/>
         /// </value>
-        Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken = default);
+        Task<bool> GetIsFastUpToDateCheckEnabledAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///     Gets a value indicating the level of fast up to date check logging.
@@ -28,31 +28,31 @@ namespace Microsoft.VisualStudio.ProjectSystem
         /// <value>
         ///     The level of fast up to date check logging.
         /// </value>
-        Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken = default);
+        Task<LogLevel> GetFastUpToDateLoggingLevelAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///     Gets a value indicating whether the designer view is the default editor for the specified designer category.
         /// </summary>
-        Task<bool> GetUseDesignerByDefaultAsync(string designerCategory, bool defaultValue, CancellationToken cancellationToken = default);
+        Task<bool> GetUseDesignerByDefaultAsync(string designerCategory, bool defaultValue, CancellationToken cancellationToken);
 
         /// <summary>
         ///     Sets a value indicating whether the designer view is the default editor for the specified designer category.
         /// </summary>
-        Task SetUseDesignerByDefaultAsync(string designerCategory, bool value, CancellationToken cancellationToken = default);
+        Task SetUseDesignerByDefaultAsync(string designerCategory, bool value, CancellationToken cancellationToken);
 
         /// <summary>
         ///     Gets a value indicating if analyzers should be skipped for implicitly triggered build.
         /// </summary>
-        Task<bool> GetSkipAnalyzersForImplicitlyTriggeredBuildAsync(CancellationToken cancellationToken = default);
+        Task<bool> GetSkipAnalyzersForImplicitlyTriggeredBuildAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///     Gets a value indicating if single-target builds should be preferred for startup projects. 
         /// </summary>
-        Task<bool> GetPreferSingleTargetBuildsForStartupProjectsAsync(CancellationToken cancellationToken = default);
+        Task<bool> GetPreferSingleTargetBuildsForStartupProjectsAsync(CancellationToken cancellationToken);
 
         /// <summary>
         ///     Gets a value indicating if the project system should attempt to detect cycles in the NuGet restore process.
         /// </summary>
-        Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken = default);
+        Task<bool> GetDetectNuGetRestoreCyclesAsync(CancellationToken cancellationToken);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProviderTests.cs
@@ -308,8 +308,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms
             unconfiguredProject ??= UnconfiguredProjectFactory.Create(configuredProject: project);
             projectTree ??= IPhysicalProjectTreeFactory.Create();
             options ??= IProjectSystemOptionsFactory.Create();
+            var asyncTasks = IProjectAsynchronousTasksServiceFactory.Create();
 
-            var provider = new Mock<WindowsFormsEditorProvider>(unconfiguredProject, projectTree.AsLazy(), options.AsLazy());
+            var provider = new Mock<WindowsFormsEditorProvider>(unconfiguredProject, asyncTasks, projectTree.AsLazy(), options.AsLazy());
             provider.Protected().Setup<IRule?>("GetBrowseObjectProperties", ItExpr.IsAny<ConfiguredProject>(), ItExpr.IsAny<IProjectItemTree>())
                     .Returns((ConfiguredProject configuredProject, IProjectItemTree node) => node.BrowseObjectProperties);
 


### PR DESCRIPTION
Removing the default forces the caller to think about cancellation when consuming the API. They may still pass a default if they wish to.

This change plumbs through cancellation in `WindowsFormsEditorProvider`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9063)