### PR TITLE
Fix KeyNotFoundException in enum provider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -27,19 +27,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
 
             string? targetFrameworkIdentifier = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkIdentifierProperty);
 
-            string ruleName;
-
             if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetCoreApp))
             {
-                ruleName = SupportedNETCoreAppTargetFramework.SchemaName;
+                return GetSupportedTargetFrameworksFromItems(SupportedNETCoreAppTargetFramework.SchemaName);
             }
             else if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetFramework))
             {
-                ruleName = SupportedNETFrameworkTargetFramework.SchemaName;
+                return GetSupportedTargetFrameworksFromItems(SupportedNETFrameworkTargetFramework.SchemaName);
             }
             else if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetStandard))
             {
-                ruleName = SupportedNETStandardTargetFramework.SchemaName;
+                return GetSupportedTargetFrameworksFromItems(SupportedNETStandardTargetFramework.SchemaName);
             }
             else
             {
@@ -63,14 +61,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
                 return Array.Empty<IEnumValue>();
             }
 
-            IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];
+            EnumCollection GetSupportedTargetFrameworksFromItems(string ruleName)
+            {
+                IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];
 
-            int capacity = snapshot.Items.Count;
-            var list = new List<IEnumValue>(capacity);
+                int capacity = snapshot.Items.Count;
+                var list = new List<IEnumValue>(capacity);
 
-            list.AddRange(snapshot.Items.Select(ToEnumValue));
-            list.Sort(SortValues); // TODO: This is a hotfix for item ordering. Remove this when completing: https://github.com/dotnet/project-system/issues/7025
-            return list;
+                list.AddRange(snapshot.Items.Select(ToEnumValue));
+                list.Sort(SortValues); // TODO: This is a hotfix for item ordering. Remove this when completing: https://github.com/dotnet/project-system/issues/7025
+                return list;
+            }
         }
 
         protected override IEnumValue ToEnumValue(KeyValuePair<string, IImmutableDictionary<string, string>> item)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -16,10 +16,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
         protected override string[] RuleNames => new[] { SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName };
 
         [ImportingConstructor]
-        public SupportedTargetFrameworksEnumProvider(
-            ConfiguredProject project,
-            IProjectSubscriptionService subscriptionService)
-            : base(project, subscriptionService) {
+        public SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
+            : base(project, subscriptionService)
+        {
         }
 
         protected override EnumCollection Transform(IProjectSubscriptionUpdate input)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
         {
             IProjectRuleSnapshot configurationGeneral = input.CurrentState[ConfigurationGeneral.SchemaName];
 
-            string targetFrameworkIdentifier = configurationGeneral.Properties[ConfigurationGeneral.TargetFrameworkIdentifierProperty];
+            string? targetFrameworkIdentifier = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkIdentifierProperty);
 
             string ruleName;
 
@@ -44,24 +44,24 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
             }
             else
             {
-                string storedTargetFramework = configurationGeneral.Properties[ConfigurationGeneral.TargetFrameworkProperty];
-                string storedTargetFrameworkIdentifier = configurationGeneral.Properties[ConfigurationGeneral.TargetFrameworkIdentifierProperty];
-                string storedTargetFrameworkMoniker = configurationGeneral.Properties[ConfigurationGeneral.TargetFrameworkMonikerProperty];
-
-                var result = new List<IEnumValue>();
+                string? targetFramework = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkProperty);
+                string? targetFrameworkMoniker = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkMonikerProperty);
 
                 // This is the case where the TargetFrameworkProperty has a value we recognize but it's not in the supported lists the SDK sends us.
                 // We decided we will show it in the UI.
-                if (!Strings.IsNullOrEmpty(storedTargetFramework))
+                if (!Strings.IsNullOrEmpty(targetFramework))
                 {
-                    result.Add(new PageEnumValue(new EnumValue
+                    return new IEnumValue[]
                     {
-                        Name = (!Strings.IsNullOrEmpty(storedTargetFrameworkMoniker))? storedTargetFrameworkMoniker : storedTargetFramework,
-                        DisplayName = (!Strings.IsNullOrEmpty(storedTargetFrameworkIdentifier)) ? storedTargetFrameworkIdentifier : storedTargetFramework
-                    }));
+                        new PageEnumValue(new EnumValue
+                        {
+                            Name = targetFrameworkMoniker ?? targetFramework,
+                            DisplayName = targetFrameworkIdentifier ?? targetFramework
+                        })
+                    };
                 }
 
-                return result;
+                return Array.Empty<IEnumValue>();
             }
 
             IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];


### PR DESCRIPTION
NFE data shows it's possible to hit a `KeyNotFoundException` in the `SupportedTargetFrameworksEnumProvider`. This could happen if the `ConfigurationGeneral` doesn't have the required set of properties.

This change makes the code fail gracefully in such cases.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9218)