### PR TITLE
Simpler fix for FUTD check of copy items when building for debug

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
@@ -151,12 +151,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             return null;
         }
 
-        int IVsUpdateSolutionEvents.UpdateSolution_StartUpdate(ref int pfCancelUpdate)
+        int IVsUpdateSolutionEvents.UpdateSolution_Begin(ref int pfCancelUpdate)
         {
             _solutionBuildEventListener.NotifySolutionBuildStarting();
 
             return HResult.OK;
         }
+
         int IVsUpdateSolutionEvents.UpdateSolution_Done(int fSucceeded, int fModified, int fCancelCommand)
         {
             _solutionBuildEventListener.NotifySolutionBuildCompleted(cancelled: false);
@@ -174,7 +175,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         #region IVsUpdateSolutionEvents stubs
 
         int IVsUpdateSolutionEvents.OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy) => HResult.OK;
-        int IVsUpdateSolutionEvents.UpdateSolution_Begin(ref int pfCancelUpdate) => HResult.OK;
+        int IVsUpdateSolutionEvents.UpdateSolution_StartUpdate(ref int pfCancelUpdate) => HResult.OK;
 
         int IVsUpdateSolutionEvents2.OnActiveProjectCfgChange(IVsHierarchy pIVsHierarchy) => HResult.OK;
         int IVsUpdateSolutionEvents2.UpdateSolution_Begin(ref int pfCancelUpdate) => HResult.OK;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.TimestampCache.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
     internal sealed partial class BuildUpToDateCheck
     {
-        internal readonly struct TimestampCache
+        internal readonly struct TimestampCache : ITimestampCache
         {
             private readonly Dictionary<string, DateTime> _timestampCache = new(StringComparers.Paths);
             private readonly IFileSystem _fileSystem;
@@ -41,6 +41,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 }
 
                 return time;
+            }
+
+            public void ClearTimestamps(IEnumerable<string> paths)
+            {
+                // This should never be called.
+                throw new NotImplementedException();
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/SolutionBuildContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/SolutionBuildContext.cs
@@ -10,7 +10,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate;
 /// </summary>
 internal sealed class SolutionBuildContext
 {
-
     /// <summary>
     /// A cache of timestamps for the absolute paths of both source and target of copy items
     /// across all projects.


### PR DESCRIPTION
This is an alternative implementation of #9130 that also fixes #9124, but in a slightly cleaner way.

The previous fix is fine, however this is slightly more elegant and avoids raising fake events to make things work.

In the F5 case, the SBM does fire `IVsUpdateSolutionEvents.UpdateSolution_Begin` before calling the FUTDC, so changing our implementation to use that event means we construct the `SolutionBuildContext` correctly, even when the SBM calls the FUTDC twice.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9133)