### PR TITLE
Use collection expressions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -78,18 +78,18 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes"                         Version="$(CPSPackageVersion)" />
 
     <!-- Roslyn -->
-    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.7.0-1.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.8.0-1.23414.8" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.8.0-1.23414.8" />
     <PackageVersion Include="Microsoft.CSharp"                                                       Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.8.0-1.23414.8" />
     <PackageVersion Include="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.8.0-1.23414.8" />
 
     <!-- Analyzers -->
     <PackageVersion Include="CSharpIsNullAnalyzer"                                                   Version="0.1.329" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.5-beta1.23165.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.7.0-1.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.8.0-1.23414.8" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.8.0-1.23414.8" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.5-beta1.23165.1" />
 
     <!-- NuGet -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/SolutionBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/SolutionBuildManager.cs
@@ -143,7 +143,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
 
             if (count == 0)
             {
-                return Array.Empty<IVsHierarchy>();
+                return [];
             }
 
             // Get all of the dependent projects, and add them to our list

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectHelper.cs
@@ -62,7 +62,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 return results.ToImmutableAndFree();
             }
 
-            return ImmutableArray<T>.Empty;
+            return [];
         }
 
         public ImmutableArray<string> GetFullPathsOfStartupProjects()
@@ -86,7 +86,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
                 return results.ToImmutableAndFree();
             }
 
-            return ImmutableArray<string>.Empty;
+            return [];
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             {
                 return await _deltaApplier.GetCapabilitiesAsync(cancellationToken);
             }
-            return ImmutableArray<string>.Empty;
+            return [];
         }
 
         public ValueTask ReportDiagnosticsAsync(ImmutableArray<ManagedHotReloadDiagnostic> diagnostics, CancellationToken cancellationToken)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
     {
         private readonly IProjectAccessor _accessor;
 
-        private ImmutableHashSet<string> _previousIncludes = ImmutableHashSet<string>.Empty;
+        private ImmutableHashSet<string> _previousIncludes = [];
         private OrderingMoveAction _action = OrderingMoveAction.NoOp;
         private IProjectTree? _target;
         private bool _isHinting;
@@ -78,7 +78,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
         {
             _action = OrderingMoveAction.NoOp;
             _target = null;
-            _previousIncludes = ImmutableHashSet<string>.Empty;
+            _previousIncludes = [];
             _isHinting = false;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project);
             Requires.NotNull(target);
 
-            ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Above);
+            ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, [], MoveAction.Above);
             if (referenceElement is null)
             {
                 return false;
@@ -139,7 +139,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             Requires.NotNull(project);
             Requires.NotNull(target);
 
-            ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Below);
+            ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, [], MoveAction.Below);
             if (referenceElement is null)
             {
                 return false;
@@ -436,11 +436,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             if (referenceProjectTree is not null)
             {
                 // The reference element is the element for which moved items will be above or below it.
-                ProjectItemElement? referenceElement = TryGetReferenceElement(project, referenceProjectTree, ImmutableArray<string>.Empty, moveAction);
+                ProjectItemElement? referenceElement = TryGetReferenceElement(project, referenceProjectTree, [], moveAction);
 
                 if (referenceElement is not null)
                 {
-                    ImmutableArray<ProjectItemElement> elements = GetItemElements(project, projectTree, ImmutableArray<string>.Empty);
+                    ImmutableArray<ProjectItemElement> elements = GetItemElements(project, projectTree, []);
                     return TryMoveElements(elements, referenceElement, moveAction);
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/TemplateDetailsExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/TemplateDetailsExtensions.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             if (!map.TryGetValue(commandId, out ImmutableArray<TemplateDetails> list))
             {
-                list = ImmutableArray<TemplateDetails>.Empty;
+                list = [];
             }
 
             list = list.Add(new TemplateDetails(capability, dirNamePackage, Convert.ToUInt32(dirNameId), templateNamePackage, Convert.ToUInt32(templateNameId)));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/MetadataReferenceItemHandler.cs
@@ -114,7 +114,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         {
             if (aliases.Length == 1 && aliases[0] == MetadataReferenceProperties.GlobalAlias)
             {
-                return ImmutableArray<string>.Empty;
+                return [];
             }
 
             return aliases;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -638,7 +638,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
             if (items.Count == 0)
             {
-                return ImmutableArray<string>.Empty;
+                return [];
             }
 
             return items.Select(item => item.EvaluatedInclude).ToImmutableArray();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
@@ -201,7 +201,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
                         bufferedBuilds.Add(input);
 
                         // Return an empty enumerable. We don't yet want to produce any outputs.
-                        return Enumerable.Empty<IProjectVersionedValue<WorkspaceUpdate>>();
+                        return [];
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/ImmutablePropertyCollection.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore
             // If the input is empty, don't allocate anything further.
             if (inputItems.Length == 0)
             {
-                _itemByIndex = Array.Empty<T>();
+                _itemByIndex = [];
                 _itemsByName = ImmutableDictionary<string, T>.Empty;
                 return;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/DotNetImportsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/DotNetImportsEnumProvider.cs
@@ -37,7 +37,7 @@ internal class DotNetImportsEnumProvider : IDynamicEnumValuesProvider, IDynamicE
 
         if (compilation is null)
         {
-            return Enumerable.Empty<string>();
+            return [];
         }
 
         List<string> namespaceNames = new List<string>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
         /// <summary>
         /// The set of change notification observers.
         /// </summary>
-        private ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>> _observers = ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>>.Empty;
+        private ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>> _observers = [];
         /// <remarks>
         /// Used to keep track of whether or not a new subscriber has received its initial snapshot.
         /// </remarks>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandler.cs
@@ -90,7 +90,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 return createLaunchProfileValues(launchSettings);
             }
 
-            return Enumerable.Empty<IEntityValue>();
+            return [];
 
             IEnumerable<IEntityValue> createLaunchProfileValues(ILaunchSettings launchSettings)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
@@ -59,7 +59,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query.PropertyPages
                 return createLaunchProfileTypeValues();
             }
 
-            return Enumerable.Empty<IEntityValue>();
+            return [];
 
             IEnumerable<IEntityValue> createLaunchProfileTypeValues()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 return createPropertyPageValuesAsync();
             }
 
-            return Enumerable.Empty<IEntityValue>();
+            return [];
 
             IEnumerable<IEntityValue> createPropertyPageValuesAsync()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 return createSupportedValues(enumValues);
             }
 
-            return Enumerable.Empty<IEntityValue>();
+            return [];
 
             IEnumerable<IEntityValue> createSupportedValues(ReadOnlyCollection<ProjectSystem.Properties.IEnumValue> enumValues)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 return createEditorValues();
             }
 
-            return Enumerable.Empty<IEntityValue>();
+            return [];
 
             IEnumerable<IEntityValue> createEditorValues()
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
 
             var identity = new EntityIdentity(
                 ((IEntityWithId)parent).Id,
-                Enumerable.Empty<KeyValuePair<string, string>>());
+                []);
 
             return await CreateUIPropertyValueValueAsync(parent.EntityRuntime, identity, configuration, property, requestedProperties);
         }
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query
                 }
                 else
                 {
-                    configurations = Enumerable.Empty<ProjectConfiguration>();
+                    configurations = [];
                 }
             }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputSnapshot.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         public static readonly DesignTimeInputSnapshot Empty = new(
             EmptyCollections.OrdinalStringSet,
             EmptyCollections.OrdinalStringSet,
-            Enumerable.Empty<DesignTimeInputFileChange>(), string.Empty);
+            [], string.Empty);
 
         public DesignTimeInputSnapshot(ImmutableHashSet<string> inputs, ImmutableHashSet<string> sharedInputs, IEnumerable<DesignTimeInputFileChange> changedInputs, string tempPEOutputPath)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     [Export(typeof(ITargetFrameworkContentCache))]
     internal sealed class TargetFrameworkContentCache : ITargetFrameworkContentCache
     {
-        private ImmutableDictionary<FrameworkReferenceIdentity, ImmutableArray<FrameworkReferenceAssemblyItem>> _cache = ImmutableDictionary<FrameworkReferenceIdentity, ImmutableArray<FrameworkReferenceAssemblyItem>>.Empty;
+        private ImmutableDictionary<FrameworkReferenceIdentity, ImmutableArray<FrameworkReferenceAssemblyItem>> _cache = [];
 
         public ImmutableArray<FrameworkReferenceAssemblyItem> GetContents(FrameworkReferenceIdentity framework)
         {
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
                 }
                 catch
                 {
-                    return ImmutableArray<FrameworkReferenceAssemblyItem>.Empty;
+                    return [];
                 }
 
                 ImmutableArray<FrameworkReferenceAssemblyItem>.Builder results = ImmutableArray.CreateBuilder<FrameworkReferenceAssemblyItem>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/RelationProvider.cs
@@ -6,8 +6,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     internal sealed class RelationProvider : IRelationProvider
     {
         private readonly IEnumerable<IRelation> _allRelations;
-        private ImmutableDictionary<Type, ImmutableArray<IRelation>> _containsRelationsByTypes = ImmutableDictionary<Type, ImmutableArray<IRelation>>.Empty;
-        private ImmutableDictionary<Type, ImmutableArray<IRelation>> _containedByRelationsByTypes = ImmutableDictionary<Type, ImmutableArray<IRelation>>.Empty;
+        private ImmutableDictionary<Type, ImmutableArray<IRelation>> _containsRelationsByTypes = [];
+        private ImmutableDictionary<Type, ImmutableArray<IRelation>> _containedByRelationsByTypes = [];
 
         [ImportingConstructor]
         public RelationProvider([ImportMany] IEnumerable<IRelation> allRelations)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringDictionary.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringDictionary.cs
@@ -5,7 +5,7 @@ namespace System.Collections.Immutable
     internal static class ImmutableStringDictionary<TValue>
     {
         public static readonly ImmutableDictionary<string, TValue> EmptyOrdinal
-            = ImmutableDictionary<string, TValue>.Empty;
+            = [];
 
         public static readonly ImmutableDictionary<string, TValue> EmptyOrdinalIgnoreCase
             = ImmutableDictionary<string, TValue>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
@@ -5,7 +5,7 @@ namespace System.Collections.Immutable
     internal static class ImmutableStringHashSet
     {
         public static readonly ImmutableHashSet<string> EmptyOrdinal
-            = ImmutableHashSet<string>.Empty;
+            = [];
 
         public static readonly ImmutableHashSet<string> EmptyOrdinalIgnoreCase
             = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio
         {
             if (dictionary.Count == 0)
             {
-                return ImmutableArray<TOutput>.Empty;
+                return [];
             }
 
             ImmutableArray<TOutput>.Builder builder = ImmutableArray.CreateBuilder<TOutput>(initialCapacity: dictionary.Count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
@@ -170,7 +170,7 @@ namespace Microsoft.VisualStudio.Buffers.PooledObjects
         {
             if (Count == 0)
             {
-                return ImmutableArray<U>.Empty;
+                return [];
             }
 
             var tmp = PooledArray<U>.GetInstance(Count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyTriggeredBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyTriggeredBuildManager.cs
@@ -18,14 +18,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.Build
 #pragma warning restore CS0618 // Type or member is obsolete
     {
         private bool _isImplicitlyTriggeredBuild;
-        private ImmutableArray<string> _startupProjectFullPaths = ImmutableArray<string>.Empty;
+        private ImmutableArray<string> _startupProjectFullPaths = [];
 
         public bool IsImplicitlyTriggeredBuild => _isImplicitlyTriggeredBuild;
 
         public ImmutableArray<string> StartupProjectFullPaths => _startupProjectFullPaths;
 
         public void OnBuildStart()
-            => OnBuildStart(ImmutableArray<string>.Empty);
+            => OnBuildStart([]);
 
         public void OnBuildStart(ImmutableArray<string> startupProjectFullPaths)
         {
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.Build
         public void OnBuildEndOrCancel()
         {
             _isImplicitlyTriggeredBuild = false;
-            _startupProjectFullPaths = ImmutableArray<string>.Empty;
+            _startupProjectFullPaths = [];
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
 
             if (Strings.IsNullOrEmpty(propertyValue))
             {
-                return ImmutableArray<string>.Empty;
+                return [];
             }
             else
             {
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project);
             if (values.IsEmpty)
             {
-                return Enumerable.Empty<KeyValuePair<string, string>>();
+                return [];
             }
             else
             {
@@ -118,7 +118,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project);
             if (values.IsEmpty)
             {
-                return Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+                return [];
             }
             else
             {
@@ -140,7 +140,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
             if (defaultValue is not null)
                 return new[] { new KeyValuePair<string, string>(DimensionName, defaultValue) };
 
-            return Enumerable.Empty<KeyValuePair<string, string>>();
+            return [];
         }
 
         /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
@@ -149,10 +149,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             DoNotPersist = doNotPersist;
 
             EnvironmentVariables = environmentVariables.IsDefault
-                ? ImmutableArray<(string Key, string Value)>.Empty
+                ? []
                 : environmentVariables;
             OtherSettings = otherSettings.IsDefault
-                ? ImmutableArray<(string Key, object Value)>.Empty
+                ? []
                 : otherSettings;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileExtensions.cs
@@ -150,7 +150,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return profile switch
             {
                 ILaunchProfile2 launchProfile => launchProfile.EnvironmentVariables,
-                ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => Enumerable.Empty<(string Key, string Value)>(),
+                ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => [],
                 ILaunchProfile { EnvironmentVariables: { } vars } => vars.OrderBy(pair => pair.Key, StringComparers.EnvironmentVariableNames).Select(pair => (pair.Key, pair.Value))
             };
         }
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return profile switch
             {
                 ILaunchProfile2 launchProfile => launchProfile.OtherSettings,
-                ILaunchProfile { OtherSettings: null or { Count: 0 } } => Enumerable.Empty<(string Key, object Value)>(),
+                ILaunchProfile { OtherSettings: null or { Count: 0 } } => [],
                 ILaunchProfile { OtherSettings: { } settings } => settings.OrderBy(pair => pair.Key, StringComparers.LaunchProfileProperties).Select(pair => (pair.Key, pair.Value))
             };
         }
@@ -241,7 +241,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return profile switch
             {
                 ILaunchProfile2 launchProfile => launchProfile.EnvironmentVariables,
-                ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => ImmutableArray<(string Key, string Value)>.Empty,
+                ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => [],
                 ILaunchProfile { EnvironmentVariables: { } vars } => vars.OrderBy(pair => pair.Key, StringComparers.EnvironmentVariableNames).Select(pair => (pair.Key, pair.Value)).ToImmutableArray()
             };
         }
@@ -268,7 +268,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             return profile switch
             {
                 ILaunchProfile2 launchProfile => launchProfile.OtherSettings,
-                ILaunchProfile { OtherSettings: null or { Count: 0 } } => ImmutableArray<(string Key, object Value)>.Empty,
+                ILaunchProfile { OtherSettings: null or { Count: 0 } } => [],
                 ILaunchProfile { OtherSettings: { } vars } => vars.OrderBy(pair => pair.Key, StringComparers.EnvironmentVariableNames).Select(pair => (pair.Key, pair.Value)).ToImmutableArray()
             };
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -217,8 +217,8 @@ internal static class LaunchSettingsJsonEncoding
         });
 
         return (
-            profiles?.ToImmutable() ?? ImmutableArray<LaunchProfile>.Empty,
-            otherSettings?.ToImmutable() ?? ImmutableArray<(string Name, object Value)>.Empty);
+            profiles?.ToImmutable() ?? [],
+            otherSettings?.ToImmutable() ?? []);
 
         LaunchProfile ReadProfile(string name)
         {
@@ -228,7 +228,7 @@ internal static class LaunchSettingsJsonEncoding
             string? workingDirectory = null;
             bool launchBrowser = false;
             string? launchUrl = null;
-            ImmutableArray<(string Name, string Value)> environmentVariables = ImmutableArray<(string Name, string Value)>.Empty;
+            ImmutableArray<(string Name, string Value)> environmentVariables = [];
             ImmutableArray<(string Name, object Value)>.Builder? otherSettings = null;
 
             ReadObject(property =>
@@ -292,7 +292,7 @@ internal static class LaunchSettingsJsonEncoding
                 launchBrowser: launchBrowser,
                 launchUrl: launchUrl,
                 environmentVariables: environmentVariables,
-                otherSettings: otherSettings?.ToImmutable() ?? ImmutableArray<(string Name, object Value)>.Empty);
+                otherSettings: otherSettings?.ToImmutable() ?? []);
         }
 
         object? ReadCustomProfileSetting(string propertyName)
@@ -359,7 +359,7 @@ internal static class LaunchSettingsJsonEncoding
                 builder.Add((property, ReadString()));
             });
 
-            return builder?.ToImmutable() ?? ImmutableArray<(string Name, string Value)>.Empty;
+            return builder?.ToImmutable() ?? [];
         }
 
         string ReadString()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveEditorContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveEditorContextTracker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
     [AppliesTo(ProjectCapability.DotNetLanguageService)]
     internal class ActiveEditorContextTracker : IActiveEditorContextTracker
     {
-        private ImmutableList<string> _contexts = ImmutableList<string>.Empty;
+        private ImmutableList<string> _contexts = [];
         private string? _activeIntellisenseProjectContext;
 
         // UnconfiguredProject is only included for scoping reasons.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpBuildOptions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
                                   ImmutableArray<CommandLineReference> metadataReferences,
                                   ImmutableArray<CommandLineAnalyzerReference> analyzerReferences,
                                   ImmutableArray<string> compileOptions)
-            : base(sourceFiles, additionalFiles, metadataReferences, analyzerReferences, ImmutableArray<string>.Empty)
+            : base(sourceFiles, additionalFiles, metadataReferences, analyzerReferences, [])
         {
             CompileOptions = compileOptions;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
@@ -74,9 +74,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
 
             return new FSharpBuildOptions(
                     sourceFiles: sourceFiles.ToImmutableArray(),
-                    additionalFiles: ImmutableArray<CommandLineSourceFile>.Empty,
+                    additionalFiles: [],
                     metadataReferences: metadataReferences.ToImmutableArray(),
-                    analyzerReferences: ImmutableArray<CommandLineAnalyzerReference>.Empty,
+                    analyzerReferences: [],
                     compileOptions: commandLineOptions.ToImmutableArray());
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             // Check if out of date to prevent extra restore under some conditions.
             if (!_enabled || e.Value.RestoreInfo is null || IsProjectConfigurationVersionOutOfDate(e.Value.ConfiguredInputs))
             {
-                return Enumerable.Empty<IProjectVersionedValue<RestoreData>>();
+                return [];
             }
 
             bool succeeded = await RestoreCoreAsync(e.Value);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
     /// </summary>
     internal static class RestoreBuilder
     {
-        public static readonly ImmutableArray<TargetFrameworkInfo> EmptyTargetFrameworks = ImmutableArray<TargetFrameworkInfo>.Empty;
-        public static readonly ImmutableArray<ReferenceItem> EmptyReferences = ImmutableArray<ReferenceItem>.Empty;
+        public static readonly ImmutableArray<TargetFrameworkInfo> EmptyTargetFrameworks = [];
+        public static readonly ImmutableArray<ReferenceItem> EmptyReferences = [];
 
         /// <summary>
         ///     Converts an immutable dictionary of rule snapshot data into an <see cref="ProjectRestoreInfo"/> instance.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private static readonly string? s_programFiles64;
         private static readonly string? s_vsInstallationDirectory;
 
-        private string[] _nuGetPackageFolders = Array.Empty<string>();
+        private string[] _nuGetPackageFolders = [];
         private string _nuGetPackageFoldersString = "";
         private string? _projectExtensionsPath;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
@@ -217,7 +217,7 @@ internal sealed class VBWarningsValueProvider : InterceptingPropertyValueProvide
 
     private static ImmutableSortedSet<int> ParseIdList(string idList)
     {
-        ImmutableSortedSet<int> ids = ImmutableSortedSet<int>.Empty;
+        ImmutableSortedSet<int> ids = [];
         string[] idsAsStrings = idList.Split(s_diagnosticIdSeparators, StringSplitOptions.RemoveEmptyEntries);
         foreach (string idString in idsAsStrings)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
@@ -163,7 +163,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             if (snapshot.Profiles.Count == 0)
             {
-                return Enumerable.Empty<IProjectItem>();
+                return [];
             }
 
             return snapshot.Profiles.Select(p => new ProjectItem(p.Name ?? string.Empty, _project.FullPath, this));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
@@ -130,7 +130,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _context.ItemName));
             if (profile is null)
             {
-                return Enumerable.Empty<string>();
+                return [];
             }
             ImmutableDictionary<string, object> globalSettings = snapshot.GlobalSettings;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/TemporaryPropertyStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/TemporaryPropertyStorage.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     [Export(typeof(ITemporaryPropertyStorage))]
     internal sealed class TemporaryPropertyStorage : ITemporaryPropertyStorage
     {
-        private ImmutableDictionary<string, string> _properties = ImmutableDictionary<string, string>.Empty;
+        private ImmutableDictionary<string, string> _properties = [];
 
         /// <remarks>
         /// We only need <paramref name="project"/> to force the creation of one of these per

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilder.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies;
 [Export]
 internal sealed class DependenciesTreeBuilder
 {
-    private static ImmutableDictionary<ProjectConfigurationSlice, ProjectTreeFlags> s_flagsByConfigurationSlice = ImmutableDictionary<ProjectConfigurationSlice, ProjectTreeFlags>.Empty;
+    private static ImmutableDictionary<ProjectConfigurationSlice, ProjectTreeFlags> s_flagsByConfigurationSlice = [];
 
     private readonly UnconfiguredProject _unconfiguredProject;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
@@ -83,7 +83,7 @@ internal sealed class LegacyDependencySubscriber : IDependencySubscriber
                 groupNodeFlags: rootNode.Flags);
 
             _snapshot = ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty
-                .Add(_dependencyType, ImmutableArray<IDependency>.Empty);
+                .Add(_dependencyType, []);
         }
 
         public ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>> Update(IDependenciesChanges changes)
@@ -186,7 +186,7 @@ internal sealed class LegacyDependencySubscriber : IDependencySubscriber
             // Publish an empty snapshot so we don't block downstream consumers if subtree providers don't publish
             // dependencies, or if they delay for a while before doing so.
             _broadcastBlock.Post(new ProjectVersionedValue<ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>>(
-                ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty,
+                [],
                 Empty.ProjectValueVersions.Add(DataSourceKey, _version)));
 
             _publicBlock = _broadcastBlock.SafePublicize();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
@@ -188,7 +188,7 @@ internal sealed class DependenciesSnapshotProvider : OnceInitializedOnceDisposed
                     var block = DataflowBlockSlim.CreateBroadcastBlock<IProjectVersionedValue<ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>>>(
                         nameFormat: "Empty unconfigured dependency broadcast {1}");
                     block.Post(new ProjectVersionedValue<ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>>(
-                        ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty,
+                        [],
                         Empty.ProjectValueVersions));
                     return block;
                 }
@@ -230,7 +230,7 @@ internal sealed class DependenciesSnapshotProvider : OnceInitializedOnceDisposed
                     if (groups.Count == 0)
                     {
                         // Optimize the common case where there are no unconfigured dependency group types.
-                        return ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty;
+                        return [];
                     }
 
                     Dictionary<DependencyGroupType, List<IDependency>> dependenciesByType = new();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencySubscriber.cs
@@ -100,7 +100,7 @@ internal sealed class MSBuildDependencySubscriber : OnceInitializedOnceDisposed,
         private readonly ImmutableHashSet<string> _evaluationRuleNames;
         private readonly ImmutableHashSet<string> _buildRuleNames;
 
-        private ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>> _dependenciesByGroupType = ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty;
+        private ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>> _dependenciesByGroupType = [];
 
         public Source(
             UnconfiguredProject unconfiguredProject,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/SharedProjectDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/SharedProjectDependencySubscriber.cs
@@ -76,7 +76,7 @@ internal sealed class SharedProjectDependencySubscriber : IDependencySliceSubscr
             // TODO allocate less when nothing important actually changes -- update, don't just remove and re-add
 
             ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>> dependenciesByGroupType
-                = ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty;
+                = [];
 
             _dependencies.Clear();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -51,7 +51,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
             /// </summary>
             private IDisposable? _link;
 
-            private ImmutableArray<ProjectConfiguration> _lastCheckedConfigurations = ImmutableArray<ProjectConfiguration>.Empty;
+            private ImmutableArray<ProjectConfiguration> _lastCheckedConfigurations = [];
 
             /// <summary>
             /// Cancelled when this instance is disposed.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -29,18 +29,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                 newestImportInput: null,
                 isDisabled: true,
                 isBuildAccelerationEnabled: false,
-                inputSourceItemTypes: ImmutableArray<string>.Empty,
-                inputSourceItemsByItemType: ImmutableDictionary<string, ImmutableArray<string>>.Empty,
-                upToDateCheckInputItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
-                upToDateCheckOutputItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
-                upToDateCheckBuiltItemsByKindBySetName: ImmutableDictionary<string, ImmutableDictionary<string, ImmutableArray<string>>>.Empty,
-                buildFromInputFileItems: ImmutableArray<(string DestinationRelative, string SourceRelative)>.Empty,
-                resolvedAnalyzerReferencePaths: ImmutableArray<string>.Empty,
-                resolvedCompilationReferencePaths: ImmutableArray<string>.Empty,
-                copyReferenceInputs: ImmutableArray<string>.Empty,
-                presentBuildAccelerationIncompatiblePackages: ImmutableArray<string>.Empty,
+                inputSourceItemTypes: [],
+                inputSourceItemsByItemType: [],
+                upToDateCheckInputItemsByKindBySetName: [],
+                upToDateCheckOutputItemsByKindBySetName: [],
+                upToDateCheckBuiltItemsByKindBySetName: [],
+                buildFromInputFileItems: [],
+                resolvedAnalyzerReferencePaths: [],
+                resolvedCompilationReferencePaths: [],
+                copyReferenceInputs: [],
+                presentBuildAccelerationIncompatiblePackages: [],
                 lastItemsChangedAtUtc: null,
-                lastItemChanges: ImmutableArray<(bool IsAdd, string ItemType, string)>.Empty,
+                lastItemChanges: [],
                 itemHash: null,
                 projectCopyData: default);
         }
@@ -232,20 +232,20 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
             ProjectConfiguration = projectConfiguration;
             LastItemsChangedAtUtc = null;
-            InputSourceItemTypes = ImmutableArray<string>.Empty;
+            InputSourceItemTypes = [];
             InputSourceItemsByItemType = ImmutableDictionary.Create<string, ImmutableArray<string>>(StringComparers.ItemTypes);
-            SetNames = ImmutableArray<string>.Empty;
-            KindNames = ImmutableArray<string>.Empty;
+            SetNames = [];
+            KindNames = [];
             UpToDateCheckInputItemsByKindBySetName = emptyItemBySetName;
             UpToDateCheckOutputItemsByKindBySetName = emptyItemBySetName;
             UpToDateCheckBuiltItemsByKindBySetName = emptyItemBySetName;
-            BuiltFromInputFileItems = ImmutableArray<(string DestinationRelative, string SourceRelative)>.Empty;
-            ResolvedAnalyzerReferencePaths = ImmutableArray<string>.Empty;
-            ResolvedCompilationReferencePaths = ImmutableArray<string>.Empty;
-            CopyReferenceInputs = ImmutableArray<string>.Empty;
-            PresentBuildAccelerationIncompatiblePackages = ImmutableArray<string>.Empty;
+            BuiltFromInputFileItems = [];
+            ResolvedAnalyzerReferencePaths = [];
+            ResolvedCompilationReferencePaths = [];
+            CopyReferenceInputs = [];
+            PresentBuildAccelerationIncompatiblePackages = [];
             LastItemChanges = ImmutableArray<(bool IsAdd, string ItemType, string)>.Empty;
-            ProjectCopyData = new(null, "", false, ImmutableArray<CopyItem>.Empty, ImmutableArray<string>.Empty);
+            ProjectCopyData = new(null, "", false, [], []);
         }
 
         private UpToDateCheckImplicitConfiguredInput(
@@ -412,7 +412,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
 
                 if (!inputSourceItemsByItemTypeBuilder.TryGetValue(itemType, out ImmutableArray<string> before))
                 {
-                    before = ImmutableArray<string>.Empty;
+                    before = [];
                 }
 
                 projectFileClassifier ??= BuildClassifier();
@@ -601,7 +601,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
                     }
 
                     return builder is null
-                        ? ImmutableArray<string>.Empty
+                        ? []
                         : builder.Capacity == builder.Count
                             ? builder.MoveToImmutable()
                             : builder.ToImmutable();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio
             string[] values = value.Split(separator);
 
             if (values.Length == 1 && string.IsNullOrEmpty(values[0]))
-                return Array.Empty<string>();
+                return [];
 
             return values;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         /// Paths of temporary workspaces to delete when the test fixture completes.
         /// Each path is a root, so should be deleted recursively.
         /// </summary>
-        private ImmutableList<string> _rootPaths = ImmutableList<string>.Empty;
+        private ImmutableList<string> _rootPaths = [];
 
         /// <summary>
         /// Verifies that the "Dependencies" node of <paramref name="project"/> has a structure that

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/DependenciesSnapshotSliceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/DependenciesSnapshotSliceFactory.cs
@@ -8,7 +8,7 @@ internal static class DependenciesSnapshotSliceFactory
 {
     public static DependenciesSnapshotSlice Create(ProjectConfigurationSlice slice, ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>? dependenciesByType = null)
     {
-        dependenciesByType ??= ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty;
+        dependenciesByType ??= [];
 
         DependenciesSnapshotSlice ? dependenciesSnapshotSlice = null;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicityTriggeredBuildStateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicityTriggeredBuildStateFactory.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Managed.Build
                 .Returns(implicitBuild);
 
             mock.SetupGet(state => state.StartupProjectFullPaths)
-                .Returns(startupProjects?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+                .Returns(startupProjects?.ToImmutableArray() ?? []);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
@@ -40,7 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 ? launchProfiles.ToImmutableList()
                 : ImmutableList<ILaunchProfile>.Empty;
 
-            var initialGlobalSettings = globalSettings ?? ImmutableDictionary<string, object>.Empty;
+            var initialGlobalSettings = globalSettings ?? [];
 
             if (getProfilesCallback is not null)
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
@@ -8,7 +8,7 @@ internal static class IProjectCapabilitiesScopeFactory
 {
     public static IProjectCapabilitiesScope Create(IEnumerable<string>? capabilities = null)
     {
-        capabilities ??= Enumerable.Empty<string>();
+        capabilities ??= [];
         var snapshot = new Mock<IProjectCapabilitiesSnapshot>();
         snapshot.Setup(s => s.IsProjectCapabilityPresent(It.IsAny<string>())).Returns((string capability) => capabilities.Contains(capability));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectSubscriptionUpdateFactory.cs
@@ -18,9 +18,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mock = new Mock<IProjectSubscriptionUpdate>(mockBehavior);
 
-            mock.Setup(x => x.CurrentState).Returns(currentState?.ToImmutableDictionary() ?? ImmutableDictionary<string, IProjectRuleSnapshot>.Empty);
+            mock.Setup(x => x.CurrentState).Returns(currentState?.ToImmutableDictionary() ?? []);
 
-            mock.Setup(x => x.ProjectChanges).Returns(projectChanges?.ToImmutableDictionary() ?? ImmutableDictionary<string, IProjectChangeDescription>.Empty);
+            mock.Setup(x => x.ProjectChanges).Returns(projectChanges?.ToImmutableDictionary() ?? []);
 
             return mock.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ImmutableOrderedDictionary.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ImmutableOrderedDictionary.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         : IImmutableDictionary<TKey, TValue>,
           IDataWithOriginalSource<KeyValuePair<TKey, TValue>>
     {
-        public static ImmutableOrderedDictionary<TKey, TValue> Empty { get; } = new(Enumerable.Empty<KeyValuePair<TKey, TValue>>());
+        public static ImmutableOrderedDictionary<TKey, TValue> Empty { get; } = new([]);
 
         private readonly Dictionary<TKey, TValue> _dic;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ImplicitlyActiveDimensionProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ImplicitlyActiveDimensionProviderTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Configuration
         {
             var provider = CreateInstance();
 
-            var result = provider.GetImplicitlyActiveDimensions(Enumerable.Empty<string>());
+            var result = provider.GetImplicitlyActiveDimensions([]);
 
             Assert.Empty(result);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var data = new LaunchProfile(
                 name: null,
                 commandName: null,
-                otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.NativeDebuggingProperty, value.Value)));
+                otherSettings: value == null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.NativeDebuggingProperty, value.Value)));
 
             Assert.Equal(expected, data.IsNativeDebuggingEnabled());
         }
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var data = new LaunchProfile(
                 name: null,
                 commandName: null,
-                otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.SqlDebuggingProperty, value.Value)));
+                otherSettings: value == null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.SqlDebuggingProperty, value.Value)));
 
             Assert.Equal(expected, data.IsSqlDebuggingEnabled());
         }
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var data = new LaunchProfile(
                 name: null,
                 commandName: null,
-                otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugEnabledProperty, value.Value)));
+                otherSettings: value == null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugEnabledProperty, value.Value)));
 
             Assert.Equal(expected, data.IsRemoteDebugEnabled());
         }
@@ -83,7 +83,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var data = new LaunchProfile(
                 name: null,
                 commandName: null,
-                otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugMachineProperty, value)));
+                otherSettings: value is null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugMachineProperty, value)));
 
             Assert.Equal(expected, data.RemoteDebugMachine());
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -764,7 +764,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
-            testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            testSettings.Setup(m => m.Profiles).Returns([]);
 
             provider.SetCurrentSnapshot(testSettings.Object);
             provider.SetNextVersionTest(123);
@@ -796,7 +796,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
-            testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            testSettings.Setup(m => m.Profiles).Returns([]);
 
             provider.SetCurrentSnapshot(testSettings.Object);
             provider.SetNextVersionTest(123);
@@ -836,7 +836,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
-            testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            testSettings.Setup(m => m.Profiles).Returns([]);
 
             provider.SetCurrentSnapshot(testSettings.Object);
             provider.SetNextVersionTest(123);
@@ -872,7 +872,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
-            testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            testSettings.Setup(m => m.Profiles).Returns([]);
 
             provider.SetCurrentSnapshot(testSettings.Object);
             provider.SetNextVersionTest(123);
@@ -906,7 +906,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
-            testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            testSettings.Setup(m => m.Profiles).Returns([]);
             var versionedTestSettings = testSettings.As<IVersionedLaunchSettings>();
             versionedTestSettings.Setup(m => m.Version).Returns(42);
 
@@ -936,7 +936,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
             var testSettings = new Mock<ILaunchSettings>();
             testSettings.Setup(m => m.GlobalSettings).Returns(globalSettings);
-            testSettings.Setup(m => m.Profiles).Returns(ImmutableList<ILaunchProfile>.Empty);
+            testSettings.Setup(m => m.Profiles).Returns([]);
 
             provider.SetCurrentSnapshot(testSettings.Object);
             provider.SetNextVersionTest(123);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [Fact]
         public async Task WhenAddingMultipleItems_TheReturnedItemsHaveTheCorrectNames()
         {
-            ImmutableList<ILaunchProfile> newProfiles = ImmutableList<ILaunchProfile>.Empty;
+            ImmutableList<ILaunchProfile> newProfiles = [];
             var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
                 addOrUpdateProfileCallback: (p, a) =>
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -9,9 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
 
         private static readonly IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
-            Enumerable.Empty<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
-        private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders = 
-            Enumerable.Empty<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+            [];
+        private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
+            [];
 
         [Fact]
         public void DefaultProjectPath_IsTheProjectPath()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesTests.cs
@@ -11,9 +11,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
 
         private static readonly ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
-            ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>.Empty;
+            [];
         private static readonly ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
-            ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>.Empty;
+            [];
 
         [Fact]
         public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProviderTests.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     public class ProjectLaunchProfileExtensionValueProviderTests
     {
-        private static readonly ImmutableDictionary<string, object> EmptyGlobalSettings = ImmutableDictionary<string, object>.Empty;
+        private static readonly ImmutableDictionary<string, object> EmptyGlobalSettings = [];
 
         [Fact]
         public void AuthenticationMode_OnGetPropertyValueAsync_GetsModeFromActiveProfile()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilderTests.cs
@@ -120,7 +120,7 @@ public sealed class DependenciesTreeBuilderTests
     [Fact]
     public async Task BuildTreeAsync_SingleSlice_EmptyDependenciesCollection_ShowsEmptyGroupNode()
     {
-        var snapshot = CreateDependenciesSnapshot(new() { [_slice] = new() { [DependencyGroupTypes.Packages] = Array.Empty<IDependency>() } });
+        var snapshot = CreateDependenciesSnapshot(new() { [_slice] = new() { [DependencyGroupTypes.Packages] = [] } });
 
         var tree = await _builder.BuildTreeAsync(null, snapshot, CancellationToken.None);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UpToDate/BuildUpToDateCheckTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.UpToDate
         private bool _isBuildAccelerationEnabledInSettings;
         private bool? _isBuildAccelerationEnabledInProject;
         private bool? _expectedIsBuildAccelerationEnabled;
-        private IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> _copyItems = Enumerable.Empty<(string Path, ImmutableArray<CopyItem> CopyItems)>();
+        private IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> _copyItems = [];
         private bool _isCopyItemsComplete = true;
         private IReadOnlyList<string>? _targetsWithoutReferenceAssemblies;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Telemetry/ManagedTelemetryServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Telemetry/ManagedTelemetryServiceTests.cs
@@ -123,7 +123,7 @@ namespace Microsoft.VisualStudio.Telemetry
 
             Assert.Throws<ArgumentException>("properties", () =>
             {
-                service.PostProperties("event1", Enumerable.Empty<(string propertyName, object propertyValue)>());
+                service.PostProperties("event1", []);
             });
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
     {
         public static IProjectCapabilitiesScope Create(IEnumerable<string>? capabilities = null)
         {
-            capabilities ??= Enumerable.Empty<string>();
+            capabilities ??= [];
             var snapshot = new Mock<IProjectCapabilitiesSnapshot>();
             snapshot.Setup(s => s.IsProjectCapabilityPresent(It.IsAny<string>())).Returns((string capability) => capabilities.Contains(capability));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManagerTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         [Fact]
         public async Task StartupProjectsArePassedThrough()
         {
-            ImmutableArray<string> startupProjectPaths = ImmutableArray<string>.Empty;
+            ImmutableArray<string> startupProjectPaths = [];
             Action<ImmutableArray<string>> onImplicitBuildStartWithStartPaths = paths => startupProjectPaths = paths;
 
             var buildManager = await CreateInitializedInstanceAsync(
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 IProjectThreadingServiceFactory.Create(),
                 solutionBuildManager,
                 IImplicitlyTriggeredBuildManagerFactory.Create(onImplicitBuildStart, onImplicitBuildEndOrCancel, onImplicitBuildStartWithStartupPaths),
-                IStartupProjectHelperFactory.Create(startupProjectFullPaths ?? ImmutableArray<string>.Empty));
+                IStartupProjectHelperFactory.Create(startupProjectFullPaths ?? []));
             
             await instance.LoadAsync();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -725,7 +725,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             var configuredProjectServices = Mock.Of<ConfiguredProjectServices>(o =>
                 o.ProjectPropertiesProvider == delegateProvider);
 
-            var capabilitiesScope = scope ?? IProjectCapabilitiesScopeFactory.Create(capabilities: Enumerable.Empty<string>());
+            var capabilitiesScope = scope ?? IProjectCapabilitiesScopeFactory.Create(capabilities: []);
 
             var configuredProject = Mock.Of<ConfiguredProject>(o =>
                 o.UnconfiguredProject == project &&

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var startupHelper = new Mock<IStartupProjectHelper>();
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
-                         .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
+                         .Returns([]);
 
             var command = CreateInstance(startupHelper.Object);
             Assert.False(command.ExecCommand(0, EventArgs.Empty));
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var startupHelper = new Mock<IStartupProjectHelper>();
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
-                         .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
+                         .Returns([]);
 
             var command = CreateInstance(startupHelper.Object);
             Assert.False(command.QueryStatusCommand(0, EventArgs.Empty));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
         {
             var startupHelper = new Mock<IStartupProjectHelper>();
             startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
-                         .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
+                         .Returns([]);
 
             var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
             command.QueryStatus();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -435,7 +435,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
             var project = new Project(projectRootElement);
 
-            var elements = OrderingHelper.GetItemElements(project, tree.Children[0], ImmutableArray<string>.Empty);
+            var elements = OrderingHelper.GetItemElements(project, tree.Children[0], []);
 
             Assert.True(OrderingHelper.TryMoveElementsAbove(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
@@ -488,7 +488,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
             var project = new Project(projectRootElement);
 
-            var elements = OrderingHelper.GetItemElements(project, tree.Children[0], ImmutableArray<string>.Empty);
+            var elements = OrderingHelper.GetItemElements(project, tree.Children[0], []);
 
             Assert.True(OrderingHelper.TryMoveElementsBelow(project, elements, tree.Children[2]));
             Assert.True(project.IsDirty);
@@ -551,7 +551,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
 
             var project = new Project(projectRootElement);
 
-            var elements = OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty);
+            var elements = OrderingHelper.GetItemElements(project, updatedTree.Children[2], []);
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
@@ -618,8 +618,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             var project = new Project(projectRootElement);
 
             var elements =
-                OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty)
-                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[3], ImmutableArray<string>.Empty));
+                OrderingHelper.GetItemElements(project, updatedTree.Children[2], [])
+                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[3], []));
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
@@ -691,8 +691,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             var project = new Project(projectRootElement);
 
             var elements =
-                OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[0], ImmutableArray<string>.Empty)
-                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[1], ImmutableArray<string>.Empty));
+                OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[0], [])
+                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[1], []));
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);
@@ -767,8 +767,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands.Ordering
             var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
 
             var elements =
-                OrderingHelper.GetItemElements(project, updatedTree.Children[0], ImmutableArray<string>.Empty)
-                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty));
+                OrderingHelper.GetItemElements(project, updatedTree.Children[0], [])
+                .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2], []));
 
             Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
             Assert.True(project.IsDirty);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -152,7 +152,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
         public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
-            string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+            string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
             var context = IWorkspaceProjectContextMockFactory.Create();
@@ -172,7 +172,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
         public void ApplyProjectBuild_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
-            string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+            string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
             var context = IWorkspaceProjectContextMockFactory.Create();
@@ -232,7 +232,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
         public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
-            string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+            string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
             var context = IWorkspaceProjectContextMockFactory.Create();
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
         public void ApplyProjectBuild_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
         {
-            string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+            string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
             var context = IWorkspaceProjectContextMockFactory.Create();
@@ -270,7 +270,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "A.cs;B.cs",         "B.cs;A.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]
         public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
         {
-            string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+            string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
             var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
             var context = IWorkspaceProjectContextMockFactory.Create();
@@ -289,7 +289,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         [InlineData("A.cs;B.cs",                       "A.cs;B.cs",         "B.cs;A.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]
         public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
         {
-            string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+            string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
             var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
             var context = IWorkspaceProjectContextMockFactory.Create();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
@@ -17,11 +17,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 public class WorkspaceTests
 {
     private static BuildOptions EmptyBuildOptions { get; } = new BuildOptions(
-            sourceFiles: ImmutableArray<CommandLineSourceFile>.Empty,
-            additionalFiles: ImmutableArray<CommandLineSourceFile>.Empty,
-            metadataReferences: ImmutableArray<CommandLineReference>.Empty,
-            analyzerReferences: ImmutableArray<CommandLineAnalyzerReference>.Empty,
-            analyzerConfigFiles: ImmutableArray<string>.Empty);
+            sourceFiles: [],
+            additionalFiles: [],
+            metadataReferences: [],
+            analyzerReferences: [],
+            analyzerConfigFiles: []);
 
     [Fact]
     public async Task Dispose_DisposesChainedDisposables()
@@ -812,7 +812,7 @@ public class WorkspaceTests
         slice ??= ProjectConfigurationSlice.Create(ImmutableStringDictionary<string>.EmptyOrdinal.Add("TargetFramework", "net6.0"));
         unconfiguredProject ??= UnconfiguredProjectFactory.ImplementFullPath("""C:\MyProject\MyProject.csproj""");
         projectGuid ??= Guid.NewGuid();
-        updateHandlers ??= new UpdateHandlers(Array.Empty<ExportFactory<IWorkspaceUpdateHandler>>());
+        updateHandlers ??= new UpdateHandlers([]);
         logger ??= IManagedProjectDiagnosticOutputServiceFactory.Create();
         activeWorkspaceProjectContextTracker ??= IActiveEditorContextTrackerFactory.Create();
         commandLineParserServices ??= new(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst) { commandLineParserService.Object };

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
 
             Assert.Equal("Resources1.Designer.cs", _lastCompiledFile);
             Assert.Equal("C:\\TempPE", _lastOutputPath);
-            Assert.Equal(ImmutableHashSet<string>.Empty, _lastSharedInputs);
+            Assert.Equal([], _lastSharedInputs);
         }
 
         public DesignTimeInputsBuildManagerBridgeTests()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueueTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueueTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+            queue.Push(new QueueItem("FileName", [], "", false));
 
             Assert.Equal(1, queue.Count);
         }
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+            queue.Push(new QueueItem("FileName", [], "", false));
 
             queue.Pop();
 
@@ -41,9 +41,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+            queue.Push(new QueueItem("FileName", [], "", false));
 
-            queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", true));
+            queue.Push(new QueueItem("FileName", [], "", true));
 
             Assert.Equal(1, queue.Count);
             Assert.True(queue.Pop()?.IgnoreFileWriteTime);
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+            queue.Push(new QueueItem("FileName", [], "", false));
 
             queue.RemoveSpecific("FileName");
 
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 new DesignTimeInputFileChange("FileName2", false)
             });
 
-            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1", "FileName2" }), ImmutableHashSet<string>.Empty, "");
+            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1", "FileName2" }), [], "");
 
             Assert.Equal(2, queue.Count);
         }
@@ -88,7 +88,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 new DesignTimeInputFileChange("FileName1", false)
             });
 
-            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), ImmutableHashSet<string>.Empty, "");
+            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), [], "");
 
             Assert.Equal(1, queue.Count);
         }
@@ -104,7 +104,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 new DesignTimeInputFileChange("FileName1", true)
             });
 
-            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), ImmutableHashSet<string>.Empty, "");
+            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), [], "");
 
             Assert.Equal(1, queue.Count);
             Assert.True(queue.Pop()?.IgnoreFileWriteTime);
@@ -121,7 +121,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 new DesignTimeInputFileChange("FileName2", false)
             });
 
-            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), ImmutableHashSet<string>.Empty, "");
+            queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), [], "");
 
             Assert.Equal(1, queue.Count);
             Assert.Equal("FileName1", queue.Pop()?.FileName);


### PR DESCRIPTION
C# 12 introduces collection expressions, which are a terse syntax for specifying common collection values. The feature is currently in preview. This change applies the Roslyn codefix to apply this new feature throughout the solution, so we can see how we feel about it and provide timely feedback to the Roslyn team.

It's entirely possible that our CI pipeline doesn't support this feature yet. Regardless, it'd still be interesting to discuss this feature here.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9229)