### PR TITLE
[17.7] Avoid bug during FUTDC validation after solution build completes

### DIFF
--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - name: Clone the repository
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      uses: actions/checkout@v3
 
     - name: Validate Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@9710f0fec812ce0a3b98bef4c9d842fc1f39d976
+      uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         use-quiet-mode: 'yes'
         # https://github.com/tcort/markdown-link-check#config-file-format

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
     - name: Clone the repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@96f53100ba2a5449eb71d2e6604bbcd94b9449b5
 
     - name: Validate Markdown links
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@322b2315689b8cc8c65c14a07064ec862e62ee7c
       with:
         use-quiet-mode: 'yes'
         # https://github.com/tcort/markdown-link-check#config-file-format


### PR DESCRIPTION
This is a backport of #9161 for 17.7.

I also included the GitHub actions changes from #9141 to ensure we don't get build failures for this PR. Those changes don't effect shipping code, just an optional check on GitHub to validate dead links in markdown files.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9167)