### PR TITLE
Remove use of JTF.Run in wait indicator

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -135,18 +135,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 return;
             }
 
-            _ = _threadingService.JoinableTaskFactory.RunAsync(async () =>
-            {
-                // The wait service requires the main thread to run.
-                await _threadingService.SwitchToUIThread();
-                // Displays a dialog showing the progress of updating the namespaces in the files.
-                _waitService.Run(
-                    title: string.Empty,
-                    message: _renameMessage!,
-                    allowCancel: true,
-                    asyncMethod: ApplyRenamesAsync,
-                    totalSteps: _renameActionSetByFilePath.Count);
-            });
+            // Display a dialog showing the progress of updating the namespaces in the files.
+            _ = _waitService.RunAsync(
+                title: string.Empty,
+                message: _renameMessage!,
+                allowCancel: true,
+                asyncMethod: ApplyRenamesAsync,
+                totalSteps: _renameActionSetByFilePath.Count);
 
             return;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -118,11 +118,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
                 Solution currentSolution = await PublishLatestSolutionAsync(_projectAsynchronousTasksService.UnloadCancellationToken);
 
                 string renameOperationName = string.Format(CultureInfo.CurrentCulture, VSResources.Renaming_Type_from_0_to_1, oldName, value);
-                WaitIndicatorResult<Solution> indicatorResult = _waitService.Run(
-                                title: VSResources.Renaming_Type,
-                                message: renameOperationName,
-                                allowCancel: true,
-                                context => documentRenameResult.UpdateSolutionAsync(currentSolution, context.CancellationToken));
+                WaitIndicatorResult<Solution> indicatorResult = await _waitService.RunAsync(
+                    title: VSResources.Renaming_Type,
+                    message: renameOperationName,
+                    allowCancel: true,
+                    context => documentRenameResult.UpdateSolutionAsync(currentSolution, context.CancellationToken));
 
                 // Do not warn the user if the rename was cancelled by the user	
                 if (indicatorResult.IsCancelled)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Waiting/VisualStudioWaitIndicator.cs
@@ -20,17 +20,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             _waitDialogFactoryService = waitDialogFactoryService;
         }
 
-        public WaitIndicatorResult Run(string title, string message, bool allowCancel, Func<IWaitContext, Task> asyncMethod, int totalSteps = 0)
+        public async Task<WaitIndicatorResult> RunAsync(string title, string message, bool allowCancel, Func<IWaitContext, Task> asyncMethod, int totalSteps = 0)
         {
-            _joinableTaskContext.VerifyIsOnMainThread();
+            await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
 
             using IWaitContext waitContext = new VisualStudioWaitContext(_waitDialogFactoryService.Value, title, message, allowCancel, totalSteps);
 
             try
             {
-#pragma warning disable VSTHRD102 // Deliberate usage  
-                _joinableTaskContext.Factory.Run(() => asyncMethod(waitContext));
-#pragma warning restore VSTHRD102
+                await asyncMethod(waitContext);
 
                 return WaitIndicatorResult.Completed;
             }
@@ -44,17 +42,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
             }
         }
 
-        public WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<IWaitContext, Task<T>> asyncMethod, int totalSteps = 0)
+        public async Task<WaitIndicatorResult<T>> RunAsync<T>(string title, string message, bool allowCancel, Func<IWaitContext, Task<T>> asyncMethod, int totalSteps = 0)
         {
-            _joinableTaskContext.VerifyIsOnMainThread();
+            await _joinableTaskContext.Factory.SwitchToMainThreadAsync();
 
             using IWaitContext waitContext = new VisualStudioWaitContext(_waitDialogFactoryService.Value, title, message, allowCancel, totalSteps);
 
             try
             {
-#pragma warning disable VSTHRD102 // Deliberate usage  
-                T result = _joinableTaskContext.Factory.Run(() => asyncMethod(waitContext));
-#pragma warning restore VSTHRD102
+                T result = await asyncMethod(waitContext);
 
                 return WaitIndicatorResult<T>.FromResult(result);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/IWaitIndicator.cs
@@ -5,8 +5,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
     internal interface IWaitIndicator
     {
-        WaitIndicatorResult Run(string title, string message, bool allowCancel, Func<IWaitContext, Task> asyncMethod, int totalSteps = 0);
+        Task<WaitIndicatorResult> RunAsync(string title, string message, bool allowCancel, Func<IWaitContext, Task> asyncMethod, int totalSteps = 0);
 
-        WaitIndicatorResult<T> Run<T>(string title, string message, bool allowCancel, Func<IWaitContext, Task<T>> asyncMethod, int totalSteps = 0);
+        Task<WaitIndicatorResult<T>> RunAsync<T>(string title, string message, bool allowCancel, Func<IWaitContext, Task<T>> asyncMethod, int totalSteps = 0);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Waiting/WaitIndicatorResult.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.VisualStudio.ProjectSystem.Waiting
 {
     /// <summary>
-    ///     Represents the result of <see cref="IWaitIndicator.Run(string, string, bool, Func{IWaitContext, Task}, int)"/>.
+    ///     Represents the result of <see cref="IWaitIndicator.RunAsync(string, string, bool, Func{IWaitContext, Task}, int)"/>.
     /// </summary>
     internal readonly struct WaitIndicatorResult
     {
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Waiting
     }
 
     /// <summary>
-    ///     Represents the result of <see cref="IWaitIndicator.Run{T}(string, string, bool, Func{IWaitContext, Task{T}}, int)"/>.
+    ///     Represents the result of <see cref="IWaitIndicator.RunAsync{T}(string, string, bool, Func{IWaitContext, Task{T}}, int)"/>.
     /// </summary>
     internal readonly struct WaitIndicatorResult<T>
     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Waiting/VisualStudioWaitIndicatorTests.cs
@@ -7,47 +7,42 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
 {
-    public static class VisualStudioWaitIndicatorTests
+    public class VisualStudioWaitIndicatorTests
     {
         [Fact]
-        public static void Run_WhenAsyncMethodThrows_Throws()
+        public async Task Run_WhenAsyncMethodThrows_Throws()
         {
             var (instance, _) = CreateInstance();
-            Assert.Throws<Exception>(() =>
-            {
-                instance.Run<string>("", "", false, _
-                    => throw new Exception());
-            });
+
+            await Assert.ThrowsAsync<Exception>(
+                () => instance.RunAsync<string>("", "", false, _ => throw new Exception()));
         }
 
         [Fact]
-        public static void Run_WhenAsyncMethodThrowsWrapped_Throws()
+        public async Task Run_WhenAsyncMethodThrowsWrapped_Throws()
         {
             var (instance, _) = CreateInstance();
-            Assert.Throws<Exception>(() =>
-            {
-                instance.Run("", "", false, async _
-                    => await Task.FromException<string>(new Exception()));
-            });
+            
+            await Assert.ThrowsAsync<Exception>(
+                () => instance.RunAsync("", "", false, _ => Task.FromException<string>(new Exception())));
         }
 
         [Fact]
-        public static void Run_WhenAsyncMethodThrowsOperationCanceled_SetsIsCancelledToTrue()
+        public async Task Run_WhenAsyncMethodThrowsOperationCanceled_SetsIsCancelledToTrue()
         {
             var (instance, _) = CreateInstance();
 
-            var result = instance.Run("", "", false, async _
-                    => await Task.FromException<string>(new OperationCanceledException()));
+            var result = await instance.RunAsync("", "", false, _ => Task.FromException<string>(new OperationCanceledException()));
 
             Assert.True(result.IsCancelled);
         }
 
         [Fact]
-        public static void Run_WhenAsyncMethodThrowsAggregrateContainedOperationCanceled_SetsIsCancelledToTrue()
+        public async Task Run_WhenAsyncMethodThrowsAggregateContainedOperationCanceled_SetsIsCancelledToTrue()
         {
             var (instance, _) = CreateInstance();
 
-            var result = instance.Run("", "", false, async _ =>
+            var result = await instance.RunAsync("", "", false, async _ =>
             {
                 await Task.WhenAll(
                     Task.Run(() => throw new OperationCanceledException()),
@@ -60,12 +55,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         }
 
         [Fact]
-        public static void Run_WhenUserCancels_CancellationTokenIsCancelled()
+        public async Task Run_WhenUserCancels_CancellationTokenIsCancelled()
         {
             var (instance, userCancel) = CreateInstance(isCancelable: true);
 
             CancellationToken? result = default;
-            instance.Run("", "", true, context =>
+            await instance.RunAsync("", "", true, context =>
             {
                 userCancel();
 
@@ -79,11 +74,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Waiting
         }
 
         [Fact]
-        public static void Run_ReturnsResultOfAsyncMethod()
+        public async Task Run_ReturnsResultOfAsyncMethod()
         {
             var (instance, _) = CreateInstance();
 
-            var result = instance.Run("", "", false, _ =>
+            var result = await instance.RunAsync("", "", false, _ =>
             {
                 return Task.FromResult("Hello");
             });


### PR DESCRIPTION
JTF.Run should only be used when implementing legacy APIs that cannot be made asynchronous. In our internal `IWaitIndicator` these two methods can be made async and their usages updated to avoid the use of JTF.Run.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9243)