### PR TITLE
Avoid ObjectDisposedException in language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -141,10 +141,14 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     /// <summary>
     /// Adds an object that will be disposed along with this <see cref="Workspace"/> instance.
     /// </summary>
+    /// <remarks>
+    /// If this <see cref="Workspace"/> has already been disposed, <paramref name="disposable"/> will
+    /// be disposed immediately.
+    /// </remarks>
     /// <param name="disposable">The object to dispose when this object is disposed.</param>
     public void ChainDisposal(IDisposable disposable)
     {
-        Verify.NotDisposed(this);
+        // NOTE we intentionally don't Verify.NotDisposed here, as that can cause hangs during workspace construction
 
         _disposableBag.Add(disposable);
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
@@ -42,6 +42,21 @@ public class WorkspaceTests
     }
 
     [Fact]
+    public async Task ChainDisposal_DisposesArgumentIfAlreadyDisposed()
+    {
+        var workspace = await CreateInstanceAsync();
+
+        await workspace.DisposeAsync();
+
+        var disposable = new Mock<IDisposable>(MockBehavior.Strict);
+        disposable.Setup(o => o.Dispose());
+
+        workspace.ChainDisposal(disposable.Object);
+
+        disposable.VerifyAll();
+    }
+
+    [Fact]
     public async Task Dispose_ClearsPrimary()
     {
         var workspace = await CreateInstanceAsync();
@@ -85,8 +100,6 @@ public class WorkspaceTests
         await Assert.ThrowsAsync<ObjectDisposedException>(() => workspace.WriteAsync(w => Task.CompletedTask, CancellationToken.None));
         await Assert.ThrowsAsync<ObjectDisposedException>(() => workspace.WriteAsync(w => TaskResult.EmptyString, CancellationToken.None));
         await Assert.ThrowsAsync<ObjectDisposedException>(() => workspace.OnWorkspaceUpdateAsync(null!));
-
-        Assert.Throws<ObjectDisposedException>(() => workspace.ChainDisposal(null!));
     }
 
     [Theory]


### PR DESCRIPTION
Contributes to [AB#1861138](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1861138)

`WorkspaceFactory` is responsible for creating instances of `Workspace` and setting up their dataflow subscriptions.

General guidance when constructing a dataflow chain is to establish the first link last. In that way, the chain is fully constructed at the point data starts to flow into it.

In the case of the language service, we have two sources — one for evaluation data, and another for build data. This means we cannot prevent data from flowing during construction.

While investigating a dump from a hang, @adrianvmsft and I observed an `ObjectDisposedException` coming from the call to `ChainDisposal`. It appears that something within `Workspace.OnWorkspaceUpdateAsync` is throwing an exception, which causes the `Workspace` to dispose itself before the `WorkspaceFactory.Create` method has finished constructing the object. With the prior code, the subscriptions being created during construction would continue to call `ChainDisposal` during that construction, but calls after the disposal would throw.

This change removes the `Verify.NotDisposed` call as it is not needed, and is actively harmful in this case. Note that this will not leak objects that should otherwise be disposed, as `DisposableBag.Add` will dispose anything passed to it when the bag has already been disposed.

The `ObjectDisposedException` would lead to a hang where the exception would escape through `LanguageServiceHost.OnSlicesChanged` leading to `_firstPrimaryWorkspaceSet` never being set. I will create a separate PR to add exception handling for that, to explicitly fail that object if an exception escapes through that path to prevent this hang in the case of other exceptions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9202)