### PR TITLE
Use correct constant for metadata name

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -613,7 +613,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     {
                         string originalPath = itemMetadata[ResolvedCompilationReference.OriginalPathProperty];
                         string resolvedPath = itemMetadata[ResolvedCompilationReference.ResolvedPathProperty];
-                        string copyReferenceInput = itemMetadata[CopyUpToDateMarker.SchemaName];
+                        string copyReferenceInput = itemMetadata[ResolvedCompilationReference.CopyUpToDateMarkerProperty];
 
                         if (!projectFileClassifier.IsNonModifiable(resolvedPath))
                         {


### PR DESCRIPTION
Previous code was using a schema name rather than a property name. They just happened to have the same value, so there's no runtime change here. It's just more semantically correct.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9192)