### PR TITLE
Introduce Native AOT properties.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
@@ -9,42 +9,31 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 [AppliesTo(ProjectCapability.DotNet)]
 internal class TrimmingEnumProvider : IDynamicEnumValuesProvider
 {
-
-    [ImportingConstructor]
-    public TrimmingEnumProvider()
-    {
-    }
-
     public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
     {
         return Task.FromResult<IDynamicEnumValuesGenerator>(new TrimmingEnumGenerator());
     }
-}
 
-internal class TrimmingEnumGenerator : IDynamicEnumValuesGenerator
-{
-
-    public bool AllowCustomValues => true;
-
-    public TrimmingEnumGenerator()
+    private class TrimmingEnumGenerator : IDynamicEnumValuesGenerator
     {
-    }
+        public bool AllowCustomValues => true;
 
-    public Task<ICollection<IEnumValue>> GetListedValuesAsync()
-    {
-        List<IEnumValue> enumValues = new()
+        public Task<ICollection<IEnumValue>> GetListedValuesAsync()
+        {
+            List<IEnumValue> enumValues = new()
         {
             new PageEnumValue(new EnumValue { Name = "", DisplayName = "(Default)" }),
             new PageEnumValue(new EnumValue { Name = "none", DisplayName = "None" }),
             new PageEnumValue(new EnumValue { Name = "full", DisplayName = "Full" })
         };
 
-        return Task.FromResult<ICollection<IEnumValue>>(enumValues);
-    }
+            return Task.FromResult<ICollection<IEnumValue>>(enumValues);
+        }
 
-    public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
-    {
-        var value = new PageEnumValue(new EnumValue { Name = userSuppliedValue, DisplayName = userSuppliedValue });
-        return Task.FromResult<IEnumValue?>(value);
+        public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
+        {
+            var value = new PageEnumValue(new EnumValue { Name = userSuppliedValue, DisplayName = userSuppliedValue });
+            return Task.FromResult<IEnumValue?>(value);
+        }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using Microsoft.Build.Framework.XamlTypes;
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
+
+[ExportDynamicEnumValuesProvider("TrimmingEnumProvider")]
+[AppliesTo(ProjectCapability.DotNet)]
+internal class TrimmingEnumProvider : IDynamicEnumValuesProvider
+{
+
+    [ImportingConstructor]
+    public TrimmingEnumProvider()
+    {
+    }
+
+    public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
+    {
+        return Task.FromResult<IDynamicEnumValuesGenerator>(new TrimmingEnumGenerator());
+    }
+}
+
+internal class TrimmingEnumGenerator : IDynamicEnumValuesGenerator
+{
+
+    public bool AllowCustomValues => true;
+
+    public TrimmingEnumGenerator()
+    {
+    }
+
+    public Task<ICollection<IEnumValue>> GetListedValuesAsync()
+    {
+        List<IEnumValue> enumValues = new()
+        {
+            new PageEnumValue(new EnumValue { Name = "", DisplayName = "(Default)" }),
+            new PageEnumValue(new EnumValue { Name = "none", DisplayName = "None" }),
+            new PageEnumValue(new EnumValue { Name = "full", DisplayName = "Full" })
+        };
+
+        return Task.FromResult<ICollection<IEnumValue>>(enumValues);
+    }
+
+    public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)
+    {
+        var value = new PageEnumValue(new EnumValue { Name = userSuppliedValue, DisplayName = userSuppliedValue });
+        return Task.FromResult<IEnumValue?>(value);
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
@@ -16,18 +16,18 @@ internal class TrimmingEnumProvider : IDynamicEnumValuesProvider
 
     private class TrimmingEnumGenerator : IDynamicEnumValuesGenerator
     {
-        public bool AllowCustomValues => true;
-
-        public Task<ICollection<IEnumValue>> GetListedValuesAsync()
-        {
-            List<IEnumValue> enumValues = new()
+        private static readonly List<IEnumValue> s_enumValues = new()
         {
             new PageEnumValue(new EnumValue { Name = "", DisplayName = "(Default)" }),
             new PageEnumValue(new EnumValue { Name = "none", DisplayName = "None" }),
             new PageEnumValue(new EnumValue { Name = "full", DisplayName = "Full" })
         };
 
-            return Task.FromResult<ICollection<IEnumValue>>(enumValues);
+        public bool AllowCustomValues => true;
+
+        public Task<ICollection<IEnumValue>> GetListedValuesAsync()
+        {
+            return Task.FromResult<ICollection<IEnumValue>>(s_enumValues);
         }
 
         public Task<IEnumValue?> TryCreateEnumValueAsync(string userSuppliedValue)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/BuildPropertyPage/TrimmingEnumProvider.cs
@@ -18,7 +18,7 @@ internal class TrimmingEnumProvider : IDynamicEnumValuesProvider
     {
         private static readonly List<IEnumValue> s_enumValues = new()
         {
-            new PageEnumValue(new EnumValue { Name = "", DisplayName = "(Default)" }),
+            new PageEnumValue(new EnumValue { Name = string.Empty, DisplayName = "(Default)" }),
             new PageEnumValue(new EnumValue { Name = "none", DisplayName = "None" }),
             new PageEnumValue(new EnumValue { Name = "full", DisplayName = "Full" })
         };

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -80,7 +80,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             List<IEnumValue> enumValues = new();
             if (_includeEmptyValue)
             {
-                enumValues.Add(new PageEnumValue(new EnumValue { Name = "", DisplayName = VSResources.StartupObjectNotSet }));
+                enumValues.Add(new PageEnumValue(new EnumValue { Name = string.Empty, DisplayName = VSResources.StartupObjectNotSet }));
             }
 
             IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -79,7 +79,7 @@ internal class SplashScreenEnumProvider : IDynamicEnumValuesProvider
             List<IEnumValue> enumValues = new();
             if (_includeEmptyValue)
             {
-                enumValues.Add(new PageEnumValue(new EnumValue { Name = "", DisplayName = VSResources.StartupObjectNotSet }));
+                enumValues.Add(new PageEnumValue(new EnumValue { Name = string.Empty, DisplayName = VSResources.StartupObjectNotSet }));
             }
 
             IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -135,6 +135,9 @@
     <ProjectCapability Include="WPF" Condition="'$(UseWPF)' == 'true'" />
     <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
     <ProjectCapability Include="DataSourceWindow" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')" />
+    
+    <!-- Native AOT compilation -->
+    <ProjectCapability Include="NativeAOTProperties" Condition="'$(ShowNativeAOTProperties)' == 'true'"/>
   </ItemGroup>
 
   <!-- List of well known rule Contexts that determine which catalog the rule shows up in CPS:
@@ -558,5 +561,10 @@
 
     </ItemGroup>
   </Target>
+
+  <!-- Native AOT properties should be shown by default, except for WPF, WinForms, and class library projects. -->
+  <PropertyGroup>
+    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == '' and '$(UseWPF)' == 'false' and '$(UseWindowsForms)' == 'false' and $(OutputType) != 'Library'">true</ShowNativeAOTProperties>
+  </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -394,7 +394,7 @@
   <DynamicEnumProperty Name="Trimming"
                 DisplayName="Trimming"
                 Description="Select the desired .NET trimming option for optimizing your application's deployment size and performance."
-                HelpUrl="https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net7"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2240879"
                 Category="Publish"
                 EnumProvider="TrimmingEnumProvider"
                 MultipleValuesAllowed="False">
@@ -412,7 +412,7 @@
   <BoolProperty Name="PublishAot"
                 DisplayName="Publish native AOT"
                 Description="Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time."
-                HelpUrl="https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net7"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2240879"
                 Category="Publish">
     <BoolProperty.DataSource>
       <DataSource HasConfigurationCondition="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -26,6 +26,10 @@
               Description="Configures custom events that run before and after build."
               DisplayName="Events" />
 
+    <Category Name="Publish"
+              DisplayName="Publish"
+              Description="Configures options in the publish process." />
+    
     <Category Name="StrongNaming"
               Description="Configures strong name signing of build outputs."
               DisplayName="Strong naming" />
@@ -386,6 +390,45 @@
     <EnumValue Name="OnOutputUpdated"
                DisplayName="When the output is updated" />
   </EnumProperty>
+
+  <DynamicEnumProperty Name="Trimming"
+                DisplayName="Trimming"
+                Description="Select the desired .NET trimming option for optimizing your application's deployment size and performance."
+                HelpUrl="https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net7"
+                Category="Publish"
+                EnumProvider="TrimmingEnumProvider"
+                MultipleValuesAllowed="False">
+    <DynamicEnumProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  Persistence="ProjectFileWithInterception"/>
+    </DynamicEnumProperty.DataSource>
+    <DynamicEnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-net-core-app-version-or-greater "8.0")</NameValuePair.Value>
+      </NameValuePair>
+    </DynamicEnumProperty.Metadata>
+  </DynamicEnumProperty>
+
+  <BoolProperty Name="PublishAot"
+                DisplayName="Publish native AOT"
+                Description="Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time."
+                HelpUrl="https://learn.microsoft.com/dotnet/core/deploying/native-aot/?tabs=net7"
+                Category="Publish">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="False" />
+    </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>
+          (and
+            (has-net-core-app-version-or-greater "8.0")
+            (or
+              (not (has-project-capability "WinForms"))
+              (not (has-project-capability "WPF"))))
+        </NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
 
   <BoolProperty Name="SignAssembly"
                 Description="Sign the output assembly to give it a strong name."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -424,6 +424,7 @@
                DisplayName="When the output is updated" />
   </EnumProperty>
 
+  <!-- These Native AOT properties should not be visible for WPF, WinForms, MAUI or class library projects. -->
   <DynamicEnumProperty Name="Trimming"
                 DisplayName="Trimming"
                 Description="Select the desired .NET trimming option for optimizing your application's deployment size and performance."
@@ -437,7 +438,13 @@
     </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(has-net-core-app-version-or-greater "8.0")</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (has-net-core-app-version-or-greater "8.0")
+            (and
+               (not (has-evaluated-value "Application" "UseWindowsForms" true))
+               (not (has-evaluated-value "Application" "UseWPF" true))))
+        </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
   </DynamicEnumProperty>
@@ -455,9 +462,9 @@
         <NameValuePair.Value>
           (and
             (has-net-core-app-version-or-greater "8.0")
-            (or
-              (not (has-project-capability "WinForms"))
-              (not (has-project-capability "WPF"))))
+            (and
+               (not (has-evaluated-value "Application" "UseWindowsForms" true))
+               (not (has-evaluated-value "Application" "UseWPF" true))))
         </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -196,7 +196,7 @@
     </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(has-net-core-app-version-or-greater "8.0")</NameValuePair.Value>
+        <NameValuePair.Value>(and (has-net-core-app-version-or-greater "8.0") (has-project-capability "NativeAOTProperties"))</NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>
@@ -212,7 +212,7 @@
     </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(has-net-core-app-version-or-greater "8.0")</NameValuePair.Value>
+        <NameValuePair.Value>(and (has-net-core-app-version-or-greater "8.0") (has-project-capability "NativeAOTProperties"))</NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -184,6 +184,39 @@
                DisplayName="Embedded in DLL/EXE, portable across platforms" />
   </EnumProperty>
 
+  <!-- These bool properties should only be visible for class libraries targeting .NET 8 or higher. -->
+  <BoolProperty Name="IsTrimmable"
+                DisplayName="Trimmable"
+                Description="Marks your assembly as trimmable and enables trim warnings for that project."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2240960"
+                Category="General">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="True"
+                  Persistence="ProjectFileWithInterception" />
+    </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-net-core-app-version-or-greater "8.0")</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
+
+  <BoolProperty Name="IsAotCompatible"
+                DisplayName="AOT Compatible"
+                Description="Indicates that the library project is AOT compatible."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2240960"
+                Category="General">
+    <BoolProperty.DataSource>
+      <DataSource HasConfigurationCondition="True"
+                  Persistence="ProjectFileWithInterception" />
+    </BoolProperty.DataSource>
+    <BoolProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-net-core-app-version-or-greater "8.0")</NameValuePair.Value>
+      </NameValuePair>
+    </BoolProperty.Metadata>
+  </BoolProperty>
+
   <BoolProperty Name="WarningLevelOverridden"
                 ReadOnly="True"
                 Visible="False">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Referenční sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Podepsat výstupní sestavení, aby získalo silný název</target>
@@ -172,6 +182,16 @@
         <target state="translated">Výstup</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Nakonfiguruje podepisování silným názvem výstupů sestavení.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Cílová platforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.cs.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Soubor dokumentace</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Povolte optimalizace kompilátoru pro menší, rychlejší a efektivnější výstup.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Dokumentationsdatei</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Compileroptimierungen für eine kleinere, schnellere und effizientere Ausgabe aktivieren.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.de.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Referenzassembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Hiermit wird die Ausgabeassembly signiert, um ihr einen starken Namen zuzuweisen.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Ausgabe</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Hiermit wird die Signierung mit starken Namen für Buildausgaben konfiguriert.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Zielplattform</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Ensamblado de referencia</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Firme el ensamblado de salida para asignarle un nombre seguro.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Salida</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Configura la firma con nombre seguro de los resultados de compilación.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destino de la plataforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.es.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Archivo de documentación</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Habilita las optimizaciones del compilador para obtener resultados más eficaces, más rápidos y más pequeños.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Assembly de référence</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Signe l'assembly de sortie pour lui donner un nom fort.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Sortie</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Configure la signature de nom fort des sorties de build.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Plateforme cible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.fr.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Fichier de documentation</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Activez les optimisations du compilateur pour une sortie plus petite, plus rapide et plus efficace.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -72,6 +72,26 @@
         <target state="translated">File di documentazione</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Abilita le ottimizzazioni del compilatore per l'output più piccolo, rapido e efficiente.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.it.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Assembly di riferimento</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Firma l'assembly di output per assegnargli un nome sicuro.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Output</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Configura la firma con nome sicuro degli output di compilazione.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destinazione piattaforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -107,6 +107,16 @@
         <target state="translated">参照アセンブリ</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">出力アセンブリに署名して、厳密な名前を付けます。</target>
@@ -172,6 +182,16 @@
         <target state="translated">出力</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">ビルド出力の厳密な名前の署名を構成します。</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">プラットフォーム ターゲット</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ja.xlf
@@ -72,6 +72,26 @@
         <target state="translated">ドキュメント ファイル</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">より小さく、高速で効率的な出力に向けて、コンパイラの最適化を有効にします。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -107,6 +107,16 @@
         <target state="translated">참조 어셈블리</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">출력 어셈블리에 서명하여 강력한 이름을 지정합니다.</target>
@@ -172,6 +182,16 @@
         <target state="translated">출력</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">빌드 출력의 강력한 이름 서명을 구성합니다.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">플랫폼 대상</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ko.xlf
@@ -72,6 +72,26 @@
         <target state="translated">설명서 파일</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">더 작고 빠르며 더 효율적인 출력을 위해 컴파일러 최적화를 사용하도록 설정합니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Plik dokumentacji</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Włącz optymalizacje kompilatora dla mniejszych, szybszych i bardziej wydajnych danych wyjściowych.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pl.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Zestaw odwołań</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Podpisz zestaw wyjściowy, aby nadać mu silną nazwę.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Wyjście</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Konfiguruje podpisywanie silnymi nazwami danych wyjściowych kompilowania.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Platforma docelowa</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Montagem de referência</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Assinar o assembly de saída para dar a ele um nome forte.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Saída</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Configura a assinatura de nome forte das saídas de build.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Destino de plataforma</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.pt-BR.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Arquivo da documentação</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Habilitar otimizações do compilador para uma saída menor, mais rápida e mais eficiente.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Файл документации</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Включить оптимизацию компилятора для быстрого и эффективного получения выходных данных меньшего размера.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.ru.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Базовая сборка</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Подпишите выходную сборку, чтобы дать ей строгое имя.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Выходные данные</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Настраивает подписывание выходных данных сборки со строгим именем.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Целевая платформа</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -107,6 +107,16 @@
         <target state="translated">Başvuru bütünleştirilmiş kodu</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">Daha güçlü bir ad vermek için çıkış bütünleştirilmiş kodunu imzalayın.</target>
@@ -172,6 +182,16 @@
         <target state="translated">Çıkış</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">Derleme çıktılarının tanımlayıcı ad imzasını yapılandırır.</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">Platform hedefi</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.tr.xlf
@@ -72,6 +72,26 @@
         <target state="translated">Belge dosyası</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">Daha küçük, daha hızlı ve daha verimli çıktılar için derleyici iyileştirmelerini etkinleştirin.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -72,6 +72,26 @@
         <target state="translated">文档文件</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">启用编译器优化，实现更小、更快、更高效的输出。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hans.xlf
@@ -107,6 +107,16 @@
         <target state="translated">引用程序集</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">对输出程序集进行签名来向其提供强名称。</target>
@@ -172,6 +182,16 @@
         <target state="translated">输出</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">配置生成输出的强名称签名。</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">目标平台</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -72,6 +72,26 @@
         <target state="translated">文件檔案</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|Description">
+        <source>Indicates that the library project is AOT compatible.</source>
+        <target state="new">Indicates that the library project is AOT compatible.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsAotCompatible|DisplayName">
+        <source>AOT Compatible</source>
+        <target state="new">AOT Compatible</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|Description">
+        <source>Marks your assembly as trimmable and enables trim warnings for that project.</source>
+        <target state="new">Marks your assembly as trimmable and enables trim warnings for that project.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|IsTrimmable|DisplayName">
+        <source>Trimmable</source>
+        <target state="new">Trimmable</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|Optimize|Description">
         <source>Enable compiler optimizations for smaller, faster, and more efficient output.</source>
         <target state="translated">啟用編譯器最佳化以取得較小、更快速且較富效率的輸出。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.xaml.zh-Hant.xlf
@@ -107,6 +107,16 @@
         <target state="translated">參考組件</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|Description">
+        <source>Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</source>
+        <target state="new">Enable Ahead-of-Time (AOT) Compilation to generate native machine code for your .NET Core application during the publish process for improved performance and reduced startup time.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|PublishAot|DisplayName">
+        <source>Publish native AOT</source>
+        <target state="new">Publish native AOT</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|SignAssembly|Description">
         <source>Sign the output assembly to give it a strong name.</source>
         <target state="translated">簽署輸出組件，賦予其強式名稱。</target>
@@ -172,6 +182,16 @@
         <target state="translated">輸出</target>
         <note />
       </trans-unit>
+      <trans-unit id="Category|Publish|Description">
+        <source>Configures options in the publish process.</source>
+        <target state="new">Configures options in the publish process.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Publish|DisplayName">
+        <source>Publish</source>
+        <target state="new">Publish</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Category|StrongNaming|Description">
         <source>Configures strong name signing of build outputs.</source>
         <target state="translated">設定建置輸出的強式名稱簽署。</target>
@@ -190,6 +210,16 @@
       <trans-unit id="DynamicEnumProperty|PlatformTarget|DisplayName">
         <source>Platform target</source>
         <target state="translated">平台目標</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|Description">
+        <source>Select the desired .NET trimming option for optimizing your application's deployment size and performance.</source>
+        <target state="new">Select the desired .NET trimming option for optimizing your application's deployment size and performance.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="DynamicEnumProperty|Trimming|DisplayName">
+        <source>Trimming</source>
+        <target state="new">Trimming</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|DebugType|Description">


### PR DESCRIPTION
Partially covers #9101.

## PublishAot and Trimming

Introduces `PublishAot` and `Trimming` properties into the Build page.

![image](https://github.com/dotnet/project-system/assets/8518253/bce6aa1f-9713-4e8f-b076-4b5f8c36716d)

Their HelpUrls redirect to: https://learn.microsoft.com/dotnet/core/deploying/native-aot/


## IsTrimmable and IsAotCompatible

Also, introduces `IsTrimmable` and `IsAotCompatible` properties into the Build page.

![image](https://github.com/dotnet/project-system/assets/8518253/c2dbc3ce-77a3-4ff5-8de2-ee7678957101)

Their HelpUrls redirect to: https://learn.microsoft.com/dotnet/core/deploying/trimming/prepare-libraries-for-trimming


## Coming up next:
- [x] Remove direct links and use link manager to add help urls.
- [x] Detect when project is WPF/WinForms. _I thought of using the `has-project-capability` in the VisibilityCondition metadata, but seems like this is not being picked up._
- [x] Detect when project is MAUI or a class library.
- [ ] Unit tests.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9139)