### PR TITLE
Add file modification warning to change accessibility combobox in legacy resx editor

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -83,7 +83,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ' checked the project system yet)
         ' This field should only be accessed through the CustomToolsRegistered property.
         Private _customToolsRegistered As Boolean?
-        Private Shared _allowEdit As Boolean
+        Private _allowEdit As Boolean
 
 #Region "Nested class CodeGenerator"
 
@@ -451,12 +451,12 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                            If ResourceView.DsMsgBox(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_UpdateADependentFile, MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2, HelpIDs.Err_EditFormResx) = DialogResult.Yes Then
                                 _allowEdit = True
                             End If
-                            Else
-                                _allowEdit = False
                         End If
                         If _allowEdit Then
                             TrySetCustomToolValue(codeGenerator.CustomToolValue)
                         End If
+
+                        _allowEdit = False
                     End If
                     Return
                 End If

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/AccessModifierComboBox.vb
@@ -4,9 +4,11 @@ Imports System.CodeDom
 Imports System.CodeDom.Compiler
 Imports System.ComponentModel
 Imports System.ComponentModel.Design
+Imports System.Windows.Forms
 
 Imports Microsoft.VisualStudio.Designer.Interfaces
 Imports Microsoft.VisualStudio.Editors.Common
+Imports Microsoft.VisualStudio.Editors.ResourceEditor
 Imports Microsoft.VisualStudio.Shell.Interop
 
 Namespace Microsoft.VisualStudio.Editors.DesignerFramework
@@ -81,6 +83,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         ' checked the project system yet)
         ' This field should only be accessed through the CustomToolsRegistered property.
         Private _customToolsRegistered As Boolean?
+        Private Shared _allowEdit As Boolean
 
 #Region "Nested class CodeGenerator"
 
@@ -438,7 +441,23 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
             For Each codeGenerator As CodeGenerator In _codeGeneratorEntries
                 If codeGenerator.DisplayName.Equals(value, StringComparison.CurrentCultureIgnoreCase) Then
-                    TrySetCustomToolValue(codeGenerator.CustomToolValue)
+                    Dim Designer = CType(RootDesigner, ResourceEditorRootDesigner)
+                    If Designer IsNot Nothing Then
+                        Dim ResourceView As ResourceEditorView = Designer.GetView()
+                        ' We let the base class handle the read only mode
+                        ' As mentioned in ResourceEditorDesignerLoader, "We actually don't want users to edit Form RESX file"
+                        ' so we just need to add the same warning as there for now until the new resource explorer is released
+                        If ResourceView IsNot Nothing AndAlso Not ResourceView.ReadOnlyMode
+                           If ResourceView.DsMsgBox(My.Resources.Microsoft_VisualStudio_Editors_Designer.RSE_Err_UpdateADependentFile, MessageBoxButtons.YesNo, MessageBoxIcon.Warning, MessageBoxDefaultButton.Button2, HelpIDs.Err_EditFormResx) = DialogResult.Yes Then
+                                _allowEdit = True
+                            End If
+                            Else
+                                _allowEdit = False
+                        End If
+                        If _allowEdit Then
+                            TrySetCustomToolValue(codeGenerator.CustomToolValue)
+                        End If
+                    End If
                     Return
                 End If
             Next


### PR DESCRIPTION
Adds the following warning before being allowed to change the class accessibility:
<img width="635" alt="image" src="https://github.com/dotnet/project-system/assets/20359921/dbb4125b-32c0-4d19-872a-514f965edede">

This is an auto-generated linked file, and per comment in this folder "We actually don't want users to edit Form RESX file." There is a warning when modifying the values of this file, this editor will eventually be replaced, it's behavior we don't support anyway, and not a trivial fix, so I think adding the warning is enough. The correct behavior for users is to not modify the file at all - doesn't really make sense why it wasn't just made readonly.

Fixes #9034 


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9109)