### PR TITLE
Simplify getting binlogs from the exp hive

### DIFF
--- a/setup/ProjectSystemSetup/Properties/launchSettings.json
+++ b/setup/ProjectSystemSetup/Properties/launchSettings.json
@@ -10,6 +10,9 @@
         "CSharpDesignTimeTargetsPath": "$(VisualStudioXamlRulesDir)Microsoft.CSharp.DesignTime.targets",
         "CPS_DiagnosticRuntime": "1",
         "CPS_MetricsCollection": "1"
+        // Uncomment the following two lines to capture binlogs of all builds, including design-time builds.
+        //"MSBuildDebugEngine": "1",
+        //"MSBUILDDEBUGPATH": "c:\\binlogs"
       }
     },
     "Start (with native debugging)": {


### PR DESCRIPTION
Getting binlogs is actually quite easy. You only have to set two environment variables to make it work. However you also have to remember what those two variables are, or remember where to find them. And you have to remember to escape backslashes in the path within the JSON.

This change adds the environment variables, commented out, to our `launchSettings.json` file so that it's easier to opt in to this when you want it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9089)