### PR TITLE
Include .pdb files in our NPM package

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -737,6 +737,8 @@
       <NpmContent Include="@(SatelliteDllsProjectOutputGroupOutput)">
         <PackagePath>%(SatelliteDllsProjectOutputGroupOutput.TargetPath)</PackagePath>
       </NpmContent>
+      <!-- Include symbol files (.pdb) so we can get code coverage numbers from C# Dev Kit integration test runs. -->
+      <NpmContent Include="@(DebugSymbolsProjectOutputGroupOutput)" />
     </ItemGroup>
   </Target>
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Setup/PackageContentTests.NpmPackage.verified.txt
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Setup/PackageContentTests.NpmPackage.verified.txt
@@ -2,6 +2,7 @@
   exports.json,
   Microsoft.CodeAnalysis.dll,
   Microsoft.VisualStudio.ProjectSystem.Managed.dll,
+  Microsoft.VisualStudio.ProjectSystem.Managed.pdb,
   package.json,
   cs\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,
   de\Microsoft.VisualStudio.ProjectSystem.Managed.resources.dll,


### PR DESCRIPTION
We can request builds of the C# Dev Kit repo (vs-green) that collect code coverage numbers during integration test runs. In order for this to work, however, the code coverage system needs to be able to find the .pdb files for our managed assemblies. Here we update the project to include all the symbol files in the `DebugSymbolsProjectOutputGroupOutput` item group in our NPM package. This includes the most important file for this repo, Microsoft.VisualStudio.ProjectSystem.Managed.pdb, and, I believe, will also include the .pdb files of other referenced projects (if and when we reference other projects).

Note that the C# Dev Kit extension will not include .pdb files in what gets installed on a user's system so there is no downside to including the .pdbs.

This also updates the test to verify our NPM package content since we are now including an additional file.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9234)