### PR TITLE
Don't set "ImportedNamespaces" property anymore

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ReferencesPage/ImportedNamespacesValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ReferencesPage/ImportedNamespacesValueProvider.cs
@@ -126,6 +126,7 @@ internal sealed class ImportedNamespacesValueProvider : InterceptingPropertyValu
             });
         }
 
-        return await GetSelectedImportStringAsync();
+        // We're setting Import items, so this property shouldn't actually be set in the project file 
+        return null;
     }
 }


### PR DESCRIPTION
Removes setting an unused property in the project file

I can't repro https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1848297/ after this, even though it should be an unrelated issue, so... maybe fixes it? TBD