### PR TITLE
Add missing image monikers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -45,8 +45,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.4.0-beta.22470.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.UI.Interfaces"                          Version="17.4.0-beta.22470.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.4.0-preview-2-32826-307" />
+    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.8.36530" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.8.36530" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
     <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.7.5-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/KnownProjectImageMonikers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/KnownProjectImageMonikers.cs
@@ -33,8 +33,7 @@ internal static class KnownProjectImageMonikers
 
     public static ProjectImageMoniker Reference  { get; } = KnownMonikers.Reference.ToProjectSystemType();
     public static ProjectImageMoniker ReferenceWarning { get; } = KnownMonikers.ReferenceWarning.ToProjectSystemType();
-    // TODO get a "ReferenceError" icon https://github.com/dotnet/project-system/issues/8946
-    public static ProjectImageMoniker ReferenceError { get; } = KnownMonikers.ReferenceWarning.ToProjectSystemType();
+    public static ProjectImageMoniker ReferenceError { get; } = KnownMonikers.ReferenceError.ToProjectSystemType();
     public static ProjectImageMoniker ReferencePrivate { get; } = KnownMonikers.ReferencePrivate.ToProjectSystemType();
 
     public static ProjectImageMoniker COM { get; } = KnownMonikers.COM.ToProjectSystemType();
@@ -44,8 +43,7 @@ internal static class KnownProjectImageMonikers
 
     public static ProjectImageMoniker Library { get; } = KnownMonikers.Library.ToProjectSystemType();
     public static ProjectImageMoniker LibraryWarning { get; } = KnownMonikers.LibraryWarning.ToProjectSystemType();
-    // TODO get a "LibraryError" icon https://github.com/dotnet/project-system/issues/8946
-    public static ProjectImageMoniker LibraryError { get; } = KnownMonikers.LibraryWarning.ToProjectSystemType();
+    public static ProjectImageMoniker LibraryError { get; } = KnownMonikers.LibraryError.ToProjectSystemType();
 
     public static ProjectImageMoniker Framework { get; } = KnownMonikers.Framework.ToProjectSystemType();
     public static ProjectImageMoniker FrameworkWarning { get; } = KnownMonikers.FrameworkWarning.ToProjectSystemType();


### PR DESCRIPTION
Fixes #8946

Bump package versions in order to be able to reference newly added image monikers for dependency nodes.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9107)