### PR TITLE
Allow opting out of package-based Build Acceleration disablement

### DIFF
--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -66,6 +66,8 @@ For example, if `MyPackage` is known to be incompatible with Build Acceleration,
 </Project>
 ```
 
+The .NET Project System includes a list of known, commonly used packages that don't work with Build Acceleration. To disable this default list, set the `EnableDefaultBuildAccelerationIncompatiblePackages` property to `false`.
+
 ## Debugging
 
 ### Enable logging

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -26,7 +26,8 @@
     <PackageAction Condition="'$(PackageAction)' == ''">Pack</PackageAction>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- Specify NuGet packages that are known to not work with Build Acceleration. -->
+  <ItemGroup Condition="'$(EnableDefaultBuildAccelerationIncompatiblePackages)' != 'false'">
     <!-- Disable Build Acceleration for VSIX projects -->
     <BuildAccelerationIncompatiblePackage Include="Microsoft.VSSDK.BuildTools" />
   </ItemGroup>


### PR DESCRIPTION
We have a feature that disables Build Acceleration when certain NuGet packages are detected. This change adds the ability to set `EnableDefaultBuildAccelerationIncompatiblePackages` to `false` in order to disable this behaviour. This allows customers to more easily disable this default behaviour.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9257)