### PR TITLE
Pass legacy root node ProjectTreeFlags

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
@@ -228,7 +228,7 @@ internal sealed class LegacyDependencySubscriber : IDependencySubscriber
 
             void Post(ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>> snapshot)
             {
-                // Caller must ensure calls to not overlap
+                // Caller must ensure calls do not overlap
                 _version++;
                 bool accepted = _broadcastBlock.Post(new ProjectVersionedValue<ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>>(
                     snapshot,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
@@ -80,7 +80,7 @@ internal sealed class LegacyDependencySubscriber : IDependencySubscriber
                 normalGroupIcon: rootNode.Icon.ToProjectSystemType(),
                 warningGroupIcon: rootNode.UnresolvedIcon.ToProjectSystemType(),
                 errorGroupIcon: rootNode.UnresolvedIcon.ToProjectSystemType(),
-                groupNodeFlags: ProjectTreeFlags.Empty);
+                groupNodeFlags: rootNode.Flags);
 
             _snapshot = ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty
                 .Add(_dependencyType, ImmutableArray<IDependency>.Empty);


### PR DESCRIPTION
This fixes a regression from the dependency tree rewrite in #9008.

Implementations of the legacy extension point `IProjectDependenciesSubTreeProvider.CreateRootDependencyNode()` return an `IDependencyModel` holding various values to be applied to the group's node. One such value is `IDependencyModel.Flags` which should be applied to the group node. This change fixes that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9123)