### PR TITLE
Restructure legacy Build property page for accessibility

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.Designer.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.Designer.vb
@@ -28,18 +28,14 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
         Friend WithEvents txtXMLDocumentationFile As System.Windows.Forms.TextBox
         Friend WithEvents btnAdvanced As System.Windows.Forms.Button
         Friend WithEvents overarchingTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
-        Friend WithEvents generalHeaderTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
-        Friend WithEvents generalLabel As System.Windows.Forms.Label
-        Friend WithEvents generalLineLabel As System.Windows.Forms.Label
+        Friend WithEvents generalTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
         Friend WithEvents errorsAndWarningsTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
-        Friend WithEvents errorsAndWarningsLineLabel As System.Windows.Forms.Label
-        Friend WithEvents errorsAndWarningsLabel As System.Windows.Forms.Label
         Friend WithEvents treatWarningsAsErrorsTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
-        Friend WithEvents treatWarningsAsErrorsLineLabel As System.Windows.Forms.Label
-        Friend WithEvents treatWarningsAsErrorsLabel As System.Windows.Forms.Label
         Friend WithEvents outputTableLayoutPanel As System.Windows.Forms.TableLayoutPanel
-        Friend WithEvents outputLineLabel As System.Windows.Forms.Label
-        Friend WithEvents outputLabel As System.Windows.Forms.Label
+        Friend WithEvents generalGroupBox As SeparatorGroupBox
+        Friend WithEvents errorsAndWarningsGroupBox As SeparatorGroupBox
+        Friend WithEvents treatWarningsAsErrorsGroupBox As SeparatorGroupBox
+        Friend WithEvents outputGroupBox As SeparatorGroupBox
         Friend WithEvents lblSGenOption As System.Windows.Forms.Label
         Friend WithEvents cboSGenOption As System.Windows.Forms.ComboBox
         Private _components As System.ComponentModel.IContainer
@@ -81,24 +77,24 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.btnAdvanced = New System.Windows.Forms.Button()
             Me.overarchingTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.outputTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
-            Me.outputLineLabel = New System.Windows.Forms.Label()
-            Me.outputLabel = New System.Windows.Forms.Label()
-            Me.generalHeaderTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
-            Me.generalLineLabel = New System.Windows.Forms.Label()
-            Me.generalLabel = New System.Windows.Forms.Label()
+            Me.generalGroupBox = New SeparatorGroupBox()
+            Me.errorsAndWarningsGroupBox = New SeparatorGroupBox()
+            Me.treatWarningsAsErrorsGroupBox = New SeparatorGroupBox()
+            Me.outputGroupBox = New SeparatorGroupBox()
+            Me.generalTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
             Me.treatWarningsAsErrorsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
-            Me.treatWarningsAsErrorsLineLabel = New System.Windows.Forms.Label()
-            Me.treatWarningsAsErrorsLabel = New System.Windows.Forms.Label()
             Me.errorsAndWarningsTableLayoutPanel = New System.Windows.Forms.TableLayoutPanel()
-            Me.errorsAndWarningsLineLabel = New System.Windows.Forms.Label()
-            Me.errorsAndWarningsLabel = New System.Windows.Forms.Label()
             Me.lblSGenOption = New System.Windows.Forms.Label()
             Me.cboSGenOption = New System.Windows.Forms.ComboBox()
             Me.lblNullable = New System.Windows.Forms.Label()
             Me.cboNullable = New System.Windows.Forms.ComboBox()
             Me.overarchingTableLayoutPanel.SuspendLayout()
+            Me.generalGroupBox.SuspendLayout()
             Me.outputTableLayoutPanel.SuspendLayout()
-            Me.generalHeaderTableLayoutPanel.SuspendLayout()
+            Me.errorsAndWarningsGroupBox.SuspendLayout()
+            Me.treatWarningsAsErrorsGroupBox.SuspendLayout()
+            Me.outputGroupBox.SuspendLayout()
+            Me.generalTableLayoutPanel.SuspendLayout()
             Me.treatWarningsAsErrorsTableLayoutPanel.SuspendLayout()
             Me.errorsAndWarningsTableLayoutPanel.SuspendLayout()
             Me.SuspendLayout()
@@ -116,13 +112,13 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'chkDefineDebug
             '
             resources.ApplyResources(Me.chkDefineDebug, "chkDefineDebug")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkDefineDebug, 3)
+            Me.generalTableLayoutPanel.SetColumnSpan(Me.chkDefineDebug, 3)
             Me.chkDefineDebug.Name = "chkDefineDebug"
             '
             'chkDefineTrace
             '
             resources.ApplyResources(Me.chkDefineTrace, "chkDefineTrace")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkDefineTrace, 3)
+            Me.generalTableLayoutPanel.SetColumnSpan(Me.chkDefineTrace, 3)
             Me.chkDefineTrace.Name = "chkDefineTrace"
             '
             'lblPlatformTarget
@@ -140,19 +136,19 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'chkPrefer32Bit
             '
             resources.ApplyResources(Me.chkPrefer32Bit, "chkPrefer32Bit")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkPrefer32Bit, 3)
+            Me.generalTableLayoutPanel.SetColumnSpan(Me.chkPrefer32Bit, 3)
             Me.chkPrefer32Bit.Name = "chkPrefer32Bit"
             '
             'chkAllowUnsafeCode
             '
             resources.ApplyResources(Me.chkAllowUnsafeCode, "chkAllowUnsafeCode")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkAllowUnsafeCode, 3)
+            Me.generalTableLayoutPanel.SetColumnSpan(Me.chkAllowUnsafeCode, 3)
             Me.chkAllowUnsafeCode.Name = "chkAllowUnsafeCode"
             '
             'chkOptimizeCode
             '
             resources.ApplyResources(Me.chkOptimizeCode, "chkOptimizeCode")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkOptimizeCode, 3)
+            Me.generalTableLayoutPanel.SetColumnSpan(Me.chkOptimizeCode, 3)
             Me.chkOptimizeCode.Name = "chkOptimizeCode"
             '
             'lblWarningLevel
@@ -181,7 +177,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'rbWarningNone
             '
             resources.ApplyResources(Me.rbWarningNone, "rbWarningNone")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.rbWarningNone, 3)
+            Me.treatWarningsAsErrorsTableLayoutPanel.SetColumnSpan(Me.rbWarningNone, 3)
             Me.rbWarningNone.Name = "rbWarningNone"
             '
             'rbWarningSpecific
@@ -192,7 +188,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'rbWarningAll
             '
             resources.ApplyResources(Me.rbWarningAll, "rbWarningAll")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.rbWarningAll, 3)
+            Me.treatWarningsAsErrorsTableLayoutPanel.SetColumnSpan(Me.rbWarningAll, 3)
             Me.rbWarningAll.Name = "rbWarningAll"
             '
             'txtSpecificWarnings
@@ -223,7 +219,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'chkRegisterForCOM
             '
             resources.ApplyResources(Me.chkRegisterForCOM, "chkRegisterForCOM")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.chkRegisterForCOM, 3)
+            Me.outputTableLayoutPanel.SetColumnSpan(Me.chkRegisterForCOM, 3)
             Me.chkRegisterForCOM.Name = "chkRegisterForCOM"
             '
             'txtXMLDocumentationFile
@@ -239,119 +235,83 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             'overarchingTableLayoutPanel
             '
             resources.ApplyResources(Me.overarchingTableLayoutPanel, "overarchingTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.outputTableLayoutPanel, 0, 16)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.generalHeaderTableLayoutPanel, 0, 0)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsTableLayoutPanel, 0, 12)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.errorsAndWarningsTableLayoutPanel, 0, 9)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkRegisterForCOM, 0, 19)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkXMLDocumentationFile, 0, 18)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtXMLDocumentationFile, 1, 18)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.btnOutputPathBrowse, 2, 17)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtOutputPath, 1, 17)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblOutputPath, 0, 17)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningSpecific, 0, 15)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtSpecificWarnings, 1, 15)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningAll, 0, 14)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.rbWarningNone, 0, 13)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtSupressWarnings, 1, 11)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSupressWarnings, 0, 11)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboWarningLevel, 1, 10)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblWarningLevel, 0, 10)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboPlatformTarget, 1, 4)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkOptimizeCode, 0, 8)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkAllowUnsafeCode, 0, 7)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkPrefer32Bit, 0, 6)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkDefineTrace, 0, 3)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.chkDefineDebug, 0, 2)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.txtConditionalCompilationSymbols, 1, 1)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblConditionalCompilationSymbols, 0, 1)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblPlatformTarget, 0, 4)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblSGenOption, 0, 20)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboSGenOption, 1, 20)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.btnAdvanced, 2, 21)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.lblNullable, 0, 5)
-            Me.overarchingTableLayoutPanel.Controls.Add(Me.cboNullable, 1, 5)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.generalGroupBox, 0, 0)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.errorsAndWarningsGroupBox, 0, 1)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsGroupBox, 0, 2)
+            Me.overarchingTableLayoutPanel.Controls.Add(Me.outputGroupBox, 0, 3)
             Me.overarchingTableLayoutPanel.Name = "overarchingTableLayoutPanel"
             '
-            'outputTableLayoutPanel
+            'generalTableLayoutPanel
             '
-            resources.ApplyResources(Me.outputTableLayoutPanel, "outputTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.outputTableLayoutPanel, 3)
-            Me.outputTableLayoutPanel.Controls.Add(Me.outputLineLabel, 1, 0)
-            Me.outputTableLayoutPanel.Controls.Add(Me.outputLabel, 0, 0)
-            Me.outputTableLayoutPanel.Name = "outputTableLayoutPanel"
-            '
-            'outputLineLabel
-            '
-            Me.outputLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
-            resources.ApplyResources(Me.outputLineLabel, "outputLineLabel")
-            Me.outputLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.outputLineLabel.Name = "outputLineLabel"
-            '
-            'outputLabel
-            '
-            resources.ApplyResources(Me.outputLabel, "outputLabel")
-            Me.outputLabel.Name = "outputLabel"
-            '
-            'generalHeaderTableLayoutPanel
-            '
-            resources.ApplyResources(Me.generalHeaderTableLayoutPanel, "generalHeaderTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.generalHeaderTableLayoutPanel, 3)
-            Me.generalHeaderTableLayoutPanel.Controls.Add(Me.generalLineLabel, 1, 0)
-            Me.generalHeaderTableLayoutPanel.Controls.Add(Me.generalLabel, 0, 0)
-            Me.generalHeaderTableLayoutPanel.Name = "generalHeaderTableLayoutPanel"
-            '
-            'generalLineLabel
-            '
-            Me.generalLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
-            resources.ApplyResources(Me.generalLineLabel, "generalLineLabel")
-            Me.generalLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.generalLineLabel.Name = "generalLineLabel"
-            '
-            'generalLabel
-            '
-            resources.ApplyResources(Me.generalLabel, "generalLabel")
-            Me.generalLabel.Name = "generalLabel"
-            '
-            'treatWarningsAsErrorsTableLayoutPanel
-            '
-            resources.ApplyResources(Me.treatWarningsAsErrorsTableLayoutPanel, "treatWarningsAsErrorsTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.treatWarningsAsErrorsTableLayoutPanel, 3)
-            Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsLineLabel, 1, 0)
-            Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.treatWarningsAsErrorsLabel, 0, 0)
-            Me.treatWarningsAsErrorsTableLayoutPanel.Name = "treatWarningsAsErrorsTableLayoutPanel"
-            '
-            'treatWarningsAsErrorsLineLabel
-            '
-            Me.treatWarningsAsErrorsLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
-            resources.ApplyResources(Me.treatWarningsAsErrorsLineLabel, "treatWarningsAsErrorsLineLabel")
-            Me.treatWarningsAsErrorsLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.treatWarningsAsErrorsLineLabel.Name = "treatWarningsAsErrorsLineLabel"
-            '
-            'treatWarningsAsErrorsLabel
-            '
-            resources.ApplyResources(Me.treatWarningsAsErrorsLabel, "treatWarningsAsErrorsLabel")
-            Me.treatWarningsAsErrorsLabel.Name = "treatWarningsAsErrorsLabel"
+            resources.ApplyResources(Me.generalTableLayoutPanel, "generalTableLayoutPanel")
+            Me.generalTableLayoutPanel.Controls.Add(Me.txtConditionalCompilationSymbols, 1, 0)
+            Me.generalTableLayoutPanel.Controls.Add(Me.lblConditionalCompilationSymbols, 0, 0)
+            Me.generalTableLayoutPanel.Controls.Add(Me.chkDefineDebug, 0, 1)
+            Me.generalTableLayoutPanel.Controls.Add(Me.chkDefineTrace, 0, 2)
+            Me.generalTableLayoutPanel.Controls.Add(Me.lblPlatformTarget, 0, 3)
+            Me.generalTableLayoutPanel.Controls.Add(Me.cboPlatformTarget, 1, 3)
+            Me.generalTableLayoutPanel.Controls.Add(Me.lblNullable, 0, 4)
+            Me.generalTableLayoutPanel.Controls.Add(Me.cboNullable, 1, 4)
+            Me.generalTableLayoutPanel.Controls.Add(Me.chkPrefer32Bit, 0, 5)
+            Me.generalTableLayoutPanel.Controls.Add(Me.chkAllowUnsafeCode, 0, 6)
+            Me.generalTableLayoutPanel.Controls.Add(Me.chkOptimizeCode, 0, 7)
+            Me.generalTableLayoutPanel.Name = "generalTableLayoutPanel"
             '
             'errorsAndWarningsTableLayoutPanel
             '
             resources.ApplyResources(Me.errorsAndWarningsTableLayoutPanel, "errorsAndWarningsTableLayoutPanel")
-            Me.overarchingTableLayoutPanel.SetColumnSpan(Me.errorsAndWarningsTableLayoutPanel, 3)
-            Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.errorsAndWarningsLineLabel, 1, 0)
-            Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.errorsAndWarningsLabel, 0, 0)
+            Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.txtSupressWarnings, 1, 1)
+            Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.lblSupressWarnings, 0, 1)
+            Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.cboWarningLevel, 1, 0)
+            Me.errorsAndWarningsTableLayoutPanel.Controls.Add(Me.lblWarningLevel, 0, 0)
             Me.errorsAndWarningsTableLayoutPanel.Name = "errorsAndWarningsTableLayoutPanel"
             '
-            'errorsAndWarningsLineLabel
+            'treatWarningsAsErrorsTableLayoutPanel
             '
-            Me.errorsAndWarningsLineLabel.AccessibleRole = System.Windows.Forms.AccessibleRole.Separator
-            resources.ApplyResources(Me.errorsAndWarningsLineLabel, "errorsAndWarningsLineLabel")
-            Me.errorsAndWarningsLineLabel.BackColor = System.Drawing.SystemColors.ControlDark
-            Me.errorsAndWarningsLineLabel.Name = "errorsAndWarningsLineLabel"
+            resources.ApplyResources(Me.treatWarningsAsErrorsTableLayoutPanel, "treatWarningsAsErrorsTableLayoutPanel")
+            Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.rbWarningNone, 0, 0)
+            Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.rbWarningAll, 0, 1)
+            Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.rbWarningSpecific, 0, 2)
+            Me.treatWarningsAsErrorsTableLayoutPanel.Controls.Add(Me.txtSpecificWarnings, 1, 2)
+            Me.treatWarningsAsErrorsTableLayoutPanel.Name = "treatWarningsAsErrorsTableLayoutPanel"
             '
-            'errorsAndWarningsLabel
+            'outputTableLayoutPanel
             '
-            resources.ApplyResources(Me.errorsAndWarningsLabel, "errorsAndWarningsLabel")
-            Me.errorsAndWarningsLabel.Name = "errorsAndWarningsLabel"
+            resources.ApplyResources(Me.outputTableLayoutPanel, "outputTableLayoutPanel")
+            Me.outputTableLayoutPanel.Controls.Add(Me.lblOutputPath, 0, 0)
+            Me.outputTableLayoutPanel.Controls.Add(Me.txtOutputPath, 1, 0)
+            Me.outputTableLayoutPanel.Controls.Add(Me.btnOutputPathBrowse, 2, 0)
+            Me.outputTableLayoutPanel.Controls.Add(Me.chkXMLDocumentationFile, 0, 1)
+            Me.outputTableLayoutPanel.Controls.Add(Me.txtXMLDocumentationFile, 1, 1)
+            Me.outputTableLayoutPanel.Controls.Add(Me.chkRegisterForCOM, 0, 2)
+            Me.outputTableLayoutPanel.Controls.Add(Me.lblSGenOption, 0, 3)
+            Me.outputTableLayoutPanel.Controls.Add(Me.cboSGenOption, 1, 3)
+            Me.outputTableLayoutPanel.Controls.Add(Me.btnAdvanced, 2, 4)
+            Me.outputTableLayoutPanel.Name = "outputTableLayoutPanel"
+            '
+            'generalGroupBox
+            '
+            resources.ApplyResources(Me.generalGroupBox, "generalGroupBox")
+            Me.generalGroupBox.Controls.Add(Me.generalTableLayoutPanel)
+            Me.generalGroupBox.Name = "generalGroupBox"
+            '
+            'errorsAndWarningsGroupBox
+            '
+            resources.ApplyResources(Me.errorsAndWarningsGroupBox, "errorsAndWarningsGroupBox")
+            Me.errorsAndWarningsGroupBox.Controls.Add(Me.errorsAndWarningsTableLayoutPanel)
+            Me.errorsAndWarningsGroupBox.Name = "errorsAndWarningsGroupBox"
+            '
+            'treatWarningsAsErrorsGroupBox
+            '
+            resources.ApplyResources(Me.treatWarningsAsErrorsGroupBox, "treatWarningsAsErrorsGroupBox")
+            Me.treatWarningsAsErrorsGroupBox.Controls.Add(Me.treatWarningsAsErrorsTableLayoutPanel)
+            Me.treatWarningsAsErrorsGroupBox.Name = "treatWarningsAsErrorsGroupBox"
+            '
+            'outputGroupBox
+            '
+            resources.ApplyResources(Me.outputGroupBox, "outputGroupBox")
+            Me.outputGroupBox.Controls.Add(Me.outputTableLayoutPanel)
+            Me.outputGroupBox.Name = "outputGroupBox"
             '
             'lblSGenOption
             '
@@ -387,12 +347,20 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
             Me.overarchingTableLayoutPanel.PerformLayout()
             Me.outputTableLayoutPanel.ResumeLayout(False)
             Me.outputTableLayoutPanel.PerformLayout()
-            Me.generalHeaderTableLayoutPanel.ResumeLayout(False)
-            Me.generalHeaderTableLayoutPanel.PerformLayout()
+            Me.outputGroupBox.ResumeLayout(False)
+            Me.outputGroupBox.PerformLayout()
+            Me.generalGroupBox.ResumeLayout(False)
+            Me.generalGroupBox.PerformLayout()
+            Me.generalTableLayoutPanel.ResumeLayout(False)
+            Me.generalTableLayoutPanel.PerformLayout()
             Me.treatWarningsAsErrorsTableLayoutPanel.ResumeLayout(False)
             Me.treatWarningsAsErrorsTableLayoutPanel.PerformLayout()
+            Me.treatWarningsAsErrorsGroupBox.ResumeLayout(False)
+            Me.treatWarningsAsErrorsGroupBox.PerformLayout()
             Me.errorsAndWarningsTableLayoutPanel.ResumeLayout(False)
             Me.errorsAndWarningsTableLayoutPanel.PerformLayout()
+            Me.errorsAndWarningsGroupBox.ResumeLayout(False)
+            Me.errorsAndWarningsGroupBox.PerformLayout()
             Me.ResumeLayout(False)
             Me.PerformLayout()
 

--- a/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/BuildPropPage.resx
@@ -148,7 +148,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblConditionalCompilationSymbols.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblConditionalCompilationSymbols.ZOrder" xml:space="preserve">
     <value>25</value>
@@ -175,7 +175,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;txtConditionalCompilationSymbols.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;txtConditionalCompilationSymbols.ZOrder" xml:space="preserve">
     <value>24</value>
@@ -190,88 +190,58 @@
     <value>True</value>
   </data>
   <data name="overarchingTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>1</value>
   </data>
-  <data name="outputTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+  <data name="outputTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="outputTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="outputTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>3</value>
   </data>
-  <data name="outputLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+  <data name="outputGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="outputLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>48, 6</value>
-  </data>
-  <data name="outputLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
-  </data>
-  <data name="outputLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>544, 1</value>
-  </data>
-  <data name="outputLineLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;outputLineLabel.Name" xml:space="preserve">
-    <value>outputLineLabel</value>
-  </data>
-  <data name="&gt;&gt;outputLineLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;outputLineLabel.Parent" xml:space="preserve">
-    <value>outputTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;outputLineLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="outputLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="outputLabel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="outputGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="outputLabel.Location" type="System.Drawing.Point, System.Drawing">
+  <data name="outputGroupBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 0</value>
   </data>
-  <data name="outputLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 13</value>
-  </data>
-  <data name="outputLabel.TabIndex" type="System.Int32, mscorlib">
+  <data name="outputGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="outputLabel.Text" xml:space="preserve">
+  <data name="outputGroupBox.Text" xml:space="preserve">
     <value>Output</value>
   </data>
-  <data name="&gt;&gt;outputLabel.Name" xml:space="preserve">
-    <value>outputLabel</value>
+  <data name="&gt;&gt;outputGroupBox.Name" xml:space="preserve">
+    <value>outputGroupBox</value>
   </data>
-  <data name="&gt;&gt;outputLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;outputGroupBox.Type" xml:space="preserve">
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.SeparatorGroupBox, Microsoft.VisualStudio.Editors, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
-  <data name="&gt;&gt;outputLabel.Parent" xml:space="preserve">
-    <value>outputTableLayoutPanel</value>
+  <data name="&gt;&gt;outputGroupBox.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;outputLabel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;outputGroupBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="outputTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 404</value>
-  </data>
-  <data name="outputTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="outputGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
+  <data name="outputTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 14</value>
+  </data>
   <data name="outputTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>5</value>
   </data>
   <data name="outputTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>592, 13</value>
   </data>
   <data name="outputTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;outputTableLayoutPanel.Name" xml:space="preserve">
     <value>outputTableLayoutPanel</value>
@@ -280,190 +250,106 @@
     <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;outputTableLayoutPanel.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputGroupBox</value>
   </data>
   <data name="&gt;&gt;outputTableLayoutPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
   <data name="outputTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="outputLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="outputLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name=&quot;btnOutputPathBrowse&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;2&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;txtOutputPath&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;lblOutputPath&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;chkXMLDocumentationFile&quot; Row=&quot;1&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;txtXMLDocumentationFile&quot; Row=&quot;1&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;chkRegisterForCOM&quot; Row=&quot;2&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;lblSGenOption&quot; Row=&quot;3&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;cboSGenOption&quot; Row=&quot;3&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;btnAdvanced&quot; Row=&quot;4&quot; RowSpan=&quot;1&quot; Column=&quot;2&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;/Controls&gt;&lt;Columns Styles=&quot;AutoSize,0,Percent,100,AutoSize,0&quot; /&gt;&lt;Rows Styles=&quot;AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20&quot; /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+  <data name="generalTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
+  <data name="generalTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
+  <data name="generalTableLayoutPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="generalLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+  <data name="generalTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>3</value>
   </data>
-  <data name="generalLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>50, 6</value>
+  <data name="generalTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 14</value>
   </data>
-  <data name="generalLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
-  </data>
-  <data name="generalLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>542, 1</value>
-  </data>
-  <data name="generalLineLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.Name" xml:space="preserve">
-    <value>generalLineLabel</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.Parent" xml:space="preserve">
-    <value>generalHeaderTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;generalLineLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="generalLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="generalLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="generalLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="generalLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
-  </data>
-  <data name="generalLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
-  </data>
-  <data name="generalLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="generalLabel.Text" xml:space="preserve">
-    <value>General</value>
-  </data>
-  <data name="&gt;&gt;generalLabel.Name" xml:space="preserve">
-    <value>generalLabel</value>
-  </data>
-  <data name="&gt;&gt;generalLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;generalLabel.Parent" xml:space="preserve">
-    <value>generalHeaderTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;generalLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="generalHeaderTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="generalHeaderTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="generalTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="generalTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="generalTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>592, 13</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+  <data name="generalTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Name" xml:space="preserve">
-    <value>generalHeaderTableLayoutPanel</value>
+  <data name="&gt;&gt;generalTableLayoutPanel.Name" xml:space="preserve">
+    <value>generalTableLayoutPanel</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Type" xml:space="preserve">
+  <data name="&gt;&gt;generalTableLayoutPanel.Type" xml:space="preserve">
     <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+  <data name="&gt;&gt;generalTableLayoutPanel.Parent" xml:space="preserve">
+    <value>generalGroupBox</value>
   </data>
-  <data name="&gt;&gt;generalHeaderTableLayoutPanel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;generalTableLayoutPanel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="generalHeaderTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="generalLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="generalLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  <data name="generalTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name=&quot;txtConditionalCompilationSymbols&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;lblConditionalCompilationSymbols&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;chkDefineDebug&quot; Row=&quot;1&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;chkDefineTrace&quot; Row=&quot;2&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;lblPlatformTarget&quot; Row=&quot;3&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;cboPlatformTarget&quot; Row=&quot;3&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;lblNullable&quot; Row=&quot;4&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;cboNullable&quot; Row=&quot;4&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;chkPrefer32Bit&quot; Row=&quot;5&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;chkAllowUnsafeCode&quot; Row=&quot;6&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;chkOptimizeCode&quot; Row=&quot;7&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;/Controls&gt;&lt;Columns Styles=&quot;AutoSize,0,Percent,100,AutoSize,0&quot; /&gt;&lt;Rows Styles=&quot;AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0&quot; /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="treatWarningsAsErrorsTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+  <data name="generalGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="generalGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="generalGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="generalGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="generalGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="generalGroupBox.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="&gt;&gt;generalGroupBox.Name" xml:space="preserve">
+    <value>generalGroupBox</value>
+  </data>
+  <data name="&gt;&gt;generalGroupBox.Type" xml:space="preserve">
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.SeparatorGroupBox, Microsoft.VisualStudio.Editors, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="&gt;&gt;generalGroupBox.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;generalGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="generalGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="treatWarningsAsErrorsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="treatWarningsAsErrorsLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <data name="treatWarningsAsErrorsLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>126, 6</value>
-  </data>
-  <data name="treatWarningsAsErrorsLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
-  </data>
-  <data name="treatWarningsAsErrorsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>466, 1</value>
-  </data>
-  <data name="treatWarningsAsErrorsLineLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Name" xml:space="preserve">
-    <value>treatWarningsAsErrorsLineLabel</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.Parent" xml:space="preserve">
-    <value>treatWarningsAsErrorsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLineLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 13</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="treatWarningsAsErrorsLabel.Text" xml:space="preserve">
-    <value>Treat warnings as errors</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Name" xml:space="preserve">
-    <value>treatWarningsAsErrorsLabel</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.Parent" xml:space="preserve">
-    <value>treatWarningsAsErrorsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;treatWarningsAsErrorsLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 306</value>
+    <value>0, 14</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>592, 13</value>
@@ -478,91 +364,61 @@
     <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>treatWarningsAsErrorsGroupBox</value>
   </data>
   <data name="&gt;&gt;treatWarningsAsErrorsTableLayoutPanel.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="treatWarningsAsErrorsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="treatWarningsAsErrorsLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="treatWarningsAsErrorsLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name=&quot;rbWarningNone&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;rbWarningAll&quot; Row=&quot;1&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;3&quot; /&gt;&lt;Control Name=&quot;rbWarningSpecific&quot; Row=&quot;2&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;txtSpecificWarnings&quot; Row=&quot;2&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;/Controls&gt;&lt;Columns Styles=&quot;AutoSize,0,Percent,100,AutoSize,0&quot; /&gt;&lt;Rows Styles=&quot;AutoSize,0,AutoSize,0,AutoSize,0&quot; /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
-  <data name="errorsAndWarningsTableLayoutPanel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
+  <data name="treatWarningsAsErrorsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="treatWarningsAsErrorsGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="treatWarningsAsErrorsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="treatWarningsAsErrorsGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="treatWarningsAsErrorsGroupBox.Text" xml:space="preserve">
+    <value>Treat warnings as errors</value>
+  </data>
+  <data name="&gt;&gt;treatWarningsAsErrorsGroupBox.Name" xml:space="preserve">
+    <value>treatWarningsAsErrorsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;treatWarningsAsErrorsGroupBox.Type" xml:space="preserve">
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.SeparatorGroupBox, Microsoft.VisualStudio.Editors, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="&gt;&gt;treatWarningsAsErrorsGroupBox.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;treatWarningsAsErrorsGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="treatWarningsAsErrorsGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
+  </data>
+  <data name="errorsAndWarningsTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="errorsAndWarningsLineLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left, Right</value>
-  </data>
-  <data name="errorsAndWarningsLineLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 6</value>
-  </data>
-  <data name="errorsAndWarningsLineLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
-  </data>
-  <data name="errorsAndWarningsLineLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>486, 1</value>
-  </data>
-  <data name="errorsAndWarningsLineLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.Name" xml:space="preserve">
-    <value>errorsAndWarningsLineLabel</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.Parent" xml:space="preserve">
-    <value>errorsAndWarningsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLineLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="errorsAndWarningsLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Left</value>
-  </data>
-  <data name="errorsAndWarningsLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="errorsAndWarningsLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="errorsAndWarningsLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 0, 3, 0</value>
-  </data>
-  <data name="errorsAndWarningsLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>100, 13</value>
-  </data>
-  <data name="errorsAndWarningsLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="errorsAndWarningsLabel.Text" xml:space="preserve">
-    <value>Errors and warnings</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.Name" xml:space="preserve">
-    <value>errorsAndWarningsLabel</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.Parent" xml:space="preserve">
-    <value>errorsAndWarningsTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;errorsAndWarningsLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 224</value>
+    <value>0, 14</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>3</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>592, 13</value>
@@ -577,13 +433,43 @@
     <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>errorsAndWarningsGroupBox</value>
   </data>
   <data name="&gt;&gt;errorsAndWarningsTableLayoutPanel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
   <data name="errorsAndWarningsTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="errorsAndWarningsLineLabel" Row="0" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="errorsAndWarningsLabel" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100" /&gt;&lt;Rows Styles="AutoSize,0" /&gt;&lt;/TableLayoutSettings&gt;</value>
+    <value>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name=&quot;cboWarningLevel&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;lblWarningLevel&quot; Row=&quot;0&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;txtSupressWarnings&quot; Row=&quot;1&quot; RowSpan=&quot;1&quot; Column=&quot;1&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;Control Name=&quot;lblSupressWarnings&quot; Row=&quot;1&quot; RowSpan=&quot;1&quot; Column=&quot;0&quot; ColumnSpan=&quot;1&quot; /&gt;&lt;/Controls&gt;&lt;Columns Styles=&quot;AutoSize,0,Percent,100,AutoSize,0&quot; /&gt;&lt;Rows Styles=&quot;AutoSize,0,AutoSize,0,&quot; /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="errorsAndWarningsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="errorsAndWarningsGroupBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="errorsAndWarningsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 0</value>
+  </data>
+  <data name="errorsAndWarningsGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="errorsAndWarningsGroupBox.Text" xml:space="preserve">
+    <value>Errors and warnings</value>
+  </data>
+  <data name="&gt;&gt;errorsAndWarningsGroupBox.Name" xml:space="preserve">
+    <value>errorsAndWarningsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;errorsAndWarningsGroupBox.Type" xml:space="preserve">
+    <value>Microsoft.VisualStudio.Editors.PropertyPages.SeparatorGroupBox, Microsoft.VisualStudio.Editors, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+  </data>
+  <data name="&gt;&gt;errorsAndWarningsGroupBox.Parent" xml:space="preserve">
+    <value>overarchingTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;errorsAndWarningsGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="errorsAndWarningsGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 0, 0, 0</value>
   </data>
   <data name="chkRegisterForCOM.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Left</value>
@@ -613,7 +499,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkRegisterForCOM.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkRegisterForCOM.ZOrder" xml:space="preserve">
     <value>4</value>
@@ -646,7 +532,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkXMLDocumentationFile.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkXMLDocumentationFile.ZOrder" xml:space="preserve">
     <value>5</value>
@@ -673,7 +559,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;txtXMLDocumentationFile.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;txtXMLDocumentationFile.ZOrder" xml:space="preserve">
     <value>6</value>
@@ -706,7 +592,7 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btnOutputPathBrowse.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;btnOutputPathBrowse.ZOrder" xml:space="preserve">
     <value>7</value>
@@ -733,7 +619,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;txtOutputPath.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;txtOutputPath.ZOrder" xml:space="preserve">
     <value>8</value>
@@ -766,7 +652,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblOutputPath.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblOutputPath.ZOrder" xml:space="preserve">
     <value>9</value>
@@ -799,7 +685,7 @@
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;rbWarningSpecific.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;rbWarningSpecific.ZOrder" xml:space="preserve">
     <value>10</value>
@@ -826,7 +712,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;txtSpecificWarnings.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;txtSpecificWarnings.ZOrder" xml:space="preserve">
     <value>11</value>
@@ -859,7 +745,7 @@
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;rbWarningAll.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;rbWarningAll.ZOrder" xml:space="preserve">
     <value>12</value>
@@ -892,7 +778,7 @@
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;rbWarningNone.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>treatWarningsAsErrorsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;rbWarningNone.ZOrder" xml:space="preserve">
     <value>13</value>
@@ -922,7 +808,7 @@
     <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;txtSupressWarnings.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;txtSupressWarnings.ZOrder" xml:space="preserve">
     <value>14</value>
@@ -955,7 +841,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblSupressWarnings.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblSupressWarnings.ZOrder" xml:space="preserve">
     <value>15</value>
@@ -1000,7 +886,7 @@
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cboWarningLevel.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cboWarningLevel.ZOrder" xml:space="preserve">
     <value>16</value>
@@ -1033,7 +919,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblWarningLevel.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>errorsAndWarningsTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblWarningLevel.ZOrder" xml:space="preserve">
     <value>17</value>
@@ -1057,7 +943,7 @@
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cboPlatformTarget.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cboPlatformTarget.ZOrder" xml:space="preserve">
     <value>18</value>
@@ -1090,7 +976,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkOptimizeCode.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkOptimizeCode.ZOrder" xml:space="preserve">
     <value>19</value>
@@ -1123,7 +1009,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkAllowUnsafeCode.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkAllowUnsafeCode.ZOrder" xml:space="preserve">
     <value>20</value>
@@ -1156,7 +1042,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkPrefer32Bit.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkPrefer32Bit.ZOrder" xml:space="preserve">
     <value>21</value>
@@ -1189,7 +1075,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkDefineTrace.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkDefineTrace.ZOrder" xml:space="preserve">
     <value>22</value>
@@ -1222,7 +1108,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblPlatformTarget.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblPlatformTarget.ZOrder" xml:space="preserve">
     <value>26</value>
@@ -1255,7 +1141,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblSGenOption.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblSGenOption.ZOrder" xml:space="preserve">
     <value>27</value>
@@ -1282,7 +1168,7 @@
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cboSGenOption.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cboSGenOption.ZOrder" xml:space="preserve">
     <value>28</value>
@@ -1315,7 +1201,7 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;btnAdvanced.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>outputTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;btnAdvanced.ZOrder" xml:space="preserve">
     <value>29</value>
@@ -1351,7 +1237,7 @@
     <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;lblNullable.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;lblNullable.ZOrder" xml:space="preserve">
     <value>30</value>
@@ -1375,7 +1261,7 @@
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;cboNullable.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;cboNullable.ZOrder" xml:space="preserve">
     <value>31</value>
@@ -1387,7 +1273,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="overarchingTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>22</value>
+    <value>4</value>
   </data>
   <data name="overarchingTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>592, 550</value>
@@ -1406,9 +1292,6 @@
   </data>
   <data name="&gt;&gt;overarchingTableLayoutPanel.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="overarchingTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="outputTableLayoutPanel" Row="16" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="generalHeaderTableLayoutPanel" Row="0" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="treatWarningsAsErrorsTableLayoutPanel" Row="12" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="errorsAndWarningsTableLayoutPanel" Row="9" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkRegisterForCOM" Row="19" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkXMLDocumentationFile" Row="18" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtXMLDocumentationFile" Row="18" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnOutputPathBrowse" Row="17" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="txtOutputPath" Row="17" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblOutputPath" Row="17" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningSpecific" Row="15" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="txtSpecificWarnings" Row="15" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="rbWarningAll" Row="14" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="rbWarningNone" Row="13" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtSupressWarnings" Row="11" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblSupressWarnings" Row="11" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboWarningLevel" Row="10" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblWarningLevel" Row="10" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboPlatformTarget" Row="4" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="chkOptimizeCode" Row="8" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkAllowUnsafeCode" Row="7" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkPrefer32Bit" Row="6" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineTrace" Row="3" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="chkDefineDebug" Row="2" RowSpan="1" Column="0" ColumnSpan="3" /&gt;&lt;Control Name="txtConditionalCompilationSymbols" Row="1" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="lblConditionalCompilationSymbols" Row="1" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblPlatformTarget" Row="4" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="lblSGenOption" Row="20" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboSGenOption" Row="20" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;Control Name="btnAdvanced" Row="21" RowSpan="1" Column="2" ColumnSpan="1" /&gt;&lt;Control Name="lblNullable" Row="5" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="cboNullable" Row="5" RowSpan="1" Column="1" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="AutoSize,0,Percent,100,AutoSize,0" /&gt;&lt;Rows Styles="AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,AutoSize,0,Absolute,20" /&gt;&lt;/TableLayoutSettings&gt;</value>
   </data>
   <data name="chkDefineDebug.Location" type="System.Drawing.Point, System.Drawing">
     <value>23, 50</value>
@@ -1432,7 +1315,7 @@
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;chkDefineDebug.Parent" xml:space="preserve">
-    <value>overarchingTableLayoutPanel</value>
+    <value>generalTableLayoutPanel</value>
   </data>
   <data name="&gt;&gt;chkDefineDebug.ZOrder" xml:space="preserve">
     <value>23</value>

--- a/src/Microsoft.VisualStudio.Editors/PropPages/SeparatorGroupBox.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/SeparatorGroupBox.vb
@@ -1,0 +1,40 @@
+﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+Imports System.Drawing
+Imports System.Windows.Forms
+
+Namespace Microsoft.VisualStudio.Editors.PropertyPages
+
+    ''' <summary>
+    ''' This class implements a <see cref="GroupBox"/> with custom appearance.
+    ''' </summary>
+    ''' <remarks>
+    ''' The control is rendered as a label followed by a horizontal line, commonly used as a separator.
+    ''' </remarks>
+    Friend NotInheritable Class SeparatorGroupBox
+        Inherits GroupBox
+
+        Private Const LabelToLineDistance As Integer = 8
+
+        Public Sub New()
+        End Sub
+
+        Protected Overrides Sub OnPaint(e As PaintEventArgs)
+            Dim format = New StringFormat() With {.Alignment = StringAlignment.Near, .Trimming = StringTrimming.Character}
+            TextRenderer.DrawText(e.Graphics, Text, Font, New Point(0), ForeColor)
+
+            Dim linePoint1 = New Point(ClientRectangle.Left, ClientRectangle.Top + (Font.Height \ 2))
+            Dim linePoint2 = New Point(ClientRectangle.Right, ClientRectangle.Top + (Font.Height \ 2))
+
+            Dim stringSize = TextRenderer.MeasureText(e.Graphics, Text, Font, ClientRectangle.Size)
+            linePoint1.X += CInt(stringSize.Width)
+            linePoint1.X += LabelToLineDistance
+
+            Using pen As New Pen(SystemColors.ControlDark, SystemInformation.BorderSize.Height)
+                e.Graphics.DrawLine(pen, linePoint1, linePoint2)
+            End Using
+        End Sub
+
+    End Class
+
+End Namespace

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ymboly podmíněné kompilace:</target>
@@ -17,24 +27,9 @@
         <target state="translated">Může mít hodnotu &amp;null:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Výstup</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Obecné</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Zpracovávat upozornění jako chyby</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Chyby a upozornění</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definovat konstant&amp;u DEBUG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.cs.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ymboly podmíněné kompilace:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Výstup</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Obecné</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Zpracovávat upozornění jako chyby</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Chyby a upozornění</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definovat konstant&amp;u DEBUG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">&amp;Symbole für bedingte Kompilierung:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Ausgabe</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Allgemein</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Warnungen als Fehler behandeln</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Fehler und Warnungen</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">&amp;DEBUG-Konstante definieren</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.de.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">&amp;Symbole für bedingte Kompilierung:</target>
@@ -17,24 +27,9 @@
         <target state="translated">NULL-&amp;Werte zulassen:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Ausgabe</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Allgemein</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Warnungen als Fehler behandeln</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Fehler und Warnungen</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">&amp;DEBUG-Konstante definieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Sí&amp;mbolos de compilación condicional:</target>
@@ -17,24 +27,9 @@
         <target state="translated">Acepta v&amp;lores NULL:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Salida</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">General</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Tratar advertencias como errores</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Errores y advertencias</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definir constante DEB&amp;UG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.es.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Sí&amp;mbolos de compilación condicional:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Salida</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">General</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Tratar advertencias como errores</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Errores y advertencias</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definir constante DEB&amp;UG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ymboles de compilation conditionnelle :</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Sortie</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Général</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Considérer les avertissements comme des erreurs</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Erreurs et avertissements</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Définir la constante DEB&amp;UG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.fr.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ymboles de compilation conditionnelle :</target>
@@ -17,24 +27,9 @@
         <target state="translated">Nulla&amp;ble :</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Sortie</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Général</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Considérer les avertissements comme des erreurs</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Erreurs et avertissements</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Définir la constante DEB&amp;UG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Sim&amp;boli di compilazione condizionale:</target>
@@ -17,24 +27,9 @@
         <target state="translated">Nulla&amp;ble:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Output</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Generale</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Considera gli avvisi come errori</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Errori e avvisi</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definisci costante DEB&amp;UG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.it.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Sim&amp;boli di compilazione condizionale:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Output</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Generale</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Considera gli avvisi come errori</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Errori e avvisi</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definisci costante DEB&amp;UG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">条件付きコンパイル シンボル(&amp;Y):</target>
@@ -17,24 +27,9 @@
         <target state="translated">Null 許容(&amp;B):</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">出力</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">全般</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">警告をエラーとして扱う</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">エラーおよび警告</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">DEBUG 定数の定義(&amp;U)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ja.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">条件付きコンパイル シンボル(&amp;Y):</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">出力</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">全般</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">警告をエラーとして扱う</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">エラーおよび警告</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">DEBUG 定数の定義(&amp;U)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">조건부 컴파일 기호(&amp;Y):</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">출력</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">일반</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">경고를 오류로 처리</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">오류 및 경고</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">DEBUG 상수 정의(&amp;U)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ko.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">조건부 컴파일 기호(&amp;Y):</target>
@@ -17,24 +27,9 @@
         <target state="translated">Null 허용(&amp;B):</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">출력</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">일반</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">경고를 오류로 처리</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">오류 및 경고</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">DEBUG 상수 정의(&amp;U)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ymbole kompilacji warunkowej:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Wyjściowe</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Ogólne</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Traktuj ostrzeżenia jako błędy</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Błędy i ostrzeżenia</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Zdefiniuj stałą DEB&amp;UG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pl.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ymbole kompilacji warunkowej:</target>
@@ -17,24 +27,9 @@
         <target state="translated">&amp;Dopuszczalna wartość null:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Wyjściowe</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Ogólne</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Traktuj ostrzeżenia jako błędy</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Błędy i ostrzeżenia</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Zdefiniuj stałą DEB&amp;UG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ímbolos de compilação condicional:</target>
@@ -17,24 +27,9 @@
         <target state="translated">Anulá&amp;vel:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Saída</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Geral</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Tratar avisos como erros</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Erros e avisos</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definir constante DEB&amp;UG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.pt-BR.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">S&amp;ímbolos de compilação condicional:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Saída</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Geral</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Tratar avisos como erros</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Erros e avisos</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Definir constante DEB&amp;UG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Обознач&amp;ения условной компиляции:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Выходные данные</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Общие</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Обрабатывать предупреждения как ошибки</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Ошибки и предупреждения</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Определить константу DEB&amp;UG</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.ru.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Обознач&amp;ения условной компиляции:</target>
@@ -17,24 +27,9 @@
         <target state="translated">Допускающий значе&amp;ние null:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Выходные данные</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Общие</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Обрабатывать предупреждения как ошибки</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Ошибки и предупреждения</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">Определить константу DEB&amp;UG</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Koşullu derleme s&amp;embolleri:</target>
@@ -17,24 +27,9 @@
         <target state="translated">Null A&amp;tanabilir:</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">Çıkış</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">Genel</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">Uyarıları hata olarak değerlendir</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">Hatalar ve uyarılar</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">DEB&amp;UG sabit değerini tanımlayın</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.tr.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">Koşullu derleme s&amp;embolleri:</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">Çıkış</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">Genel</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">Uyarıları hata olarak değerlendir</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">Hatalar ve uyarılar</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">DEB&amp;UG sabit değerini tanımlayın</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">条件编译和符号(&amp;Y):</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">输出</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">常规</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">将警告视为错误</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">错误和警告</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">定义 DEBUG 常数(&amp;U)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hans.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">条件编译和符号(&amp;Y):</target>
@@ -17,24 +27,9 @@
         <target state="translated">可以为 null(&amp;B):</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">输出</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">常规</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">将警告视为错误</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">错误和警告</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">定义 DEBUG 常数(&amp;U)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
@@ -7,6 +7,16 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="new">Errors and warnings</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="new">General</target>
+        <note />
+      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">條件式編譯符號(&amp;Y):</target>
@@ -17,24 +27,9 @@
         <target state="translated">可為 Null(&amp;B):</target>
         <note />
       </trans-unit>
-      <trans-unit id="outputLabel.Text">
+      <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="translated">輸出</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalLabel.Text">
-        <source>General</source>
-        <target state="translated">一般</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsLabel.Text">
-        <source>Treat warnings as errors</source>
-        <target state="translated">將警告視為錯誤</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="errorsAndWarningsLabel.Text">
-        <source>Errors and warnings</source>
-        <target state="translated">錯誤和警告</target>
+        <target state="new">Output</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -145,6 +140,11 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">定義 DEBUG 常數(&amp;U)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">

--- a/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/xlf/BuildPropPage.zh-Hant.xlf
@@ -7,16 +7,6 @@
         <target state="translated">5</target>
         <note />
       </trans-unit>
-      <trans-unit id="errorsAndWarningsGroupBox.Text">
-        <source>Errors and warnings</source>
-        <target state="new">Errors and warnings</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="generalGroupBox.Text">
-        <source>General</source>
-        <target state="new">General</target>
-        <note />
-      </trans-unit>
       <trans-unit id="lblConditionalCompilationSymbols.Text">
         <source>Conditional compilation s&amp;ymbols:</source>
         <target state="translated">條件式編譯符號(&amp;Y):</target>
@@ -29,7 +19,22 @@
       </trans-unit>
       <trans-unit id="outputGroupBox.Text">
         <source>Output</source>
-        <target state="new">Output</target>
+        <target state="translated">輸出</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="generalGroupBox.Text">
+        <source>General</source>
+        <target state="translated">一般</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
+        <source>Treat warnings as errors</source>
+        <target state="translated">將警告視為錯誤</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="errorsAndWarningsGroupBox.Text">
+        <source>Errors and warnings</source>
+        <target state="translated">錯誤和警告</target>
         <note />
       </trans-unit>
       <trans-unit id="chkRegisterForCOM.Text">
@@ -140,11 +145,6 @@
       <trans-unit id="chkDefineDebug.Text">
         <source>Define DEB&amp;UG constant</source>
         <target state="translated">定義 DEBUG 常數(&amp;U)</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="treatWarningsAsErrorsGroupBox.Text">
-        <source>Treat warnings as errors</source>
-        <target state="new">Treat warnings as errors</target>
         <note />
       </trans-unit>
       <trans-unit id="txtSpecificWarnings.AccessibleName">


### PR DESCRIPTION
The **Build** property page used for legacy projects was essentially a flat list of components separated into sections by labels: **General**, **Errors and warnings**, **Treat warnings as errors**, **Output**. This posed a problem to accessibility tools like screen readers, which did not recognize these labels to be groupings, leading to incomplete and confusing voice output. For example, when navigating to the **Treat warnings as errors** section, the reader would announce just "None" without context.

This PR introduces a new `SeparatorGroupBox` control. It has the same appearance as separator labels but it can have children, allowing for proper control hierarchy. The Build property page is restructured to take advantage of the new control.

```
overarchingTableLayoutPanel
|
|- generalGroupBox
|  |
|  |- generalTableLayoutPanel
|  |  |
|  |  |- <controls in the General sections>
| 
|- errorsAndWarningsGroupBox
|  |
|  |- errorsAndWarningsTableLayoutPanel
|  |  |
|  |  |- <controls in the Errors and warnings section>
|  |
...
```

Overall, the only significant difference in appearance is that controls are not aligned across sections anymore. E.g. the **Conditional compilation symbols** text box uses the full width of the page rather than having its right edge aligned with all the other text boxes. I subjectively rate this as an improvement.

## Before:
![image](https://github.com/dotnet/project-system/assets/12206368/45fd1eed-56f7-40a6-acbf-0e96b67b693d)

## After:
![image](https://github.com/dotnet/project-system/assets/12206368/11322f65-8c24-4cbc-801a-b1b0a93fc264)


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9213)