### PR TITLE
Mark IsExternalInit as private assets

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,7 +103,7 @@
 
     <!-- 3rd party -->
     <PackageVersion Include="Newtonsoft.Json"                                                        Version="13.0.3" />
-    <PackageVersion Include="IsExternalInit"                                                         Version="1.0.3" PrivateAssets="all" />
+    <PackageVersion Include="IsExternalInit"                                                         Version="1.0.3" />
 
     <!-- Tests -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                                                 Version="17.5.0-preview-20221003-04" />
@@ -114,7 +114,7 @@
     <PackageVersion Include="xunit.assert"                                                           Version="2.4.2" />
     <PackageVersion Include="xunit.combinatorial"                                                    Version="1.5.25" />
     <PackageVersion Include="xunit.extensibility.core"                                               Version="2.4.2" />
-    <PackageVersion Include="xunit.extensibility.execution"                                          Version="2.4.2" NoWarn="NU1608" />
+    <PackageVersion Include="xunit.extensibility.execution"                                          Version="2.4.2" />
     <PackageVersion Include="xunit.runner.console"                                                   Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio"                                              Version="2.4.5" />
 

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -55,7 +55,7 @@
 
     <!-- 3rd party -->
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="IsExternalInit" />
+    <PackageReference Include="IsExternalInit" PrivateAssets="all" />
 
     <!-- Host-Agnostic Visual Studio -->
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />


### PR DESCRIPTION
Moving to CPVM requires that extra properties specified on actual package reference now

This package ended up in our package and is blocking our VS insertion because we are using newer version.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9153)