### PR TITLE
Cache repo root path

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Utilities/RepoUtil.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Utilities/RepoUtil.cs
@@ -4,6 +4,8 @@ namespace Microsoft.VisualStudio.Utilities
 {
     internal static class RepoUtil
     {
+        private static string? _root;
+
         /// <summary>
         /// Gets the absolute path to the checked out location of this repo.
         /// </summary>
@@ -12,18 +14,22 @@ namespace Microsoft.VisualStudio.Utilities
         /// </remarks>
         public static string FindRepoRootPath()
         {
-            // Start with this DLL's location
-            string path = typeof(RepoUtil).Assembly.Location;
-
-            // Walk up the tree until we find the 'artifacts' folder
-            while (!Path.GetFileName(path).Equals("artifacts", StringComparisons.Paths))
+            if (_root is null)
             {
-                path = Path.GetDirectoryName(path);
+                // Start with this DLL's location
+                string path = typeof(RepoUtil).Assembly.Location;
+
+                // Walk up the tree until we find the 'artifacts' folder
+                while (!Path.GetFileName(path).Equals("artifacts", StringComparisons.Paths))
+                {
+                    path = Path.GetDirectoryName(path);
+                }
+
+                // Go up one more level
+                _root = Path.GetDirectoryName(path);
             }
 
-            // Go up one more level
-            path = Path.GetDirectoryName(path);
-            return path;
+            return _root;
         }
     }
 }


### PR DESCRIPTION
Avoids doing file system operations multiple times during test runs. This value won't change during the lifetime of the process.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9236)