### PR TITLE
Fix CodeQL in build

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -94,7 +94,7 @@ variables:
   Codeql.Enabled: true
   # Work-around for CodeQL failing with dotnet test. See https://twcsecurityassurance.visualstudio.com/Semmle/_workitems/edit/24228
   Codeql.CLIVersion: 2.13.4
-  Codeql.CLIHash: 892670c6323510b53c25363e301c64f35ecff02000820d0ebc081ee51fc4b2b6 // sha256 hash for windows CLI
+  Codeql.CLIHash: 892670c6323510b53c25363e301c64f35ecff02000820d0ebc081ee51fc4b2b6
   # Default to skipping auto-injection for CodeQL. It is not skipped in the Build job only.
   # https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/codeql/configuring-codeql3000-ado-pipelines#monolithic-repos-and-multistage-pipelines
   Codeql.SkipTaskAutoInjection: true


### PR DESCRIPTION
The CodeQL task in auto-injected into our official builds in order to check for known code vulnerabilities. A bug in CodeQL was causing "dotnet test" to fail (see https://twcsecurityassurance.visualstudio.com/Semmle/_workitems/edit/24228), and while it has been fixed in a newer version of CodeQL it will be a while before the pipeline task picks up the new version. In the meantime we can specify a version with the fix by setting Codeql.CLIVersion and Codeql.CLIHash in our official.yml file.

However, the injected CodeQL task is now complaining that "Hash verification failed" and disabling CodeQL. The issue is the text "// sha256 hash for windows CLI" at the end of the CLIHash value; it is being treated as part of the hash rather than a comment. This change removes the comment.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9185)