### PR TITLE
Fix empty dependency group node for external dependencies

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
@@ -122,7 +122,16 @@ internal sealed class LegacyDependencySubscriber : IDependencySubscriber
 
             if (anyChanges)
             {
-                _snapshot = _snapshot.SetItem(_dependencyType, _dependencyById.Values.ToImmutableArray());
+                if (_dependencyById.Count == 0)
+                {
+                    // No dependencies exist, so remove it from the snapshot to prevent us displaying an
+                    // empty group node with no children.
+                    _snapshot = _snapshot.Remove(_dependencyType);
+                }
+                else
+                {
+                    _snapshot = _snapshot.SetItem(_dependencyType, _dependencyById.Values.ToImmutableArray());
+                }
             }
 
             return _snapshot;


### PR DESCRIPTION
Fixes #9227

Implementations of the `IProjectDependenciesSubTreeProvider` interface may extend the dependencies tree with additional dependency types.

The rewrite in 17.7 introduced a subtle change in bevahiour where removing the last dependency in a group added via this interface would leave the group node visible in the tree.

This change ensures we remove the group altogether when the last item is removed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9228)