### PR TITLE
Delete platform properties when targeting lower than .NET 5.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -282,7 +282,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private async Task<string> GetTargetFrameworkAliasAsync(string targetFrameworkMoniker)
         {
             IProjectSubscriptionService? subscriptionService = _configuredProject.Services.ProjectSubscription;
-            Assumes.Present(subscriptionService);
+            if (subscriptionService is null)
+            {
+                return string.Empty;
+            }
 
             IImmutableDictionary<string, IProjectRuleSnapshot> supportedTargetFrameworks = await subscriptionService.ProjectRuleSource.GetLatestVersionAsync(_configuredProject, new string[] { SupportedTargetFramework.SchemaName });
             IProjectRuleSnapshot targetFrameworkRuleSnapshot = supportedTargetFrameworks[SupportedTargetFramework.SchemaName];
@@ -306,7 +309,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private async Task<string> GetTargetPlatformAliasAsync(string targetPlatformIdentifier)
         {
             IProjectSubscriptionService? subscriptionService = _configuredProject.Services.ProjectSubscription;
-            Assumes.Present(subscriptionService);
+            if (subscriptionService is null)
+            {
+                return string.Empty;
+            }
 
             IImmutableDictionary<string, IProjectRuleSnapshot> sdkSupportedTargetPlatformIdentifiers = await subscriptionService.ProjectRuleSource.GetLatestVersionAsync(_configuredProject, new string[] { SdkSupportedTargetPlatformIdentifier.SchemaName });
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             return IsValueDefinedInContextMSBuildPropertiesAsync(defaultProperties, s_msBuildPropertyNames);
         }
 
-        public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties projectProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
+        public override async Task<string?> OnSetPropertyValueAsync(string propertyName, string unevaluatedPropertyValue, IProjectProperties defaultProperties, IReadOnlyDictionary<string, string>? dimensionalConditions = null)
         {
             ComplexTargetFramework storedProperties = await GetStoredPropertiesAsync();
 
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                         // Delete platform properties
                         storedProperties.TargetPlatformIdentifier = null;
                         storedProperties.TargetPlatformVersion = null;
-                        await ResetPlatformPropertiesAsync(projectProperties);
+                        await ResetPlatformPropertiesAsync(defaultProperties);
                     }
                 }
 
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     {
                         // Delete platform properties.
                         storedProperties.TargetPlatformVersion = null;
-                        await ResetPlatformPropertiesAsync(projectProperties);
+                        await ResetPlatformPropertiesAsync(defaultProperties);
 
                         storedProperties.TargetPlatformIdentifier = unevaluatedPropertyValue;
                     }
@@ -107,7 +107,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     storedProperties.TargetPlatformVersion = unevaluatedPropertyValue;
                 }
 
-                await projectProperties.SetPropertyValueAsync(TargetFrameworkProperty, await ComputeValueAsync(storedProperties));
+                await defaultProperties.SetPropertyValueAsync(TargetFrameworkProperty, await ComputeValueAsync(storedProperties));
             }
 
             return null;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             TargetPlatformVersionProperty
         },
         ExportInterceptingPropertyValueProviderFile.ProjectFile)]
-    internal sealed class CompoundTargetFrameworkValueProvider : InterceptingPropertyValueProviderBase
+    internal class CompoundTargetFrameworkValueProvider : InterceptingPropertyValueProviderBase
     {
         private const string InterceptedTargetFrameworkProperty = "InterceptedTargetFramework";
         private const string TargetPlatformProperty = ConfigurationGeneral.TargetPlatformIdentifierProperty;
@@ -44,10 +44,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         }
 
         [ImportingConstructor]
-        public CompoundTargetFrameworkValueProvider(ProjectProperties properties, ConfiguredProject configuredProject)
+        public CompoundTargetFrameworkValueProvider(ProjectProperties properties)
         {
             _properties = properties;
-            _configuredProject = configuredProject;
+            _configuredProject = properties.ConfiguredProject;
         }
 
         private async Task<ComplexTargetFramework> GetStoredPropertiesAsync()
@@ -279,13 +279,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// Retrieves the target framework alias (i.e. net5.0) from the project's subscription service.
         /// </summary>
         /// <returns></returns>
-        private async Task<string> GetTargetFrameworkAliasAsync(string targetFrameworkMoniker)
+        internal virtual async Task<string> GetTargetFrameworkAliasAsync(string targetFrameworkMoniker)
         {
             IProjectSubscriptionService? subscriptionService = _configuredProject.Services.ProjectSubscription;
-            if (subscriptionService is null)
-            {
-                return string.Empty;
-            }
+            Assumes.Present(subscriptionService);
 
             IImmutableDictionary<string, IProjectRuleSnapshot> supportedTargetFrameworks = await subscriptionService.ProjectRuleSource.GetLatestVersionAsync(_configuredProject, new string[] { SupportedTargetFramework.SchemaName });
             IProjectRuleSnapshot targetFrameworkRuleSnapshot = supportedTargetFrameworks[SupportedTargetFramework.SchemaName];
@@ -309,10 +306,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private async Task<string> GetTargetPlatformAliasAsync(string targetPlatformIdentifier)
         {
             IProjectSubscriptionService? subscriptionService = _configuredProject.Services.ProjectSubscription;
-            if (subscriptionService is null)
-            {
-                return string.Empty;
-            }
+            Assumes.Present(subscriptionService);
 
             IImmutableDictionary<string, IProjectRuleSnapshot> sdkSupportedTargetPlatformIdentifiers = await subscriptionService.ProjectRuleSource.GetLatestVersionAsync(_configuredProject, new string[] { SdkSupportedTargetPlatformIdentifier.SchemaName });
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProviderTests.cs
@@ -1,37 +1,78 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-namespace Microsoft.VisualStudio.ProjectSystem.Properties
+namespace Microsoft.VisualStudio.ProjectSystem.Properties;
+
+public class CompoundTargetFrameworkValueProviderTests
 {
-    public class CompoundTargetFrameworkValueProviderTests
+    [Fact]
+    public async Task WhenChangingTargetFramework_PlatformPropertiesAreDeleted()
     {
-        [Fact]
-        public async Task WhenChangingTargetFramework_PlatformPropertiesAreDeleted()
+        // Previous target framework properties
+        var propertiesAndValues = new Dictionary<string, string?>
         {
-            // Previous target framework properties
-            var propertiesAndValues = new Dictionary<string, string>
-            {
-                { "InterceptedTargetFramework", ".net5.0-windows" },
-                { "TargetPlatformIdentifier", "windows" },
-                { "TargetPlatformVersion", "7.0" }
-            };
+            { "InterceptedTargetFramework", ".net5.0-windows" },
+            { "TargetPlatformIdentifier", "windows" },
+            { "TargetPlatformVersion", "7.0" }
+        };
 
-            // New target framework properties: only projects targeting .NET 5 or higher use platform properties.
-            var projectProperties = ProjectPropertiesFactory.Create(
-                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkProperty, "netcoreapp1.0", null),
-                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkMonikerProperty, ".NETCoreApp,Version=v1.0", null),
-                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkIdentifierProperty, "NETCoreApp", null),
-                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformIdentifierProperty, null, null),
-                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformVersionProperty, null, null));
-            
-            var iProjectProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(propertiesAndValues);
-            var configuredProject = projectProperties.ConfiguredProject;
+        // New target framework properties: only projects targeting .NET 5 or higher use platform properties.
+        var projectProperties = ProjectPropertiesFactory.Create(
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkProperty, "netcoreapp1.0", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkMonikerProperty, ".NETCoreApp,Version=v1.0", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkIdentifierProperty, "NETCoreApp", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformIdentifierProperty, null, null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformVersionProperty, null, null));
+        
+        var iProjectProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(propertiesAndValues);
+        var configuredProject = projectProperties.ConfiguredProject;
 
-            var provider = new CompoundTargetFrameworkValueProvider(projectProperties, configuredProject);
-            await provider.OnSetPropertyValueAsync("InterceptedTargetFramework", ".NETCoreApp,Version=v1.0", iProjectProperties);
+        var provider = new CompoundTargetFrameworkValueProvider(projectProperties, configuredProject);
+        await provider.OnSetPropertyValueAsync("InterceptedTargetFramework", ".NETCoreApp,Version=v1.0", iProjectProperties);
 
-            // The value of the property we surface in the UI is stored as a moniker.
-            var actual = await provider.OnGetEvaluatedPropertyValueAsync("InterceptedTargetFramework", "", iProjectProperties);
-            Assert.Equal(".NETCoreApp,Version=v1.0", actual);
-        }
+        // The value of the property we surface in the UI is stored as a moniker.
+        var actualTargetFramework = await provider.OnGetEvaluatedPropertyValueAsync("InterceptedTargetFramework", "", iProjectProperties);
+        Assert.Equal(".NETCoreApp,Version=v1.0", actualTargetFramework);
+
+        var actualPlatformIdentifier = await provider.OnGetEvaluatedPropertyValueAsync(ConfigurationGeneral.TargetPlatformIdentifierProperty, "", iProjectProperties);
+        Assert.Equal("", actualPlatformIdentifier);
+
+        var actualPlatformVersion = await provider.OnGetEvaluatedPropertyValueAsync(ConfigurationGeneral.TargetPlatformVersionProperty, "", iProjectProperties);
+        Assert.Equal("", actualPlatformVersion);
+    }
+
+    [Fact]
+    public async Task WhenChangingTargetFrameworkHigherThanNet5_PlatformPropertiesAreKept()
+    {
+        // Previous target framework properties
+        var propertiesAndValues = new Dictionary<string, string?>
+        {
+            { "InterceptedTargetFramework", ".net5.0-windows" },
+            { "TargetPlatformIdentifier", "windows" },
+            { "TargetPlatformVersion", "7.0" }
+        };
+
+        // New target framework properties: only projects targeting .NET 5 or higher use platform properties.
+        var projectProperties = ProjectPropertiesFactory.Create(
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkProperty, "net6.0", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkMonikerProperty, ".NETCoreApp,Version=v6.0", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkIdentifierProperty, "NETCoreApp", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformIdentifierProperty, "Windows", null),
+            new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformVersionProperty, "7.0", null));
+
+        var iProjectProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(propertiesAndValues);
+        var configuredProject = projectProperties.ConfiguredProject;
+
+        var provider = new CompoundTargetFrameworkValueProvider(projectProperties, configuredProject);
+        await provider.OnSetPropertyValueAsync("InterceptedTargetFramework", ".NETCoreApp,Version=v6.0", iProjectProperties);
+
+        // The value of the property we surface in the UI is stored as a moniker.
+        var actualTargetFramework = await provider.OnGetEvaluatedPropertyValueAsync("InterceptedTargetFramework", "", iProjectProperties);
+        Assert.Equal(".NETCoreApp,Version=v6.0", actualTargetFramework);
+
+        var actualPlatformIdentifier = await provider.OnGetEvaluatedPropertyValueAsync(ConfigurationGeneral.TargetPlatformIdentifierProperty, "", iProjectProperties);
+        Assert.Equal("Windows", actualPlatformIdentifier);
+
+        var actualPlatformVersion = await provider.OnGetEvaluatedPropertyValueAsync(ConfigurationGeneral.TargetPlatformVersionProperty, "", iProjectProperties);
+        Assert.Equal("7.0", actualPlatformVersion);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProviderTests.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    public class CompoundTargetFrameworkValueProviderTests
+    {
+        [Fact]
+        public async Task WhenChangingTargetFramework_PlatformPropertiesAreDeleted()
+        {
+            // Previous target framework properties
+            var propertiesAndValues = new Dictionary<string, string>
+            {
+                { "InterceptedTargetFramework", ".net5.0-windows" },
+                { "TargetPlatformIdentifier", "windows" },
+                { "TargetPlatformVersion", "7.0" }
+            };
+
+            // New target framework properties: only projects targeting .NET 5 or higher use platform properties.
+            var projectProperties = ProjectPropertiesFactory.Create(
+                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkProperty, "netcoreapp1.0", null),
+                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkMonikerProperty, ".NETCoreApp,Version=v1.0", null),
+                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkIdentifierProperty, "NETCoreApp", null),
+                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformIdentifierProperty, null, null),
+                new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetPlatformVersionProperty, null, null));
+            
+            var iProjectProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(propertiesAndValues);
+            var configuredProject = projectProperties.ConfiguredProject;
+
+            var provider = new CompoundTargetFrameworkValueProvider(projectProperties, configuredProject);
+            await provider.OnSetPropertyValueAsync("InterceptedTargetFramework", ".NETCoreApp,Version=v1.0", iProjectProperties);
+
+            // The value of the property we surface in the UI is stored as a moniker.
+            var actual = await provider.OnGetEvaluatedPropertyValueAsync("InterceptedTargetFramework", "", iProjectProperties);
+            Assert.Equal(".NETCoreApp,Version=v1.0", actual);
+        }
+    }
+}


### PR DESCRIPTION
Fixes [AB#1846189](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1846189).

We are resetting the platform properties when a target framework is changed; instead, we should keep them if the new value is `.NET 5` or higher.

Unit tests are included: instead of mocking the project services this provider uses, I mocked the provider methods that access data. At the end of the day, these tests only cover the `OnSetPropertyValueAsync()` logic and what I really want to ensure is that we compute the correct value in `ComputeValueAsync()`.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9235)