### PR TITLE
Avoid NFE when ConfigurationGeneral rule is modified to remove expected property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -678,11 +678,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     jointRuleUpdate.ProjectChanges.TryGetValue(ResolvedProjectReference.SchemaName, out IProjectChangeDescription? change2) &&
                     jointRuleUpdate.ProjectChanges.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectChangeDescription? change3))
                 {
-                    if (change1.Difference.AnyChanges || change2.Difference.AnyChanges || change3.Difference.AnyChanges)
+                    if ((change1.Difference.AnyChanges || change2.Difference.AnyChanges || change3.Difference.AnyChanges) &&
+                        change3.After.Properties.TryGetStringProperty(ConfigurationGeneral.TargetPathProperty, out string? targetPath))
                     {
                         // Register this project's data with the CopyToOutputDirectoryItem tracking service.
-
-                        string targetPath = jointRuleUpdate.CurrentState[ConfigurationGeneral.SchemaName].Properties[ConfigurationGeneral.TargetPathProperty];
 
                         projectFileClassifier ??= BuildClassifier();
 


### PR DESCRIPTION
Fixes [AB#1847450](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1847450)

The project system uses rule files to define a schema for the properties and items it needs to extract from the project. We use these rules in code when retrieving such values.

The rules are also extension points, and project types may replace or extend these rules for their own purposes.

Replacing a core rule file (like `ConfigurationGeneral`) is a bad idea as it can fall out of date when we take dependencies upon properties that are expected to be there, and the replacement rule does not include them.

That appears to be what's happening from our NFE data. Some project kind is using the FUTDC while not defining the `TargetPath` property in the `ConfigurationGeneral` rule.

I'll investigate this in more depth separately as it seems like another component might have an issue that could resurface elsewhere. In the meantime, this change makes the FUTDC tolerant of this missing value. The consequence of it being absent is the checking of copy items won't be as extensive, and build acceleration would be disabled for that project and for any that reference it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9217)