### PR TITLE
Re-enable Build Acceleration within the solution

### DIFF
--- a/eng/imports/VisualStudio.props
+++ b/eng/imports/VisualStudio.props
@@ -19,9 +19,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    
-    <!-- Infrastructure -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools"     PrivateAssets="all" />
 
     <!-- VS SDK -->
     <PackageReference Include="Microsoft.Internal.VisualStudio.Interop" />

--- a/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -27,6 +27,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Content Include="UnifiedSettings\ManagedProjectSystem.registration.json">
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>

--- a/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -25,6 +25,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
       <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup</IncludeOutputGroupsInVSIX>
     </ProjectReference>

--- a/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" />
   </ItemGroup>
 


### PR DESCRIPTION
When Build Acceleration observes the `Microsoft.VSSDK.BuildTools` package in the project, it disables itself out of caution, as VSIX projects cannot be accelerated (they must call MSBuild in order to pack the VSIX).

In our solution we were adding this VSSDK package to every project, effectively disabling it entirely within the solution.

This change removes it from VisualStudio.props and adds it only to the VSIX project files themselves.

NOTE: This only impacts our team's development experience. This doesn't change anything for users of the project system in VS.