### PR TITLE
Check if a custom namespace has been specified when generating the Settings designer class.

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -144,10 +144,11 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 '   appropriate code.
                 '
                 Dim projectRootNamespace As String = String.Empty
+
                 If isVB Then
                     projectRootNamespace = GetProjectRootNamespace()
                 End If
-                
+
                 ' then get the CodeCompileUnit for this .settings file
                 '
                 Dim generatedClass As CodeTypeDeclaration = Nothing
@@ -254,9 +255,15 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             ' Create a new namespace to put our class in
             '
             Dim ns as CodeNamespace
-            
+
             If IsVb Then
-                ns = New CodeNamespace(MyNamespaceName)
+                ' Check if the project has a custom namespace; if so, use it in the creation of the CompileUnit.
+                If DefaultNamespace IsNot String.Empty Then
+                    ns = New CodeNamespace(DefaultNamespace)
+                Else
+                    ns = New CodeNamespace(MyNamespaceName)
+                End If
+
             Else
                 ns = New CodeNamespace(DesignerFramework.DesignUtil.GenerateValidLanguageIndependentNamespace(DefaultNamespace))
             End If
@@ -1093,4 +1100,4 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
 #End Region
 
     End Class
-End Namespace
+End namespace

--- a/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/SettingsDesigner/SettingsSingleFileGeneratorBase.vb
@@ -265,7 +265,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 End If
 
             Else
-                ns = New CodeNamespace(DesignerFramework.DesignUtil.GenerateValidLanguageIndependentNamespace(DefaultNamespace))
+                ns = New CodeNamespace(DesignUtil.GenerateValidLanguageIndependentNamespace(DefaultNamespace))
             End If
             
             CompileUnit.Namespaces.Add(ns)
@@ -595,8 +595,8 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
             If projectRootNamespace <> "" Then
                 fullTypeName = projectRootNamespace & "."
             End If
-            
-            If defaultNamespace <> "" AndAlso Not defaultNamespace.Equals(MyNamespaceName) Then ' defaultNamespace, if none exists, will come in thru wszDefaultNamespace as My. We don't want to duplicate it.
+
+            If defaultNamespace <> "" AndAlso Not defaultNamespace.Equals(MyNamespaceName, StringComparison.Ordinal) Then ' defaultNamespace, if none exists, will come in thru wszDefaultNamespace as My. We don't want to duplicate it.
                 fullTypeName &= defaultNamespace & "."
             End If
 
@@ -683,7 +683,7 @@ Namespace Microsoft.VisualStudio.Editors.SettingsDesigner
                 .HasSet = False
             }
 
-            Dim fullTypeReference As CodeTypeReference = New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name, isVb)) With {
+            Dim fullTypeReference As New CodeTypeReference(GetFullTypeName(projectRootNamespace, defaultNamespace, GeneratedType.Name, isVb)) With {
                 .Options = CodeTypeReferenceOptions.GlobalReference
             }
             SettingProperty.Type = fullTypeReference


### PR DESCRIPTION
Fixes:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1708985
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1845024

We got a couple of feedback tickets around VB projects having their namespace wrongly generated to the `My` namespace on the `Settings.Designer.vb` file, instead of their custom namespace.

[Back in 2022](https://github.com/dotnet/project-system/pull/8391/commits/0d007c1af0e6234418379e3d7236f73ea3a7cbd7), we added some logic to the `SettingsSingleFileGeneratorBase.vb` to include the `My` namespace if the project was VB; we forgot to include a consideration for custom namespaces, which would be found in the `DefaultNamespace` parameter when calling `Create`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9174)