### PR TITLE
fix: Force the CoreCompile target to run in design-time builds

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -386,6 +386,26 @@
   <Target Name="CollectResolvedSDKReferencesDesignTime" />
   <Target Name="ResolveFrameworkReferences" />
 
+  <!-- Force the CoreCompile target to run in design-time builds.
+       The project system gets the compiler inputs from the CoreCompile target. However, if the target's
+       outputs are up-to-date with respect to its inputs MSBuild won't run the target and we won't get the
+       compiler arguments. The CoreCompile target includes $(NonExistentFile) as an output; by setting it
+       to the path of a non-existent file we can ensure that MSBuild sees the outputs as out-of-date and
+       runs the target.  -->
+  <Target
+    Name="_ComputeNonExistentFilePropertyDesignTime"
+    Condition="'$(DesignTimeBuild)' == 'true'">
+
+    <PropertyGroup>
+      <NonExistentFile>__NonExistentSubDir__\__NonExistentFile__</NonExistentFile>
+    </PropertyGroup>
+  </Target>
+
+  <!-- Ensure _ComputeNonExistentFilePropertyDesignTime runs before CoreCompile. -->
+  <PropertyGroup>
+    <CoreCompileDependsOn>$(CoreCompileDependsOn);_ComputeNonExistentFilePropertyDesignTime</CoreCompileDependsOn>
+  </PropertyGroup>
+  
   <Target
     Name="ResolveProjectReferencesDesignTime2"
     Returns="@(_ProjectReferencesFromRAR2);@(_ProjectReferencesWithoutOutputAssembly)"


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dotnettools/issues/210
Fixes https://github.com/dotnet/vscode-csharp/issues/5853

Most of the information that the Project System passes on to the Language Service comes from `CscCommandLineArgs` MSBuild items produced during a design-time build. Each item represents one argument--source file, metadata reference, compiler option, etc.--that would be passed to the compiler. To obtain these items the Project System calls the `CoreCompile` target which both creates these items and returns them.

The way the `CoreCompile` target produces these is interesting and a bit tricky. They aren't defined in an `<ItemGroup>` in the target but rather created by the `Csc` task invoked by the target. This is important because of how MSBuild handles targets it considers up-to-date: tasks aren't run, but `<ItemGroup>`s are still evaluated. So if the `CoreCompile` target doesn't run because it is up-to-date, the `CscCommandLineArgs` are never created.

Running the C# compiler can be an expensive operation, so of course we don't want to run it if we don't need to. To this end it specifies its inputs in an `Inputs` attribute and its outputs in an `Outputs` attribute. If the `Outputs` are all newer than the `Inputs` then MSBuild will decide it is up-to-date and doesn't need to run. But now we have two competing requirements: the `CoreCompile` target _must_ run in design-time builds regardless of whether or not it is up-to-date, but it _must not_ run in "real" builds if it is up-to-date.

The target provides a way out of this by specifying `$(NonExistentFile)` as an output. If the property isn't set it has no effect on the MSBuild up-to-date check. But if we set it to a non-existent file then the target will never be considered up-to-date, and will always run. So "real" builds don't set this property at all, and design-time builds set it in some other target that is guaranteed to run before `CoreCompile`.

In .NET SDK-based projects that target is `_ComputeNonExistentFileProperty` in [Microsoft.Common.CurrentVersion.targets](https://github.com/dotnet/msbuild/blob/3c3b3c52a142f75532de216eb7a9b9c832d99da6/src/Tasks/Microsoft.Common.CurrentVersion.targets#L3786). This works well enough in Visual Studio for Windows, but C# Dev Kit doesn't set all of the properties in depends on in its `Condition` attribute. Specifically, `$(BuildingInsideVisualStudio)` must be set to "true"--and C# Dev Kit will _never_ set this property. It makes a whole bunch of changes to the build that make sense in Visual Studio for Windows but lead to incorrect behavior in C# Dev Kit.

The end result is that if a project's `CoreCompile` target is considered up-to-date then the Project System will get very little information on the project (mostly just source files from MSBuild evaluation) and the Language Service will be very broken as the project will appear to have no references. Semantic colorization, completion, Go to Definition, etc. will all be limited to types and members defined in the project itself.

The fix here is to create a new target, `_ComputeNonExistentFilePropertyDesignTime`, that sets `$(NonExistentFile)` anytime we're running a design-time build. This new target lives in Microsoft.Managed.DesignTime.targets which ships with the IDE (VS for Windows and/or C# Dev Kit) rather than the SDK; thus the fix does not depend on the user updating to a newer SDK.

Arguably `_ComputeNonExistentFileProperty` should be removed from the SDK entirely as it effects things the SDK does not itself care about, and the `Condition` logic is strongly tied to the behavior of VS for Windows (actually it's worse than that as some of the logic is only relevant to much older versions of VS for Windows).

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9147)