### PR TITLE
Don't call DisplayMissingComponentsPromptIfNeeded if missing sdk/workload didn't change

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Acquisition/MissingSetupComponentRegistrationService.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Collections.Concurrent;
-using System.Linq;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.ProjectSystem.Workloads;


### PR DESCRIPTION
It turns out that `IVSShellUtilitiesHelper.IsVSFromPreviewChannelAsync` takes an incredibly long amount of time to execute. Since `DisplayMissingComponentsPromptIfNeeded` was being called even in the case where a project already had a missing component, this method call ended up causing a noticeable perf impact. 

This code change only calls `DisplayMissingComponentsPromptIfNeeded` if a project's missing workload/sdk value was actually changed

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9250)