### PR TITLE
Fix application of build data item changes to dependency tree

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Snapshot/DependencyExtensions.cs
@@ -25,13 +25,13 @@ internal static class DependencyExtensions
         return max;
     }
 
-    public static DiagnosticLevel GetDiagnosticLevel(this IImmutableDictionary<string, string> properties)
+    public static DiagnosticLevel GetDiagnosticLevel(this IImmutableDictionary<string, string> properties, DiagnosticLevel defaultLevel = DiagnosticLevel.None)
     {
         string? levelString = properties.GetStringProperty(ProjectItemMetadata.DiagnosticLevel);
 
         if (string.IsNullOrWhiteSpace(levelString))
         {
-            return DiagnosticLevel.None;
+            return defaultLevel;
         }
 
         if (StringComparer.OrdinalIgnoreCase.Equals(levelString, "Warning"))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
@@ -88,7 +88,7 @@ internal sealed class MSBuildDependencyCollection
             if (evaluationProjectChange.Difference.AddedItems.Count is 0 &&
                 evaluationProjectChange.Difference.ChangedItems.Count is 0 &&
                 buildProjectChange?.Difference.AddedItems.Count is 0 or null &&
-                buildProjectChange?.Difference.AddedItems.Count is 0 or null)
+                buildProjectChange?.Difference.ChangedItems.Count is 0 or null)
             {
                 // Nothing added or changed. Return early.
                 return;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
@@ -180,10 +180,11 @@ internal abstract class MSBuildDependencyFactoryBase : IMSBuildDependencyFactory
     /// </summary>
     /// <param name="isResolved"><see langword="true"/> if the dependency is resolved, <see langword="false"/> if it is unresolved, or <see langword="null"/> if the status is not yet determined.</param>
     /// <param name="properties">The properties of the item.</param>
+    /// <param name="defaultLevel">The diagnostic level to use when the property is either missing or empty. Intended to receive a dependency's current diagnostic level when an evaluation-only update is being processed.</param>
     /// <returns></returns>
-    protected internal virtual DiagnosticLevel GetDiagnosticLevel(bool? isResolved, IImmutableDictionary<string, string> properties)
+    protected internal virtual DiagnosticLevel GetDiagnosticLevel(bool? isResolved, IImmutableDictionary<string, string> properties, DiagnosticLevel defaultLevel = DiagnosticLevel.None)
     {
-        return (isResolved, properties.GetDiagnosticLevel()) switch
+        return (isResolved, properties.GetDiagnosticLevel(defaultLevel)) switch
         {
             (false, DiagnosticLevel.None) => DiagnosticLevel.Warning,
             (_, DiagnosticLevel level) => level
@@ -380,7 +381,7 @@ internal abstract class MSBuildDependencyFactoryBase : IMSBuildDependencyFactory
             bool? isResolved = isEvaluationOnlySnapshot ? dependency.IsResolved : false;
 
             bool isImplicit = IsImplicit(projectFullPath, properties);
-            DiagnosticLevel diagnosticLevel = GetDiagnosticLevel(isResolved, properties);
+            DiagnosticLevel diagnosticLevel = GetDiagnosticLevel(isResolved, properties, defaultLevel: dependency.DiagnosticLevel);
             string caption = GetUnresolvedCaption(itemSpec, properties);
             ProjectImageMoniker icon = GetIcon(isImplicit, diagnosticLevel);
             ProjectTreeFlags flags = UpdateTreeFlags(itemSpec, FlagCache.Get(isResolved ?? true, isImplicit));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollectionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollectionTests.cs
@@ -382,7 +382,7 @@ public sealed class MSBuildDependencyCollectionTests
         factory.Setup(f => f.GetUnresolvedCaption("Item1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("UnresolvedCaption");
         factory.Setup(f => f.GetResolvedCaption("ResolvedItem1", "Item1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("ResolvedCaption");
         factory.Setup(f => f.UpdateTreeFlags(It.IsAny<string>(), It.IsAny<ProjectTreeFlags>())).Returns((string id, ProjectTreeFlags f) => f);
-        factory.Setup(f => f.GetDiagnosticLevel(It.IsAny<bool?>(), It.IsAny<ImmutableDictionary<string, string>>())).CallBase();
+        factory.Setup(f => f.GetDiagnosticLevel(It.IsAny<bool?>(), It.IsAny<ImmutableDictionary<string, string>>(), It.IsAny<DiagnosticLevel>())).CallBase();
 
         return new MSBuildDependencyCollection(factory.Object);
     }


### PR DESCRIPTION
Fixes [AB#1820619](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1820619)

Due to a copy/paste bug, certain modifications of the project file could not be reflected in the tree. The fix is straightforward.

For example, changing `Version` or `NoWarn` metadata on a `PackageReference` item in such a way to introduce or remove a diagnostic would not update the tree correctly before this fix.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9182)