### PR TITLE
Allow enabling Build Acceleration via a feature flag

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FeatureFlagNames.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/FeatureFlagNames.cs
@@ -23,6 +23,12 @@ internal static class FeatureFlagNames
     public const string EnableIncrementalBuildFailureTelemetry = "ManagedProjectSystem.EnableIncrementalBuildFailureTelemetry";
 
     /// <summary>
+    /// Controls whether Build Acceleration should be enabled when a project does not explicitly opt in
+    /// or out via the <c>AccelerateBuildsInVisualStudio</c> MSBuild property.
+    /// </summary>
+    public const string EnableBuildAccelerationByDefault = "ManagedProjectSystem.EnableBuildAccelerationByDefault";
+
+    /// <summary>
     /// When this feature flag is enabled, build diagnostics will be published by CPS and should not be passed to Roslyn.
     /// </summary>
     public const string LspPullDiagnosticsFeatureFlagName = "Lsp.PullDiagnostics";

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -89,6 +89,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             return IsFlagEnabledAsync(FeatureFlagNames.EnableIncrementalBuildFailureTelemetry, defaultValue: false, cancellationToken);
         }
 
+        public ValueTask<bool> IsBuildAccelerationEnabledByDefaultAsync(CancellationToken cancellationToken)
+        {
+            return IsFlagEnabledAsync(FeatureFlagNames.EnableBuildAccelerationByDefault, defaultValue: false, cancellationToken);
+        }
+
         public ValueTask<bool> IsLspPullDiagnosticsEnabledAsync(CancellationToken cancellationToken)
         {
             return IsFlagEnabledAsync(FeatureFlagNames.LspPullDiagnosticsFeatureFlagName, defaultValue: false, cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -66,6 +66,12 @@ namespace Microsoft.VisualStudio.ProjectSystem
         ValueTask<bool> IsIncrementalBuildFailureTelemetryEnabledAsync(CancellationToken cancellationToken);
 
         /// <summary>
+        ///     Gets whether Build Acceleration should be enabled when a project does not explicitly opt in
+        ///     or out via the <c>AccelerateBuildsInVisualStudio</c> MSBuild property.
+        /// </summary>
+        ValueTask<bool> IsBuildAccelerationEnabledByDefaultAsync(CancellationToken cancellationToken);
+
+        /// <summary>
         ///     Gets whether LSP pull diagnostics are enabled.
         /// </summary>
         ValueTask<bool> IsLspPullDiagnosticsEnabledAsync(CancellationToken cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -241,6 +241,33 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Build acceleration is enabled for this project via a feature flag. See &quot;Tools | Options | Environment | Preview Features&quot; to control this setting. See https://aka.ms/vs-build-acceleration..
+        /// </summary>
+        internal static string FUTD_BuildAccelerationEnabledViaFeatureFlag {
+            get {
+                return ResourceManager.GetString("FUTD_BuildAccelerationEnabledViaFeatureFlag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build acceleration is enabled for this project via the &apos;AccelerateBuildsInVisualStudio&apos; MSBuild property. See https://aka.ms/vs-build-acceleration..
+        /// </summary>
+        internal static string FUTD_BuildAccelerationEnabledViaProperty {
+            get {
+                return ResourceManager.GetString("FUTD_BuildAccelerationEnabledViaProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration..
+        /// </summary>
+        internal static string FUTD_BuildAccelerationIsNotEnabledForThisProject {
+            get {
+                return ResourceManager.GetString("FUTD_BuildAccelerationIsNotEnabledForThisProject", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Build acceleration copied {0} files..
         /// </summary>
         internal static string FUTD_BuildAccelerationSummary_1 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -460,6 +460,17 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</value>
     <comment>{0} is a file path.</comment>
   </data>
+  <data name="FUTD_BuildAccelerationEnabledViaFeatureFlag" xml:space="preserve">
+    <value>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</value>
+    <comment>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</comment>
+  </data>
+  <data name="FUTD_BuildAccelerationEnabledViaProperty" xml:space="preserve">
+    <value>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</value>
+    <comment>Do not translate 'AccelerateBuildsInVisualStudio'.</comment>
+  </data>
+  <data name="FUTD_BuildAccelerationIsNotEnabledForThisProject" xml:space="preserve">
+    <value>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</value>
+  </data>
   <data name="DiagnosticLevel_None" xml:space="preserve">
     <value>None</value>
     <comment>Indicates that a diagnostic (i.e. a compiler warning) should be disabled.</comment>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Přidávají se výstupy {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Akcelerace sestavení zkopírovala soubory: {0}.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -82,6 +82,21 @@
         <target state="translated">{0} Ausgaben werden hinzugefügt:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Die Buildbeschleunigung kopierte {0} Dateien.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Agregando salidas de {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">La aceleración de compilación copió {0} archivos.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Ajout de sorties {0} :</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Accélération de build a copié {0} fichiers.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Aggiunta di output {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Accelerazione della compilazione ha copiato {0} file.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -82,6 +82,21 @@
         <target state="translated">{0} 出力の追加:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">ビルド アクセラレーションによって {0} 個のファイルがコピーされました。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -82,6 +82,21 @@
         <target state="translated">{0} 출력 추가:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">빌드 가속이 {0}개의 파일을 복사했습니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Dodawanie {0} danych wyjściowych:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Skopiowane pliki po przyspieszeniu kompilacji: {0}</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Adicionando {0} saídas:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Aceleração de compilação copiada {0} arquivos.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -82,6 +82,21 @@
         <target state="translated">Добавление выходных данных {0}:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Ускорение построения — скопировано столько файлов: {0}.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -82,6 +82,21 @@
         <target state="translated">{0} çıkışları ekleniyor:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">Derleme hızlandırması {0} dosyayı kopyaladı.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -82,6 +82,21 @@
         <target state="translated">正在添加 {0} 个输出:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">生成加速已复制 {0} 文件。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -82,6 +82,21 @@
         <target state="translated">正在新增 {0} 輸入:</target>
         <note>{0} is an MSBuild item type.</note>
       </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaFeatureFlag">
+        <source>Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.</target>
+        <note>"Tools | Options | Environment | Preview Features" references UI labels that must be made to match the equivalent values in each culture.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationEnabledViaProperty">
+        <source>Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.</target>
+        <note>Do not translate 'AccelerateBuildsInVisualStudio'.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_BuildAccelerationIsNotEnabledForThisProject">
+        <source>Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</source>
+        <target state="new">Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="FUTD_BuildAccelerationSummary_1">
         <source>Build acceleration copied {0} files.</source>
         <target state="translated">建置加速已複製 {0} 個檔案。</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -9,6 +9,7 @@ using Xunit.Abstractions;
 
 #pragma warning disable IDE0055
 #pragma warning disable IDE0058
+#pragma warning disable CS0649 // Field is never assigned to
 
 namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 {
@@ -37,6 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         // Values returned by mocks that may be modified in test cases as needed
         private bool _isTaskQueueEmpty = true;
         private bool _isFastUpToDateCheckEnabledInSettings = true;
+        private bool _isBuildAccelerationEnabledInSettings;
         private bool? _isBuildAccelerationEnabled;
         private IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> _copyItems = Enumerable.Empty<(string Path, ImmutableArray<CopyItem> CopyItems)>();
         private bool _isCopyItemsComplete = true;
@@ -62,6 +64,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 .ReturnsAsync(_logLevel);
             projectSystemOptions.Setup(o => o.GetIsFastUpToDateCheckEnabledAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => _isFastUpToDateCheckEnabledInSettings);
+            projectSystemOptions.Setup(o => o.IsBuildAccelerationEnabledByDefaultAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => _isBuildAccelerationEnabledInSettings);
 
             var projectCommonServices = IProjectCommonServicesFactory.CreateWithDefaultThreadingPolicy();
             var jointRuleSource = new ProjectValueDataSource<IProjectSubscriptionUpdate>(projectCommonServices);
@@ -251,6 +255,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 """
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     No build outputs defined.
                 Project is up-to-date.
@@ -268,6 +273,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 """
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     No build outputs defined.
                 Project is up-to-date.
@@ -277,6 +283,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Critical build tasks are running, not up-to-date.
                 """,
                 "CriticalTasks");
@@ -309,6 +316,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 The set of project items was changed more recently ({ToLocalTime(itemChangedTime)}) than the last successful build start time ({ToLocalTime(lastBuildTime)}), not up-to-date.
                     Compile item added 'ItemPath1'
                     Compile item added 'ItemPath2'
@@ -348,6 +356,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -385,6 +394,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -411,6 +421,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 The set of project items was changed more recently ({ToLocalTime(itemChangeTime)}) than the last successful build start time ({ToLocalTime(lastBuildTime)}), not up-to-date.
                     Compile item removed 'Input.cs'
                 """,
@@ -444,6 +455,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -487,6 +499,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -533,6 +546,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -555,6 +569,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Run check again (t5)
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -601,6 +616,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -631,6 +647,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Run check again (t6)
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -677,6 +694,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // Run test (t2)
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -720,6 +738,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckOutput outputs:
                         C:\Dev\Solution\Project\Output
@@ -779,6 +798,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Project is up-to-date.
@@ -788,6 +808,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Project is up-to-date.
@@ -814,6 +835,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertUpToDateAsync(
                     $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Comparing timestamps of copy marker inputs and output:
@@ -885,6 +907,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                    $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Comparing timestamps of copy marker inputs and output:
@@ -924,6 +947,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -976,6 +1000,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1015,6 +1040,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1055,6 +1081,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1103,6 +1130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1157,6 +1185,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1208,6 +1237,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1256,6 +1286,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1293,6 +1324,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
@@ -1336,6 +1368,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertNotUpToDateAsync(
                 $"""
                 Ignoring up-to-date check items with Kind="Ignored"
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckOutput outputs:
                         C:\Dev\Solution\Project\Output
@@ -1386,6 +1419,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckOutput outputs:
                         C:\Dev\Solution\Project\Output
@@ -1432,6 +1466,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             await AssertUpToDateAsync(
                 $"""
                 Ignoring up-to-date check items with Kind="Ignored"
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckOutput outputs:
                         C:\Dev\Solution\Project\Output
@@ -1485,6 +1520,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckOutput outputs:
                         C:\Dev\Solution\Project\Output
@@ -1531,6 +1567,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     No build outputs defined.
                 Checking built output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:
@@ -1560,6 +1597,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     No build outputs defined.
                 Checking built output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:
@@ -1592,6 +1630,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     No build outputs defined.
                 Checking built output ({UpToDateCheckBuilt.SchemaName} with {UpToDateCheckBuilt.OriginalProperty} property) file:
@@ -1637,6 +1676,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -1660,6 +1700,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -1701,6 +1742,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1751,6 +1793,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -1774,6 +1817,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -1815,6 +1859,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1868,6 +1913,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -1891,6 +1937,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -1932,6 +1979,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:
@@ -1969,6 +2017,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             await AssertNotUpToDateAsync(
                 $"""
+                Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                 Comparing timestamps of inputs and outputs:
                     No build outputs defined.
                 Checking items to copy to the output directory:
@@ -2012,6 +2061,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -2035,6 +2085,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 {
                     await AssertUpToDateAsync(
                         $"""
+                        Build acceleration is enabled for this project via the 'AccelerateBuildsInVisualStudio' MSBuild property. See https://aka.ms/vs-build-acceleration.
                         Comparing timestamps of inputs and outputs:
                             No build outputs defined.
                         Checking items to copy to the output directory:
@@ -2076,6 +2127,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             {
                 await AssertNotUpToDateAsync(
                     $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
                     Comparing timestamps of inputs and outputs:
                         No build outputs defined.
                     Checking items to copy to the output directory:


### PR DESCRIPTION
Contributes to #9106. A change is also needed in VS to define the feature flag.

This change adds code that checks the `ManagedProjectSystem.EnableBuildAccelerationByDefault` feature flag when a project does not explicitly define the `AccelerateBuildsInVisualStudio` MSBuild property. This allows users to enable the feature at the IDE level, rather than the project level.

If a project defines the `AccelerateBuildsInVisualStudio` property, then that value overrides any feature flag value.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9181)