### PR TITLE
Fix invalid nameFormat patterns

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -136,7 +136,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
                     update => OnSlicesChanged(update, cancellationToken),
                     _unconfiguredProject,
                     ProjectFaultSeverity.LimitedFunctionality,
-                    "LanguageServiceHostSlices {0}"),
+                    nameFormat: "LanguageServiceHostSlices {1}"),
                 linkOptions: DataflowOption.PropagateCompletion,
                 cancellationToken: cancellationToken),
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
@@ -212,6 +212,6 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 // If we got here, we return the input item unchanged (just wrapped in an array).
                 return new[] { input };
             },
-            new ExecutionDataflowBlockOptions { NameFormat = "Workspace update ordering {0}" });
+            new ExecutionDataflowBlockOptions { NameFormat = "Workspace update ordering {1}" });
     }
 }


### PR DESCRIPTION
In `DataflowBlockSlimBase.ToString`, CPS passes two arguments for the formatting of these strings. `{0}` is the type name and `{1}` is the instance's hash code, which uniquely identifies the block instance. When debugging a heap dump want the instance details, as we can see the type name.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9201)