### PR TITLE
Don't hang when update handling throws, and report NFE

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -136,7 +136,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
                     update => OnSlicesChanged(update, cancellationToken),
                     _unconfiguredProject,
                     ProjectFaultSeverity.LimitedFunctionality,
-                    "LanguageServiceHostSlices {0}"),
+                    nameFormat: "LanguageServiceHostSlices {1}"),
                 linkOptions: DataflowOption.PropagateCompletion,
                 cancellationToken: cancellationToken),
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
@@ -212,6 +212,6 @@ internal class WorkspaceFactory : IWorkspaceFactory
                 // If we got here, we return the input item unchanged (just wrapped in an array).
                 return new[] { input };
             },
-            new ExecutionDataflowBlockOptions { NameFormat = "Workspace update ordering {0}" });
+            new ExecutionDataflowBlockOptions { NameFormat = "Workspace update ordering {1}" });
     }
 }


### PR DESCRIPTION
Fixes [AB#1861138](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1861138)

Includes #9201 as I had to modify the same code here too. That's only a tiny PR thankfully.

Components such as CodeModel can wait on the language service to initialise. In particular, they need the first "primary" workspace to be available, so that it can be interacted with.

Currently that readiness is signalled with a `TaskCompletionSource`.

If the first data update causes an exception in the handler, the previous code would neither complete nor fault that `TaskCompletionSource`, leaving any waiting code to wait indefinitely (hang).

This change ensures that any fault on the handling block causes that `TaskCompletionSource` to be faulted, if it isn't already complete.

We also register the failure with the project fault handler, so that an NFE is sent via telemetry, and a gold bar is displayed to the user indicating the the project is in a state where it will have limited functionality:

![image](https://github.com/dotnet/project-system/assets/350947/ca8728fe-eaf2-4183-928a-a0d6bc624c12)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9203)