### PR TITLE
Disable Build Acceleration for Slow Cheetah

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -29,6 +29,8 @@
   <ItemGroup>
     <!-- Disable Build Acceleration for VSIX projects -->
     <BuildAccelerationIncompatiblePackage Include="Microsoft.VSSDK.BuildTools" />
+    <!-- Slow Cheetah doesn't support Build Acceleration -->
+    <BuildAccelerationIncompatiblePackage Include="Microsoft.VisualStudio.SlowCheetah" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(AssemblyReferenceTabs)' == '' And '$(UsingMicrosoftNETSdk)' == 'true'">


### PR DESCRIPTION
Fixes #8886

Slow Cheetah _can_ work with Build Acceleration, so long as `TransformOnBuild` items don't have `CopyToOutputDirectory` set to `Always`. When that occurs, Build Acceleration thinks it is supposed to copy the untransformed item to the output directory, which will overwrite any transformation done when a real build occurs.

A [GitHub code search](https://github.com/search?type=code&q=%3CTransformOnBuild%3Etrue%3C%2FTransformOnBuild%3E+language%3AXML) suggests that this `Always` metadata is not uncommon on such items, and so we should disable Build Acceleration out of caution whenever we detect that package is in use.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9258)