### PR TITLE
Subscribe to project changes to check for missing runtimes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Runtimes/MissingSdkRuntimeDetector.cs
@@ -20,18 +20,29 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private readonly ConfiguredProject _project;
         private readonly IProjectFaultHandlerService _projectFaultHandlerService;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
+        private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
+
+        private IDisposable? _subscription;
 
         [ImportingConstructor]
         public MissingSdkRuntimeDetector(
             IMissingSetupComponentRegistrationService missingSetupComponentRegistrationService,
             ConfiguredProject configuredProject,
             IProjectThreadingService threadingService,
-            IProjectFaultHandlerService projectFaultHandlerService)
+            IProjectFaultHandlerService projectFaultHandlerService, 
+            IActiveConfiguredProjectSubscriptionService projectSubscriptionService)
             : base(threadingService.JoinableTaskContext)
         {
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
             _project = configuredProject;
             _projectFaultHandlerService = projectFaultHandlerService;
+            _projectSubscriptionService = projectSubscriptionService;
+        }
+        
+        
+        private Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> _)
+        {
+            return RegisterSdkNetCoreRuntimeNeededInProjectAsync(_project);
         }
 
         public Task LoadAsync()
@@ -42,7 +53,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public Task UnloadAsync()
         {
             _missingSetupComponentRegistrationService.UnregisterProjectConfiguration(_projectGuid, _project);
-
+            _subscription?.Dispose();
+            
             return Task.CompletedTask;
         }
 
@@ -57,29 +69,26 @@ namespace Microsoft.VisualStudio.ProjectSystem
             // safe to use within IProjectDynamicLoadComponent.LoadAsync.
             _projectGuid = await _project.UnconfiguredProject.GetProjectGuidAsync();
             _missingSetupComponentRegistrationService.RegisterProjectConfiguration(_projectGuid, _project);
-            _projectFaultHandlerService.Forget(RegisterSdkNetCoreRuntimeNeededInProjectAsync(_project), _project.UnconfiguredProject);
+            _subscription = _projectSubscriptionService.ProjectRuleSource.SourceBlock.LinkToAsyncAction(target: OnProjectChangedAsync, _project.UnconfiguredProject);
         }
 
         private async Task RegisterSdkNetCoreRuntimeNeededInProjectAsync(ConfiguredProject project)
         {
-            if (IsInitialized)
+            var projectProperties = project.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+
+            ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
+
+            string? targetFrameworkIdentifier = await configuration.TargetFrameworkIdentifier.GetDisplayValueAsync();
+
+            string? targetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
+
+            if (!string.Equals(targetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) ||
+                string.IsNullOrEmpty(targetFrameworkVersion))
             {
-                var projectProperties = project.Services.ExportProvider.GetExportedValue<ProjectProperties>();
-
-                ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
-
-                string? targetFrameworkIdentifier = await configuration.TargetFrameworkIdentifier.GetDisplayValueAsync();
-
-                string? targetFrameworkVersion = await configuration.TargetFrameworkVersion.GetDisplayValueAsync();
-
-                if (!string.Equals(targetFrameworkIdentifier, s_netCoreTargetFrameworkIdentifier, StringComparisons.FrameworkIdentifiers) ||
-                    string.IsNullOrEmpty(targetFrameworkVersion))
-                {
-                    targetFrameworkVersion = string.Empty;
-                }
-                
-                _missingSetupComponentRegistrationService.RegisterPossibleMissingSdkRuntimeVersion(_projectGuid, project, targetFrameworkVersion);
+                targetFrameworkVersion = string.Empty;
             }
+            
+            _missingSetupComponentRegistrationService.RegisterPossibleMissingSdkRuntimeVersion(_projectGuid, project, targetFrameworkVersion);
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Runtimes/MissingSdkRuntimeDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Runtimes/MissingSdkRuntimeDetector.cs
@@ -18,9 +18,8 @@ namespace Microsoft.VisualStudio.ProjectSystem
         private Guid _projectGuid;
 
         private readonly ConfiguredProject _project;
-        private readonly IProjectFaultHandlerService _projectFaultHandlerService;
         private readonly IMissingSetupComponentRegistrationService _missingSetupComponentRegistrationService;
-        private readonly IActiveConfiguredProjectSubscriptionService _projectSubscriptionService;
+        private readonly IProjectSubscriptionService _projectSubscriptionService;
 
         private IDisposable? _subscription;
 
@@ -30,12 +29,11 @@ namespace Microsoft.VisualStudio.ProjectSystem
             ConfiguredProject configuredProject,
             IProjectThreadingService threadingService,
             IProjectFaultHandlerService projectFaultHandlerService, 
-            IActiveConfiguredProjectSubscriptionService projectSubscriptionService)
+            IProjectSubscriptionService projectSubscriptionService)
             : base(threadingService.JoinableTaskContext)
         {
             _missingSetupComponentRegistrationService = missingSetupComponentRegistrationService;
             _project = configuredProject;
-            _projectFaultHandlerService = projectFaultHandlerService;
             _projectSubscriptionService = projectSubscriptionService;
         }
         


### PR DESCRIPTION
This PR fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1867244 as well as addresses 1 of 2 gaps in our missing component tracking.

The root cause of the linked issue is that `RegisterSdkNetCoreRuntimeNeededInProjectAsync` is called within `InitializeCoreAsync`. `IsInitialized` isn't true until after `InitializeCoreAsync` completes, so this will always be false. Because `RegisterSdkNetCoreRuntimeNeededInProjectAsync` only runs once, on configured project load, we never register missing runtimes.

The simple solution was to eliminate the block, but... looking into this area, I realized there were two gaps:
1. If you modify the project runtime identifier _after the project is loaded_ to one that you do not have installed on your machine, we do not show the missing component UI. 
2. If you modify the project type/runtime identifier and no longer have any missing components, we do not hide the missing component UI (I filed #9239 to track this small issue, because it's dependent on the shell)

The solution to 1) that I had was to subscribe to `IProjectSubscriptionService`, but I'm not sure if that's too heavy. @drewnoakes, is there a way to only get TFM updates?

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9240)