### PR TITLE
Fix WPF application framework re-enable bug

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -229,8 +229,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                                 }
                             }
                         }
-
-                        // does not remove the two empty item groups following because project.ItemGroups is a readonly
                     });
 
                     // Create the Application.xaml if it doesn't exist. We don't care about the path, we just need it to be created.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -212,7 +212,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 {
                     // Enabled
 
-                    //project accessor to remove the applicationdefinition property if re-enabled
+                    // Project accessor to remove the ApplicationDefinition property if re-enabled
                     await _projectAccessor.OpenProjectXmlForWriteAsync(_project, project =>
                     {
                         foreach (ProjectItemGroupElement itemGroup in project.ItemGroups.ToList())
@@ -252,7 +252,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                         await defaultProperties.SetPropertyValueAsync(StartupObjectMSBuild, "Sub Main");
                     }
 
-                    // Set the Application.xaml file's build action to None and set Application Definition remove fpr Application.xaml.
+                    // Set the Application.xaml file's build action to None, which will also remove it from the ApplicationDefinition item group.
                     string? appXamlFilePath = await GetAppXamlRelativeFilePathAsync(create: false);
                     if (appXamlFilePath is not null)
                     {


### PR DESCRIPTION
Fixes [AB#1882665](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1882665)

When you disable and then re-enable "Application Framework" in VB WPF projects, it adds 
`<ApplicationDefinition Include="Application.xaml" />` to the project file, which is already implicitly declared and causes the build to fail. This PR removes this ApplicationDefinition when the property is re-enabled.

Note that this change leaves empty `<ItemGroup />` in the project file because the `ItemGroups` is a readonly collection available by MSBuild

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9256)