### PR TITLE
Bump compiler version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.3.57" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.3.198" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.9-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.18" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
@@ -48,7 +48,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.4.0-preview-2-32826-307" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.7.5-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.7.9" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.2.2146" />
@@ -57,8 +57,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.8.9" />
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.7.15-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.7.15-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.7.30" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.7.30" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.7.36307-preview.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.6.11" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
@@ -78,18 +78,18 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes"                         Version="$(CPSPackageVersion)" />
 
     <!-- Roslyn -->
-    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.7.0-1.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.8.0-3.23429.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.8.0-3.23429.9" />
     <PackageVersion Include="Microsoft.CSharp"                                                       Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.8.0-3.23429.9" />
     <PackageVersion Include="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.8.0-3.23429.9" />
 
     <!-- Analyzers -->
     <PackageVersion Include="CSharpIsNullAnalyzer"                                                   Version="0.1.329" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.5-beta1.23165.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.7.0-1.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.8.0-3.23429.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.8.0-3.23429.9" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.5-beta1.23165.1" />
 
     <!-- NuGet -->

--- a/spelling.dic
+++ b/spelling.dic
@@ -61,6 +61,7 @@ shproj
 typeof
 uint
 unadvise
+unadvising
 unescape
 unescapes
 ushort

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PackageRestoreConfiguredInputFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/PackageRestoreConfiguredInputFactory.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             ProjectConfiguration projectConfiguration = ProjectConfigurationFactory.Create("Debug|x64");
             IComparable projectVersion = 0;
 
-            return new PackageRestoreConfiguredInput[1]{new PackageRestoreConfiguredInput(projectConfiguration, restoreInfo, projectVersion)};
+            return new[] { new PackageRestoreConfiguredInput(projectConfiguration, restoreInfo, projectVersion) };
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsTests.cs
@@ -7,7 +7,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [Fact]
         public void LaunchSettings_CtorTests()
         {
-            var profiles = new List<LaunchProfile>()
+            var profiles = new[]
             {
                 new LaunchProfile("abc", null, commandLineArgs: "test"),
                 new LaunchProfile("def", null),
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             var settings = new LaunchSettings(profiles);
             Assert.NotNull(settings.ActiveProfile);
             Assert.True(settings.ActiveProfile.Name == "abc");
-            Assert.Equal(profiles.Count, settings.Profiles.Count);
+            Assert.Equal(profiles.Length, settings.Profiles.Count);
             Assert.Empty(settings.GlobalSettings);
 
             settings = new LaunchSettings(profiles, activeProfileName: "ghi");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PropertyPages
         {
             Castle.DynamicProxy.Generators.AttributesToAvoidReplicating.Add(typeof(UIPermissionAttribute));
 
-            var rect = new RECT[] { new RECT() { left = 25, top = 25 } };
+            var rect = new[] { new RECT() { left = 25, top = 25 } };
             var page = new Mock<PropertyPage>()
             {
                 CallBase = true

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
                 ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
                 ImmutableHashSet<string>.Empty,
-                new DesignTimeInputFileChange[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
+                new[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
                 "C:\\TempPE"));
 
             // One file should have been added
@@ -60,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
                 ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
                 ImmutableHashSet<string>.Empty,
-                new DesignTimeInputFileChange[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
+                new[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
                 "C:\\TempPE"));
 
             await _bridge.BuildDesignTimeOutputAsync("Resources1.Designer.cs");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueueTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueueTests.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            var range = ImmutableArray.CreateRange(new DesignTimeInputFileChange[]
+            var range = ImmutableArray.CreateRange(new[]
             {
                 new DesignTimeInputFileChange("FileName1", false),
                 new DesignTimeInputFileChange("FileName2", false)
@@ -82,7 +82,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            var range = ImmutableArray.CreateRange(new DesignTimeInputFileChange[]
+            var range = ImmutableArray.CreateRange(new[]
             {
                 new DesignTimeInputFileChange("FileName1", false),
                 new DesignTimeInputFileChange("FileName1", false)
@@ -98,7 +98,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            var range = ImmutableArray.CreateRange(new DesignTimeInputFileChange[]
+            var range = ImmutableArray.CreateRange(new[]
             {
                 new DesignTimeInputFileChange("FileName1", false),
                 new DesignTimeInputFileChange("FileName1", true)
@@ -115,7 +115,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
         {
             var queue = new CompilationQueue();
 
-            var range = ImmutableArray.CreateRange(new DesignTimeInputFileChange[]
+            var range = ImmutableArray.CreateRange(new[]
             {
                 new DesignTimeInputFileChange("FileName1", false),
                 new DesignTimeInputFileChange("FileName2", false)


### PR DESCRIPTION
Update to newer compiler packages, and fix new warnings.

Pulled out of #9229.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9242)