### PR TITLE
MEF component will never be null

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/IUpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/IUpToDateCheckStatePersistence.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     /// <summary>
     /// Persists fast up-to-date check state across solution lifetimes.
     /// </summary>
-    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.OneOrZero)]
+    [ProjectSystemContract(ProjectSystemContractScope.Global, ProjectSystemContractProvider.Private)]
     internal interface IUpToDateCheckStatePersistence
     {
         /// <summary>


### PR DESCRIPTION
Previously the FUTDC was split between two layers, with `IUpToDateCheckStatePersistence` coming from the VS layer. The consumer didn't assume that the VS layer was present, so used `AllowDefault = true` on that import.

Since then, we moved the FUTDC into the VS layer. So now, we can assume `IUpToDateCheckStatePersistence` will always be present and non-null.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9263)