### PR TITLE
Ensure LangVersion property is written without configuration conditions

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -438,6 +438,11 @@
                   HelpUrl="https://aka.ms/csharp-versions"
                   ReadOnly="true"
                   Category="Advanced">
+    <StringProperty.DataSource>
+      <DataSource Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext"
+                  HasConfigurationCondition="False" />
+    </StringProperty.DataSource>
     <StringProperty.ValueEditors>
       <ValueEditor EditorType="String">
         <ValueEditor.Metadata>


### PR DESCRIPTION
Fixes #9073

When a Roslyn codefix attempts to set the `LangVersion` property on the project, the project file was updated in a way that added configuration conditions to the properties. This creates unnecessary clutter in the project file, as this property is very unlikely to vary by configuration.

The Roslyn codefix uses the `IVsBuildPropertyStorage.SetPropertyValue` method, which is implemented via the CPS `ProjectNode`. Following that code shows CPS's `PropertyHasConfigurationConditionAsync` method is used to determine whether to include configuration conditions or not.

That method loops through all rules in the catalog looking for one that contains the property. The order in which it does this is not stable, based on string hash codes. We define the `LangVersion` property in multiple rule files, and there are slight configuration differences between them. In this case, the `BuildPropertyPage.xaml` rule was being queried first, and was identifying the property as having a configuration condition.

This change fixes the issue by ensuring `LangVersion` is configured in a consistent fashion across these rule files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9075)