### PR TITLE
Fix loading for Resource Designer 

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -86,7 +86,7 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 _view.Text = "DesignerWindowPaneBase View"
 
                 _host = DirectCast(GetService(GetType(IDesignerHost)), IDesignerHost)
-                If _host IsNot Nothing AndAlso Not _host.Loading Then
+                If _host IsNot Nothing AndAlso _undoEngine Is Nothing AndAlso Not _host.Loading Then
                     PopulateView()
                     EnableUndo()
                 End If
@@ -137,10 +137,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     ' a load event if a bad event handler threw before
                     ' we got invoked.
                     '
-                    If _view IsNot Nothing AndAlso _view.Controls.Count = 0 Then
-                        PopulateView()
-                        EnableUndo()
-                    End If
                     Return _view
                 End Get
             End Property
@@ -205,7 +201,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' Called to enable OLE undo.
             ''' </summary>
             Private Sub EnableUndo()
-
                 Debug.Assert(_undoEngine Is Nothing, "EnableUndo should only be called once.  Call DisableUndo before calling this again.")
 
                 ' Undo requires that IDesignerSerializationService and
@@ -248,9 +243,11 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             ''' <param name="sender"></param>
             ''' <param name="e"></param>
             Private Sub OnLoaded(sender As Object, e As LoadedEventArgs)
-                PopulateView()
-                EnableUndo()
-                'ChangeFormEditorCaption()
+                If _undoEngine Is Nothing Then
+                    PopulateView()
+                    EnableUndo()
+                    'ChangeFormEditorCaption()
+                End If
             End Sub
 
             ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceSerializationService.vb
@@ -95,7 +95,7 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
             Requires.NotNull(Value)
 
             If TypeOf Value IsNot Resource Then
-                Throw CreateArgumentException(NameOf(Value))
+                Return
             End If
             Dim Resource As Resource = DirectCast(Value, Resource)
 


### PR DESCRIPTION
We have various points where we attempt to populate the window view and also register undo (EnableUndo), and no guards to make sure that it's not called multiple times. Added a condition to all the spots where we want to call PopulateView/EnableUndo.

Additionally, we end up having our serialize function called after this line:
`                    Dim NewResourceEditorRoot As ResourceEditorRootComponent = CType(LoaderHost.CreateComponent(GetType(ResourceEditorRootComponent)), ResourceEditorRootComponent)`

...which fails because ResourceEditorRootComponent is in fact not a Resource. I do not know why this didn't fail before, because seemingly this would also have been called in the past, but it seems to have something to do with its interaction with #9265, though it's unclear how.

edit: this has been tested for async file loading on solution open as well as the normal synchronous loading

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9267)