### PR TITLE
feature: Add resource DLLs to NPM package

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -712,11 +712,14 @@
     </None>
   </ItemGroup>
 
-  <Target Name="AddFilesForNpmPackage" DependsOnTargets="Build" Condition="'$(TargetFramework)' == 'net7.0'">
+  <Target Name="AddFilesForNpmPackage" DependsOnTargets="Build;SatelliteDllsProjectOutputGroup" Condition="'$(TargetFramework)' == 'net7.0'">
     <ItemGroup>
       <NpmContent Include="exports.json" />
       <!-- We have a runtime dependency on Microsoft.CodeAnalysis.dll in VS Code scenarios. -->
       <NpmContent Include="$(PkgMicrosoft_CodeAnalysis_Common)\lib\net6.0\Microsoft.CodeAnalysis.dll" />
+      <NpmContent Include="@(SatelliteDllsProjectOutputGroupOutput)">
+        <PackagePath>%(SatelliteDllsProjectOutputGroupOutput.TargetPath)</PackagePath>
+      </NpmContent>
     </ItemGroup>
   </Target>
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Setup/PackageContentTests.NpmPackage.verified.txt
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Setup/PackageContentTests.NpmPackage.verified.txt
@@ -2,5 +2,18 @@
   exports.json,
   Microsoft.CodeAnalysis.dll,
   Microsoft.VisualStudio.ProjectSystem.Managed.dll,
-  package.json
+  package.json,
+  cs\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  de\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  es\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  fr\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  it\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  ja\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  ko\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  pl\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  pt-BR\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  ru\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  tr\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  zh-Hans\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
+  zh-Hant\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll
 ]


### PR DESCRIPTION
Related to [AB#1839423](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1839423).

This commit updates our build to include the Microsoft.VisualStudio.ProjectSystem.Managed resource DLLs in locale-specific directories within the NPM package. This is the layout that the .NET resource manager generally expects for automatic discovery of locale-specific resources.

Here our existing `AddFilesForNpmPackage` target takes a dependency on the `SatelliteDllsProjectOutputGroup` target. The latter creates `SatelliteDllsProjectOutputGroupOutput` items representing each locale-specific .resource.dll, and the former converts these to the `NpmContent` items used by later tasks to actually create the package.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9168)