### PR TITLE
Revert "Bump package versions"

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.3.57" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.3.198" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.18" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.9-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
@@ -48,7 +48,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.4.0-preview-2-32826-307" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.7.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.7.5-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes"                           Version="15.0.36" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.2.2146" />
@@ -57,8 +57,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.8.9" />
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.7.30" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.7.30" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.7.15-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.7.15-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.7.36307-preview.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.6.11" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
@@ -78,18 +78,18 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes"                         Version="$(CPSPackageVersion)" />
 
     <!-- Roslyn -->
-    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.8.0-3.23429.9" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.8.0-3.23429.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.7.0-1.final" />
     <PackageVersion Include="Microsoft.CSharp"                                                       Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.8.0-3.23429.9" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.7.0-1.final" />
     <PackageVersion Include="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.8.0-3.23429.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.7.0-1.final" />
 
     <!-- Analyzers -->
     <PackageVersion Include="CSharpIsNullAnalyzer"                                                   Version="0.1.329" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.3.5-beta1.23165.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.8.0-3.23429.9" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.8.0-3.23429.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.7.0-1.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.7.0-1.final" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers"                                           Version="3.3.5-beta1.23165.1" />
 
     <!-- NuGet -->


### PR DESCRIPTION
This reverts commit 9fceaf559b2ef79a8eec825761bbfa4a84799e0c from #9242 - Microsoft.CodeAnalysis and Microsoft.VIsualStudio.LanguageServices versions are higher than the currently used ones from VS. 

This is blocking our M2 insertion, so out of caution reverting the entire commit

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9245)