### PR TITLE
Resolve a Component Governance issue

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -62,6 +62,11 @@
     <!-- Package for creating an NPM package during build. -->
     <!-- See: https://dev.azure.com/devdiv/DevDiv/_git/vs-green?path=/components&anchor=packaging-components -->
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.NpmPack" PrivateAssets="all" />
+
+    <!-- Force a particular version of this package to resolve a Component Governance issue. -->
+    <!-- ExcludeAssets="all" is specified because we don't actually want to _use_ the package. -->
+    <!-- TODO: This can be removed when CPS and/or MSBuild no longer depend (directly or transitively) on the bad version. -->
+    <PackageReference Include="System.Security.Cryptography.Pkcs" VersionOverride="7.0.2" ExcludeAssets="all" />
   </ItemGroup>
 
   <!-- Dependencies -->


### PR DESCRIPTION
Versions of System.Security.Cryptography.Pkcs prior to 7.0.2 contain a vulnerability that could lead to a DOS attack. We pull this in through CPS, which is getting it from MSBuild. As best I can tell MSBuild is the only component in the chain that actually uses System.Security.Cryptography.Pkcs; the rest of us are just getting transitive dependencies and so we're getting flagged by Component Governance.

Here we attempt to make Component Governance happy by forcing System.Security.Cryptography.Pkcs to a good version. Since we don't actually want to use the package in any way we specify ExcludeAssets="all".

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9187)