### PR TITLE
Fix label layout to be anchored to the left margin.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblConditionalCompilationSymbols.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>None</value>
+    <value>Left</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="lblConditionalCompilationSymbols.AutoSize" type="System.Boolean, mscorlib">


### PR DESCRIPTION
Note that this is on the legacy property pages.
This change was done manually in the `BuildPropPage.resx` instead of its designer; editing in the `BuildPropPage.vb` designer caused many other properties being changed that had nothing to do with it.


Before:
![image](https://github.com/dotnet/project-system/assets/8518253/c262a0a8-a342-4df3-b6ca-2b865d9ea68e)

After:
![image](https://github.com/dotnet/project-system/assets/8518253/ebe3fb85-0828-440d-abed-60cdeec6a748)

Fixes [AB#1823714](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1823714)

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9088)