### PR TITLE
Update build pipelines for C# dev kit

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -19,6 +19,9 @@ trigger:
     - dev*
     # Any other branches that contain major feature development, or require access to the pipeline, prior to merge.
     - feature/*
+    exclude:
+    # We avoid running C# dev kit feature branch here since it is getting picked up by dev* above
+    - dev/PortToNET6
   paths:
     exclude:
     - docs/*

--- a/eng/pipelines/pull-request.yml
+++ b/eng/pipelines/pull-request.yml
@@ -1,7 +1,7 @@
 # Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 # Name: DotNet-Project-System-PR
-# URL: https://dev.azure.com/dnceng/public/_build?definitionId=1176
+# URL: https://dev.azure.com/dnceng-public/public/_build?definitionId=32
 
 # Validates commits as part of GitHub pull requests.
 

--- a/eng/pipelines/templates/build-pull-request.yml
+++ b/eng/pipelines/templates/build-pull-request.yml
@@ -17,6 +17,12 @@ jobs:
   - script:
     displayName: === Build Repository ===
     condition: false
+  
+  - powershell: $(Build.SourcesDirectory)/eng/scripts/AddNpmToPath.ps1
+    displayName: Add npm to path
+
+  - powershell: npm --version
+    displayName: Check npm version
 
   # Runs the full build of the projects in the repository. See Build.proj for details.
   - script: $(Build.SourcesDirectory)/build.cmd /v:normal /p:Configuration=$(BuildConfiguration) /p:CIBuild=true
@@ -41,13 +47,29 @@ jobs:
 
   # Publishes the test results to the Azure Pipeline itself so they can be viewed in the UI.
   # This needs to be ran after the build, because if the build failed due to a test failure, the test results wouldn't be published.
+  # This uploads for .NET Framework run on main branch
   - task: PublishTestResults@2
-    displayName: Publish Test Results
+    displayName: Publish Test Results (XUnit)
     inputs:
       testRunner: XUnit
       testResultsFiles: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/TestResults/*.xml
       testRunTitle: Unit Test Results
     condition: succeededOrFailed()
+    # We continue on error because this phase can fail when running tests using dotnet test. Remove when testing combines.
+    continueOnError: true
+
+  # Publishes the test results to the Azure Pipeline itself so they can be viewed in the UI.
+  # This needs to be ran after the build, because if the build failed due to a test failure, the test results wouldn't be published.
+  # This uploads for .NET Core run on C# dev kit branch
+  - task: PublishTestResults@2
+    displayName: Publish Test Results (VSTest)
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/TestResults/**/*.trx
+      testRunTitle: Unit Test Results
+    condition: succeededOrFailed()
+    # We continue on error because this phase can fail when running tests using xunit. Remove when testing combines.
+    continueOnError: true
 
   # The .artifactignore file filters the artifacts published from a particular folder.
   # This must be present in the folder we want to publish and be named '.artifactignore'.

--- a/eng/scripts/AddNpmToPath.ps1
+++ b/eng/scripts/AddNpmToPath.ps1
@@ -1,0 +1,7 @@
+# Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+# Gets the path to npm in Helix agent via powershell search.
+
+$arcadeToolsPath = "${env:SYSTEMDRIVE}\arcade-tools"
+$nodeFolderPath = Get-ChildItem $arcadeToolsPath -Filter "node-*" -Directory | ForEach-Object { $_.fullname } | Select-Object -Last 1 
+Write-Host "##vso[task.prependpath]$nodeFolderPath"


### PR DESCRIPTION
Exclude C# dev kit branch - dev/PortToNET6 from official build. We have separate pipeline for build and insertion.
Update PR build pipeline to ensure npm & copy over test results so we can run C# dev kit PRs in same pipeline.