### PR TITLE
Set up pipeline to create tag in project-system whenever VS release t…

### DIFF
--- a/eng/pipelines/tagger.yml
+++ b/eng/pipelines/tagger.yml
@@ -1,6 +1,6 @@
 # Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-# Name: DotNet-Project-System-Tagger
+# Name: dotnet-project-system-tagger
 # URL: https://dev.azure.com/devdiv/DevDiv/_build?definitionId=17277
 
 # Creates a Git tag in our repo when a VS Insertion PR is merged.
@@ -18,23 +18,19 @@ trigger: none
 pr: none
 
 resources:
-  # https://stackoverflow.com/a/63270937/294804
   # https://learn.microsoft.com/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#triggers
   repositories:
   - repository: VS
     name: VS
     type: git
-    ref: main
     trigger:
-      branches:
+      tags:
         include:
-        - main
-      paths:
-        include:
-        # File containing the package version for Managed/Managed.VS packages.
-        - src/ConfigData/Packages/ProjectSystem/Managed.props
-        # File containing the package version for AppDesigner/Editors packages.
-        - src/ConfigData/Packages/Wizard/packages.props
+        - release/vs/*
+  - repository: DotnetProjectSystem # The name used to reference this repository in the checkout step
+    type: github
+    endpoint: "DotNet-Bot Github Connection"
+    name: dotnet/project-system
 
 pool:
   # Agent Queue: https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=3123&view=jobs
@@ -43,46 +39,21 @@ pool:
   demands: Cmd
 
 variables:
-  # https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/26284/Enabling-SBOM-For-Your-Component-Insertion-into-VS?anchor=1.-add-the-%27manifest-generator-task%27-to-your-pipeline
-  Packaging.EnableSBOMSigning: true
-  # Opt out of automatically injecting Codesign Validation into the pipeline. We run Codesign Validation as part of the Compliance pipeline.
+  # Opt out of automatically injecting Codesign Validation into the pipeline since this pipeline doesn't produce build artifacts.
   # See: https://aka.ms/gdn-injection
   runCodesignValidationInjection: false
-  # Suspend enforcement of NuGet Single Feed Policy. See:
-  # - https://aka.ms/nugetmultifeed
-  # - https://docs.opensource.microsoft.com/tools/nuget_security_analysis/nuget_security_analysis/
-  # - https://docs.opensource.microsoft.com/tools/cg/how-to/nuget-multifeed-configuration/
-  # - https://onebranch.visualstudio.com/OneBranch/_wiki/wikis/OneBranch.wiki/5205/TSG-Build-Broken-Due-to-Using-Multiple-Feeds?anchor=setting-nugetsecurityanalysiswarninglevel-in-cdp
-  NugetSecurityAnalysisWarningLevel: none
-  # Conditionally set the VsCommitId variable based on the VsCommitId parameter.
-  # If the parameter provides a value other than 'Default', it will be used. Otherwise, default to the commit ID of the VS repo.
-  # For conditional variables, see: https://stackoverflow.com/a/70954396/294804
-  # For Build.SourceVersion being set to VS repo commit ID, see: https://learn.microsoft.com/azure/devops/pipelines/repos/multi-repo-checkout?view=azure-devops#triggers
-  ${{ if eq(parameters.VsCommitId, 'Default') }}:
-    VsCommitId: $(Build.SourceVersion)
-  ${{ else }}:
-    VsCommitId: ${{ parameters.VsCommitId }}
-
-parameters:
-- name: VsCommitId
-  displayName: VS Commit ID
-  type: string
-  default: Default
-
+  Codeql.Enabled: false
+  
 ###################################################################################################################################################################
 # STEPS
 ###################################################################################################################################################################
 
 steps:
-- checkout: self
-  # Required for using Git commands in the subsequent tasks below. See:
-  # - https://stackoverflow.com/questions/56733922/fatal-could-not-read-password-for-https-organizationnamedev-azure-com-ter#comment108309839_56734304
-  # - https://learn.microsoft.com/azure/devops/pipelines/scripts/git-commands?view=azure-devops&tabs=yaml#allow-scripts-to-access-the-system-token
-  persistCredentials: true
-  # Changes Build.SourcesDirectory from $(Pipeline.Workspace)/s to $(Pipeline.Workspace)/project-system
-  path: project-system
-  # Hard-coded assumption that the commit referenced by the VS insertion is within the last 100 commits to main in the repo.
-  fetchDepth: 100
+- checkout: DotnetProjectSystem
+  persistCredentials: 'true'
+  path: 'project-system'
+  fetchDepth: 1000
+  displayName: Checkout dotnet/project-system
 # Create the VS folder and fetch the VS repo Git information into it, excluding the files themselves (only .git history is required).
 # Doing this manual process over the checkout: VS task saves around 3 minutes. See: https://stackoverflow.com/a/43136160/294804
 # The System.AccessToken is required for the clone to occur. See: https://stackoverflow.com/a/56734304/294804
@@ -91,9 +62,27 @@ steps:
     git config --global advice.detachedHead false
     $null = New-Item -Path '$(Pipeline.Workspace)' -Name VS -ItemType Directory
     Set-Location '$(Pipeline.Workspace)/VS'
-    git init
+    git init --bare
     git remote add origin https://$(System.AccessToken)@dev.azure.com/devdiv/DevDiv/_git/VS
-    git fetch --depth 1 origin $(VsCommitId)
-  displayName: Fetch VS Repo
-- powershell: . '$(Build.SourcesDirectory)/eng/scripts/CreateTagFromVSCommitTitle.ps1' -vsDirectory '$(Pipeline.Workspace)/VS/' -vsCommitId '$(VsCommitId)'
-  displayName: Create VS Insertion Tag
+    git fetch --depth 100 origin $(Build.SourceVersion)
+    $lastInsertionTitle = git log --pretty=%s --grep="Insert DotNet-Project-System" -1 FETCH_HEAD -- :/src/ConfigData/Packages/ProjectSystem/Managed.props :/src/ConfigData/Packages/Wizard/packages.props | Select-Object -First 1
+    if ($lastInsertionTitle)
+    {
+      $hasShortCommitId = $lastInsertionTitle -match 'DotNet-Project-System \([a-zA-Z0-9._-]+:\d+(\.\d+)*:(\w+)\)'
+      if ($hasShortCommitId)
+      {
+        $shortCommitId = $matches[2]
+        $tagName = '$(Build.SourceBranch)'.Substring('refs/tags/'.Length)
+        $releaseName = $tagName.Substring('release/vs/'.Length)
+        Write-Host "TagName: $tagName psCommit: $shortCommitId"
+        # Generated annotated tag in dotnet/project-system
+        Set-Location '$(Pipeline.Workspace)/project-system'
+        git config user.email "dn-bot@microsoft.com"
+        git config user.name "dotnet bot"
+        git tag -a $tagName $shortCommitId -m "Auto tag created by dotnet-bot for VS release $releaseName"
+        git push --tags
+        return
+      }
+    }
+    Write-Host "Unable to find last insertion."
+  displayName: Create tag


### PR DESCRIPTION
…ags are created

- We trigger based on tags created under release/vs/* (If VS changes tag name scheme, we would need to update this)
- Because trigger is different pipeline and tag, there is no way to run the pipeline manually
- We checkout dotnet/project-system repository and create tag in this repository
- dotnet bot account is used to create annotated tag

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9175)