### PR TITLE
Don't copy intermediate translated files

### DIFF
--- a/eng/imports/VisualStudio.XamlRules.targets
+++ b/eng/imports/VisualStudio.XamlRules.targets
@@ -7,17 +7,17 @@
       <Namespace>Microsoft.VisualStudio.ProjectSystem</Namespace>
       <RuleInjectionClassName>$(XamlPropertyRuleInjectionClassName)</RuleInjectionClassName>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <XlfOutputItem>_TranslatedXamlRule</XlfOutputItem>
       <LogicalName>XamlRuleToCode:%(Filename)%(Extension)</LogicalName>
     </XamlPropertyRule>
     <XamlPropertyRuleNoCodeBehind>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <XlfOutputItem>_TranslatedXamlRule</XlfOutputItem>
       <LogicalName>XamlRuleToCode:%(Filename)%(Extension)</LogicalName>
     </XamlPropertyRuleNoCodeBehind>
     <XamlPropertyProjectItemsSchema>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <XlfOutputItem>EmbeddedResource</XlfOutputItem>
+      <XlfOutputItem>_TranslatedXamlRule</XlfOutputItem>
       <LogicalName>XamlRuleToCode:%(Filename)%(Extension)</LogicalName>
     </XamlPropertyProjectItemsSchema>
     <DesignTimeTargetsFile>
@@ -25,9 +25,20 @@
     </DesignTimeTargetsFile>
   </ItemDefinitionGroup>
 
+  <!-- Embed translated XAML rule files but don't copy the EmbeddedResource item to the output.
+       We'll handle that ourselves in CopyTranslatedXamlRulesToOutputDirectory so we can adjust the file name. -->
+  <Target Name="CreateEmbeddedResourceForTranslatedXamlRules"
+          AfterTargets="TranslateSourceFromXlf">
+    <ItemGroup>
+      <EmbeddedResource Include="@(_TranslatedXamlRule)">
+        <CopyToOutputDirectory>False</CopyToOutputDirectory>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
   <!-- Copy XAML rule files and design targets files for testing and setup authoring purposes -->
   <!-- Only copy during the net472 build as that prevents multiple (possibly simultaneous) copies,
-       and only VS uses these files. -->
+       and only VS uses these files from the output directory. -->
   <Target Name="CopyXamlRulesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory"
           Condition="'$(TargetFramework)' == 'net472'">
     <ItemGroup>
@@ -47,15 +58,11 @@
 
   <!-- Copy translated XAML rule files for testing and setup authoring purposes -->
   <!-- Only copy during the net472 build as that prevents multiple (possibly simultaneous) copies,
-       and only VS uses these files. -->
+       and only VS uses these files from the output directory. -->
   <Target Name="CopyTranslatedXamlRulesToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" DependsOnTargets="TranslateSourceFromXlf"
           Condition="'$(TargetFramework)' == 'net472'">
-    <ItemGroup>
-        <_TranslatedItemsToCopy Include="@(EmbeddedResource)" Condition="'%(EmbeddedResource.XlfSourceFormat)' == 'XamlRule'" />
-    </ItemGroup>
-
-    <Copy SourceFiles="@(_TranslatedItemsToCopy)"
-          DestinationFiles="@(_TranslatedItemsToCopy->'$(VisualStudioXamlRulesDir)%(XlfLanguage)\$([System.IO.Path]::GetFileName('%(XlfSource)'))')"
+    <Copy SourceFiles="@(_TranslatedXamlRule)"
+          DestinationFiles="@(_TranslatedXamlRule->'$(VisualStudioXamlRulesDir)%(XlfLanguage)\$([System.IO.Path]::GetFileName('%(XlfSource)'))')"
           SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
           Retries="$(CopyRetryCount)"


### PR DESCRIPTION
Related to AB#1849781.

By default we translate all `XamlPropertyRule`, `XamlPropertyRuleNoCodeBehind`, and `XamlPropertyProjectItemsSchema` items via xliff-tasks. The `XlfOutputItem` metadata on the items specifies what kind of MSBuild item xliff-tasks produces for each translated file. Currently we specify `EmbeddedResource` because we want to embed the translated files in our resource DLLs. When xliff-tasks creates the items it also copies over all the metadata from the original item--including the value of `CopyToOutputDirectory`. We'll get back to that in a moment.

The items created by xliff-tasks represent intermediate files that still need some adjustment. For example, if the input file is AnalyzerReference.xaml, the Spanish translation will be AnalyzerReference.es.xaml. When we ship the file we want it to have the original name but live under a locale-specific folder, like es\AnalyzerReference.xaml. The `CopyTranslatedXamlRulesToOutputDirectory` target takes care of this for us.

However, the intermediate items are still `EmbeddedResources` with `CopyToOutputDirectory` set to `PreserveNewest`. So the standard targets that handle copying to the output directory find these intermediate `EmbeddedResource` items and, indeed, copy them. One effect of this is that they get copied into the NPM package we produce for C# Dev Kit even though they will never get used from that location (even if they had the right name and directory structure). While these files are functionally harmless they make the NPM package much larger and will also impose maintenance costs--future devs will have to waste time trying to understand why they are present and what they do.

The fix here is to have xliff-tasks put these intermediate files into an intermediate item, `_TranslatedXamlRule`. We then have a target, `CreateEmbeddedResourceForTranslatedXamlRules`, that handles creating the `EmbeddedResource` items but resets the `CopyToOutputDirectory` metadata. Since we have now put all the translated XAML rules into their own convenient item group we also update `CopyTranslatedXamlRulesToOutputDirectory` to use that instead of digging through all the `EmbeddedResource`s to find the ones it cares about.

This reduces the NPM package to the expected files: a couple of assemblies and some package metadata files.

> Aside: Whether or not it is desirable to embed all these files as resources and whether or not we are doing it correctly such that CPS can find them at runtime are open questions that I do not attempt to address here.