### PR TITLE
fix: Address a missing .xaml file

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -523,7 +523,6 @@
       <DependentUpon>SupportedTargetFrameworkAlias.xaml</DependentUpon>
     </Compile>
     <XamlPropertyRule Include="ProjectSystem\Rules\SupportedTargetFrameworkAlias.xaml">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <XlfInput>false</XlfInput>
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
Fixes [AB#1839581](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1839581)

We have two ways of distributing .xaml files: on disk, and as embedded resources. Each has its own benefits and challenges.

On-disk files are relatively simple: we distribute them with the .NET Project System design-time targets files, and have those targets files include them as `PropertyPageSchema` items. We can also use MSBuild logic in load in a localized version of the .xaml file instead of the English. On the downside we need additional setup authoring to include the .xaml files in our setup package.

Embedding .xaml files as a resource avoids the setup authoring issues, but does require that we specify an appropriate MEF import to make CPS aware of the resource. We are also unable to embed localized versions of the .xaml files (or perhaps we can embed them but not load them; the limitation is not entirely clear).

Here we fix an issue with SupportedTargetFrameworkAlias.xaml. The file is embedded (as it turns out almost all of our files are embedded even if we intend to use them from disk, which is its own issue) and we expect to use the embedded form, _but_ the design-time targets file also has a `PropertyPageSchema` item for it. That's a little weird but not inherently a problem... except that we don't copy the file to the output directory. This means it isn't copied to our NuGet package, which in turn means our C# Dev Kit component doesn't include it. So in C# Dev Kit we end up with a design-time targets file that refers to a file that doesn't exist on disk, and CPS writes an error to its log file.

There's a lot of messiness to our handling of .xaml files in general and dealing with that requires a larger refactoring of how we handle them. Here I make the expedient fix of copying the file to the output directory so it will end up in the NuGet package.

Cleaning up our handling of .xaml files is left to a later change. There are issues around how we're embedding .xaml files that are not fully understood, and I don't want to make a significant change until we do.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9156)