### PR TITLE
FUTDC avoids checking the same file twice

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -304,17 +304,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             IEnumerable<(string Path, string? ItemType, bool IsRequired)> CollectDefaultInputs()
             {
-                if (state.MSBuildProjectFullPath is not null)
-                {
-                    log.Verbose(nameof(Resources.FUTD_AddingProjectFileInputs));
-                    using (log.IndentScope())
-                    {
-                        log.VerboseLiteral(state.MSBuildProjectFullPath);
-                    }
-                    yield return (Path: state.MSBuildProjectFullPath, ItemType: null, IsRequired: true);
-                }
-
-                if (state.NewestImportInput is not null && !StringComparers.Paths.Equals(state.NewestImportInput, state.MSBuildProjectFullPath))
+                if (state.NewestImportInput is not null)
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingNewestImportInput));
                     using (log.IndentScope())

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.cs
@@ -314,7 +314,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     yield return (Path: state.MSBuildProjectFullPath, ItemType: null, IsRequired: true);
                 }
 
-                if (state.NewestImportInput is not null)
+                if (state.NewestImportInput is not null && !StringComparers.Paths.Equals(state.NewestImportInput, state.MSBuildProjectFullPath))
                 {
                     log.Verbose(nameof(Resources.FUTD_AddingNewestImportInput));
                     using (log.IndentScope())

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -338,6 +338,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             // The first item in this semicolon-separated list of project files will always be the one
             // with the newest timestamp. As we are only interested in timestamps on these files, we can
             // save memory and time by only considering this first path (dotnet/project-system#4333).
+            // Note that we cannot exclude this path using the ProjectFileClassifier, as doing so may
+            // miss other imports of interest.
             string? newestImportInput = new LazyStringSplit(msBuildAllProjects, ';').FirstOrDefault();
 
             ProjectFileClassifier? projectFileClassifier = null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             return new UpToDateCheckImplicitConfiguredInput(
                 projectConfiguration: projectConfiguration,
-                msBuildProjectFullPath: null,
                 msBuildProjectDirectory: null,
                 projectTargetPath: null,
                 copyUpToDateMarkerItem: null,
@@ -53,15 +52,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         /// <see langword="null"/> when the up-to-date check is disabled.
         /// </remarks>
         public ProjectConfiguration ProjectConfiguration { get; }
-
-        /// <summary>
-        /// Gets the full path to the project file.
-        /// </summary>
-        /// <remarks>
-        /// Comes from the <c>MSBuildProjectFullPath</c> MSBuild property.
-        /// For example, <c>C:\repos\MySolution\MyProject\MyProject.csproj</c>.
-        /// </remarks>
-        public string? MSBuildProjectFullPath { get; }
 
         /// <summary>
         /// Gets the full path to the project directory.
@@ -248,7 +238,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
         private UpToDateCheckImplicitConfiguredInput(
             ProjectConfiguration projectConfiguration,
-            string? msBuildProjectFullPath,
             string? msBuildProjectDirectory,
             string? projectTargetPath,
             string? copyUpToDateMarkerItem,
@@ -271,7 +260,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             ProjectCopyData projectCopyData)
         {
             ProjectConfiguration = projectConfiguration;
-            MSBuildProjectFullPath = msBuildProjectFullPath;
             MSBuildProjectDirectory = msBuildProjectDirectory;
             ProjectTargetPath = projectTargetPath;
             CopyUpToDateMarkerItem = copyUpToDateMarkerItem;
@@ -339,7 +327,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 return CreateDisabled(ProjectConfiguration);
             }
 
-            string? msBuildProjectFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, defaultValue: MSBuildProjectFullPath);
+            string? msBuildProjectFullPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectFullPathProperty, defaultValue: null);
             string? msBuildProjectDirectory = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.MSBuildProjectDirectoryProperty, defaultValue: MSBuildProjectDirectory);
             string? projectTargetPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPathProperty, defaultValue: "");
             string? projectOutputPath = jointRuleUpdate.CurrentState.GetPropertyOrDefault(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputPathProperty, defaultValue: OutputRelativeOrFullPath);
@@ -461,7 +449,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             return new(
                 ProjectConfiguration,
-                msBuildProjectFullPath,
                 msBuildProjectDirectory,
                 projectTargetPath,
                 copyUpToDateMarkerItem: UpdateCopyUpToDateMarkerItem(),
@@ -713,7 +700,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             return new(
                 ProjectConfiguration,
-                MSBuildProjectFullPath,
                 MSBuildProjectDirectory,
                 ProjectTargetPath,
                 CopyUpToDateMarkerItem,
@@ -740,7 +726,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         {
             return new(
                 ProjectConfiguration,
-                MSBuildProjectFullPath,
                 MSBuildProjectDirectory,
                 ProjectTargetPath,
                 CopyUpToDateMarkerItem,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.Designer.cs
@@ -196,15 +196,6 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Adding project file inputs:.
-        /// </summary>
-        internal static string FUTD_AddingProjectFileInputs {
-            get {
-                return ResourceManager.GetString("FUTD_AddingProjectFileInputs", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Adding {0} inputs:.
         /// </summary>
         internal static string FUTD_AddingTypedInputs_1 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Resources.resx
@@ -296,9 +296,6 @@ This project was loaded using the wrong project type, likely as a result of rena
     <value>In Set="{4}", no inputs are newer than earliest output '{0}' ({1}). Newest input is '{2}' ({3}).</value>
     <comment>Do not translate 'Set' as this name is used in code. {0} and {2} are file paths. {1} and {2} are datetimes. {4} is the name of the set.</comment>
   </data>
-  <data name="FUTD_AddingProjectFileInputs" xml:space="preserve">
-    <value>Adding project file inputs:</value>
-  </data>
   <data name="FUTD_AddingNewestImportInput" xml:space="preserve">
     <value>Adding newest import input:</value>
   </data>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.cs.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Přidává se nejnovější vstup importu:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Přidávají se vstupy souborů projektů:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Přidávají se vstupy {0} v sadě="{1}":</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.de.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Die neueste Importeingabe wird hinzugefügt:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Projektdateieingaben werden hinzugefügt:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">In Set="{1}" werden {0} Eingaben hinzugefügt:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.es.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Agregando una nueva entrada de importación:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Agregando entradas de archivos de proyecto:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Agregando {0} entradas en Set="{1}":</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.fr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Ajout de l’entrée d’importation la plus récente :</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Ajout d’entrées de fichier projet :</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Ajout d’entrées {0} dans Set="{1}" :</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.it.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Aggiunta dell'input di importazione più recente:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Aggiunta degli input del file di progetto:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Aggiunta di input {0} in Set="{1}":</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ja.xlf
@@ -57,11 +57,6 @@
         <target state="translated">最新のインポート入力の追加:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">プロジェクト ファイル入力の追加:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Set="{1}" で {0} 個の入力の追加:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ko.xlf
@@ -57,11 +57,6 @@
         <target state="translated">최신 가져오기 입력 추가:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">프로젝트 파일 입력 추가:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Set="{1}"에 {0} 입력 추가:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pl.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Dodawanie najnowszych danych wejściowych importu:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Dodawanie danych wejściowych pliku projektu:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Dodawanie {0} danych wejściowych w zestawie Set=„{1}”:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.pt-BR.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Adicionando entrada de importação mais recente:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Adicionando entradas de arquivo de projeto:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Adicionando {0} entradas em Set="{1}":</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.ru.xlf
@@ -57,11 +57,6 @@
         <target state="translated">Добавление новейших входных данных импорта:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Добавление входных данных файла проекта:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">Добавление входных данных {0} в Set="{1}":</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.tr.xlf
@@ -57,11 +57,6 @@
         <target state="translated">En yeni içeri aktarma girişi ekleniyor:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">Proje dosyası girişleri ekleniyor:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">{0} girişleri Set="{1}" içine ekleniyor:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hans.xlf
@@ -57,11 +57,6 @@
         <target state="translated">正在添加最新的导入输入:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">正在添加项目文件输入:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">正在 Set="{1}" 中添加 {0} 个输入:</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/xlf/Resources.zh-Hant.xlf
@@ -57,11 +57,6 @@
         <target state="translated">正在新增最新的匯入輸入:</target>
         <note />
       </trans-unit>
-      <trans-unit id="FUTD_AddingProjectFileInputs">
-        <source>Adding project file inputs:</source>
-        <target state="translated">正在新增專案檔案輸入:</target>
-        <note />
-      </trans-unit>
       <trans-unit id="FUTD_AddingTypedInputsInSet_2">
         <source>Adding {0} inputs in Set="{1}":</source>
         <target state="translated">正在 Set="{1}" 中新增 {0} 輸入:</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -398,8 +398,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -459,8 +457,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -503,8 +499,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -550,8 +544,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -573,8 +565,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -620,8 +610,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -651,8 +639,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -698,8 +684,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -742,8 +726,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckOutput outputs:
                         C:\Dev\Solution\Project\Output
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding Compile inputs:
@@ -951,8 +933,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding ResolvedAnalyzerReference inputs:
@@ -1004,8 +984,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding ResolvedCompilationReference inputs:
@@ -1044,8 +1022,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding UpToDateCheckInput inputs:
@@ -1085,8 +1061,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
@@ -1134,8 +1108,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime1)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
@@ -1189,8 +1161,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime1)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
@@ -1241,8 +1211,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime1)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
@@ -1290,8 +1258,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(buildTime)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
@@ -1328,8 +1294,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 Comparing timestamps of inputs and outputs:
                     Adding UpToDateCheckBuilt outputs:
                         {_builtPath}
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     No inputs are newer than earliest output '{_builtPath}' ({ToLocalTime(outputTime)}). Newest input is '{_projectPath}' ({ToLocalTime(_projectFileTimeUtc)}).
@@ -1376,8 +1340,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     Adding UpToDateCheckBuilt outputs:
                         C:\Dev\Solution\Project\Built
                         Skipping 'C:\Dev\Solution\Project\IgnoredBuilt.dll' with ignored Kind="Ignored"
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding UpToDateCheckInput inputs:
@@ -1427,8 +1389,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     Adding UpToDateCheckBuilt outputs:
                         C:\Dev\Solution\Project\Built
                         C:\Dev\Solution\Project\TaggedBuilt
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding UpToDateCheckInput inputs:
@@ -1474,8 +1434,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     Adding UpToDateCheckBuilt outputs:
                         C:\Dev\Solution\Project\Built
                         Skipping 'C:\Dev\Solution\Project\IgnoredBuilt' with ignored Kind="Ignored"
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding UpToDateCheckInput inputs:
@@ -1528,8 +1486,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     Adding UpToDateCheckBuilt outputs:
                         C:\Dev\Solution\Project\Built
                         C:\Dev\Solution\Project\TaggedBuilt
-                    Adding project file inputs:
-                        {_projectPath}
                     Adding newest import input:
                         {_projectPath}
                     Adding UpToDateCheckInput inputs:


### PR DESCRIPTION
The FUTDC checks the current project file. It also checks the most recently modified import.

Previously the FUTDC would check both the `MSBuildProjectFullPath` (i.e. the current `.csproj` file's path) and the first item of the `MSBuildAllProjects` property, which MSBuild sets to the newest of all imported project files.

As the FUTDC is only interested in the newest input, we only need to check that `MSBuildAllProjects` value and not the `MSBuildProjectFullPath` value. If the project file is newest, it will be covered by `MSBuildAllProjects`. If not, we don't need to check it.

This can save a little time by avoiding a file system check. It also reduces the log output a little. It also removes a localised string.

## Before

```
FastUpToDate:     Adding project file inputs:
FastUpToDate:         D:\repo\MyProject\MyProject.csproj
FastUpToDate:     Adding newest import input:
FastUpToDate:         D:\repo\MyProject\MyProject.csproj
```

## After

```
FastUpToDate:     Adding newest import input:
FastUpToDate:         D:\repo\MyProject\MyProject.csproj
```

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9194)