### PR TITLE
Update visibility conditions Native AOT properties in rule; migrate ProjectCapability to SDK.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -135,9 +135,6 @@
     <ProjectCapability Include="WPF" Condition="'$(UseWPF)' == 'true'" />
     <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
     <ProjectCapability Include="DataSourceWindow" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')" />
-    
-    <!-- Native AOT compilation -->
-    <ProjectCapability Include="NativeAOTProperties" Condition="'$(ShowNativeAOTProperties)' == 'true'"/>
   </ItemGroup>
 
   <!-- List of well known rule Contexts that determine which catalog the rule shows up in CPS:
@@ -561,12 +558,5 @@
 
     </ItemGroup>
   </Target>
-
-  <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
-  <PropertyGroup>
-    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
-                             and ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '8.0')">true</ShowNativeAOTProperties>
-    <ShowNativeAOTProperties Condition="'$(UseWPF)' == 'true' or '$(UseWindowsForms)' == 'true'">false</ShowNativeAOTProperties>
-  </PropertyGroup>
-
+  
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -565,7 +565,7 @@
   <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
   <PropertyGroup>
     <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
-                             and ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '8.0')">true</ShowNativeAOTProperties>
+                             and ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '8.0')">true</ShowNativeAOTProperties>
     <ShowNativeAOTProperties Condition="'$(UseWPF)' == 'true' or '$(UseWindowsForms)' == 'true'">false</ShowNativeAOTProperties>
   </PropertyGroup>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -562,9 +562,11 @@
     </ItemGroup>
   </Target>
 
-  <!-- Native AOT properties should be shown by default, except for WPF, WinForms, and class library projects. -->
+  <!-- Native AOT properties should be shown by default for projects targeting .NET 8 or higher, except for WPF and WinForms projects -->
   <PropertyGroup>
-    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == '' and '$(UseWPF)' == 'false' and '$(UseWindowsForms)' == 'false' and $(OutputType) != 'Library'">true</ShowNativeAOTProperties>
+    <ShowNativeAOTProperties Condition="'$(ShowNativeAOTProperties)' == ''
+                             and ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '8.0')">true</ShowNativeAOTProperties>
+    <ShowNativeAOTProperties Condition="'$(UseWPF)' == 'true' or '$(UseWindowsForms)' == 'true'">false</ShowNativeAOTProperties>
   </PropertyGroup>
 
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -196,7 +196,11 @@
     </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(and (has-net-core-app-version-or-greater "8.0") (has-project-capability "NativeAOTProperties"))</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+          (has-project-capability "NativeAOTProperties")
+          (has-evaluated-value "Application" "OutputType" "Library"))
+        </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>
@@ -212,7 +216,11 @@
     </BoolProperty.DataSource>
     <BoolProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(and (has-net-core-app-version-or-greater "8.0") (has-project-capability "NativeAOTProperties"))</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+          (has-project-capability "NativeAOTProperties")
+          (has-evaluated-value "Application" "OutputType" "Library"))
+        </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
   </BoolProperty>
@@ -424,7 +432,7 @@
                DisplayName="When the output is updated" />
   </EnumProperty>
 
-  <!-- These Native AOT properties should not be visible for WPF, WinForms, MAUI or class library projects. -->
+  <!-- These Native AOT properties should not be visible for class library projects. -->
   <DynamicEnumProperty Name="Trimming"
                 DisplayName="Trimming"
                 Description="Select the desired .NET trimming option for optimizing your application's deployment size and performance."
@@ -440,10 +448,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-            (has-net-core-app-version-or-greater "8.0")
-            (and
-               (not (has-evaluated-value "Application" "UseWindowsForms" true))
-               (not (has-evaluated-value "Application" "UseWPF" true))))
+          (has-project-capability "NativeAOTProperties")
+          (not (has-evaluated-value "Application" "OutputType" "Library")))
         </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
@@ -461,10 +467,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-            (has-net-core-app-version-or-greater "8.0")
-            (and
-               (not (has-evaluated-value "Application" "UseWindowsForms" true))
-               (not (has-evaluated-value "Application" "UseWPF" true))))
+          (has-project-capability "NativeAOTProperties")
+          (not (has-evaluated-value "Application" "OutputType" "Library")))
         </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -45,11 +45,11 @@
                 HasConfigurationCondition="True" />
   </Rule.DataSource>
   
-  <StringProperty Name="DefineConstants" 
-                       DisplayName="Conditional compilation symbols"
-                       Description="Specifies symbols on which to perform conditional compilation."
-                       HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147079"
-                       Category="General">
+  <StringProperty Name="DefineConstants"
+                  DisplayName="Conditional compilation symbols"
+                  Description="Specifies symbols on which to perform conditional compilation."
+                  HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147079"
+                  Category="General">
     <StringProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="True" />
@@ -67,12 +67,12 @@
   </StringProperty>
 
   <DynamicEnumProperty Name="PlatformTarget"
-                DisplayName="Platform target"
-                Description="Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware."
-                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147129"
-                Category="General"
-                EnumProvider="PlatformTargetEnumProvider"
-                MultipleValuesAllowed="False">
+                       DisplayName="Platform target"
+                       Description="Specifies the processor to be targeted by the output file. Choose 'Any CPU' to specify that any processor is acceptable, allowing the application to run on the broadest range of hardware."
+                       HelpUrl="https://go.microsoft.com/fwlink/?linkid=2147129"
+                       Category="General"
+                       EnumProvider="PlatformTargetEnumProvider"
+                       MultipleValuesAllowed="False">
     <DynamicEnumProperty.DataSource>
       <DataSource Persistence="ProjectFileWithInterception"
                   HasConfigurationCondition="False" />
@@ -125,9 +125,7 @@
             (or
               (has-evaluated-value "Application" "OutputType" "Exe")
               (has-evaluated-value "Application" "OutputType" "WinExe")
-              (has-evaluated-value "Application" "OutputType" "AppContainerExe")
-            )
-          )
+              (has-evaluated-value "Application" "OutputType" "AppContainerExe")))
         </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
@@ -434,12 +432,12 @@
 
   <!-- These Native AOT properties should not be visible for class library projects. -->
   <DynamicEnumProperty Name="Trimming"
-                DisplayName="Trimming"
-                Description="Select the desired .NET trimming option for optimizing your application's deployment size and performance."
-                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2240879"
-                Category="Publish"
-                EnumProvider="TrimmingEnumProvider"
-                MultipleValuesAllowed="False">
+                       DisplayName="Trimming"
+                       Description="Select the desired .NET trimming option for optimizing your application's deployment size and performance."
+                       HelpUrl="https://go.microsoft.com/fwlink/?linkid=2240879"
+                       Category="Publish"
+                       EnumProvider="TrimmingEnumProvider"
+                       MultipleValuesAllowed="False">
     <DynamicEnumProperty.DataSource>
       <DataSource HasConfigurationCondition="False"
                   Persistence="ProjectFileWithInterception"/>
@@ -448,8 +446,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-          (has-project-capability "NativeAOTProperties")
-          (not (has-evaluated-value "Application" "OutputType" "Library")))
+            (has-project-capability "NativeAOTProperties")
+            (not (has-evaluated-value "Application" "OutputType" "Library")))
         </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
@@ -467,8 +465,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-          (has-project-capability "NativeAOTProperties")
-          (not (has-evaluated-value "Application" "OutputType" "Library")))
+            (has-project-capability "NativeAOTProperties")
+            (not (has-evaluated-value "Application" "OutputType" "Library")))
         </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -198,8 +198,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-          (has-project-capability "NativeAOTProperties")
-          (has-evaluated-value "Application" "OutputType" "Library"))
+            (has-project-capability "NativeAOTProperties")
+            (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>
@@ -218,8 +218,8 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-          (has-project-capability "NativeAOTProperties")
-          (has-evaluated-value "Application" "OutputType" "Library"))
+            (has-project-capability "NativeAOTProperties")
+            (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
     </BoolProperty.Metadata>


### PR DESCRIPTION
An improvement to #9139.
Related to #9101.

I have changed the project capability condition to include `NativeAOTProperties` to projects targeting .NET 8 or higher. 
We later exclude/include class libraries when checking the visibility condition: 
- The `IsTrimmable` and `IsAotCompatible` properties should only be shown to class library projects. 
- The `Trimming` and `PublishAot` properties should not be shown to class library projects.

Update: I moved the `ProjectCapability` and its property to the SDK: https://github.com/dotnet/sdk/pull/34485. 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9208)