### PR TITLE
Revert async load changes

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/BaseDesignerLoader.vb
@@ -684,14 +684,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
         Protected Overridable Sub OnDesignerWindowActivated(Activated As Boolean)
         End Sub
 
-        ''' <summary>
-        ''' Called before the frame that's hosting the designer is shown.
-        ''' </summary>
-        ''' <param name="FirstShow">Indicates whether this is the first time the designer is being shown.</param>
-        ''' <param name="Frame">The frame hosting the designer.</param>
-        Protected Overridable Sub OnBeforeDesignerWindowShow(FirstShow As Boolean, Frame As IVsWindowFrame)
-        End Sub
-
 #End Region
 
         ''' <summary>
@@ -826,16 +818,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             End If
         End Function
 
-        Private Function OnBeforeDocumentWindowShow(docCookie As UInteger, firstShow As Integer, frame As IVsWindowFrame) As Integer _
-            Implements IVsRunningDocTableEvents.OnBeforeDocumentWindowShow, IVsRunningDocTableEvents2.OnBeforeDocumentWindowShow
-
-            ' Only notify if our frame showing
-            If CType(GetService(GetType(IVsWindowFrame)), IVsWindowFrame) Is frame Then
-                OnBeforeDesignerWindowShow(firstShow = 1, frame)
-            End If
-
-        End Function
-
 #Region "RDT events we don't care about"
 
         Private Function OnAfterAttributeChange(docCookie As UInteger, attributes As UInteger) As Integer _
@@ -856,6 +838,10 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
 
         Private Function OnAfterSave(docCookie As UInteger) As Integer _
             Implements IVsRunningDocTableEvents.OnAfterSave, IVsRunningDocTableEvents2.OnAfterSave
+        End Function
+
+        Private Function OnBeforeDocumentWindowShow(docCookie As UInteger, firstShow As Integer, frame As IVsWindowFrame) As Integer _
+            Implements IVsRunningDocTableEvents.OnBeforeDocumentWindowShow, IVsRunningDocTableEvents2.OnBeforeDocumentWindowShow
         End Function
 
 #End Region

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -139,7 +139,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                     '
                     If _view IsNot Nothing AndAlso _view.Controls.Count = 0 Then
                         PopulateView()
-                        EnableUndo()
                     End If
                     Return _view
                 End Get

--- a/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
+++ b/src/Microsoft.VisualStudio.Editors/DesignerFramework/DesignerWindowPaneProviderBase.vb
@@ -88,7 +88,6 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
                 _host = DirectCast(GetService(GetType(IDesignerHost)), IDesignerHost)
                 If _host IsNot Nothing AndAlso Not _host.Loading Then
                     PopulateView()
-                    EnableUndo()
                 End If
 
                 AddHandler surface.Loaded, AddressOf OnLoaded
@@ -238,6 +237,10 @@ Namespace Microsoft.VisualStudio.Editors.DesignerFramework
             Protected Overrides Sub OnCreate()
                 MyBase.OnCreate()
 
+                _host = DirectCast(GetService(GetType(IDesignerHost)), IDesignerHost)
+                If _host IsNot Nothing AndAlso Not _host.Loading Then
+                    EnableUndo()
+                End If
             End Sub
 
             ''' <summary>

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorDesignerLoader.vb
@@ -141,6 +141,8 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         'Try to restore the editor state from before the last reload, if any.
                         NewResourceEditorRoot.RootDesigner.TryDepersistSavedEditorState()
 
+                        'Now that we know the load succeeded, we can try registering our view helper
+                        NewResourceEditorRoot.RootDesigner.RegisterViewHelper()
                     Catch ex As Exception When ReportWithoutCrash(ex, NameOf(HandleLoad), NameOf(ResourceEditorDesignerLoader))
                         _rootComponent = Nothing
 
@@ -253,12 +255,6 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
                         _rootComponent.RootDesigner.CommitAnyPendingChanges()
                     End If
                 End If
-            End If
-        End Sub
-
-        Protected Overrides Sub OnBeforeDesignerWindowShow(FirstShow As Boolean, Frame As IVsWindowFrame)
-            If FirstShow Then
-                _rootComponent.RootDesigner.RegisterViewHelper(Frame)
             End If
         End Sub
 

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -410,12 +410,34 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ''' Register this root designer as a view helper with the current frame so the shell will can find our
         '''   implementations of IVsFindTarget, IOleCommandTarget, etc.
         ''' </summary>
-        Public Sub RegisterViewHelper(VsWindowFrame As IVsWindowFrame)
+        Public Sub RegisterViewHelper()
             Try
+                Dim VsWindowFrame As IVsWindowFrame = CType(GetService(GetType(IVsWindowFrame)), IVsWindowFrame)
+
                 If VsWindowFrame IsNot Nothing Then
                     VSErrorHandler.ThrowOnFailure(VsWindowFrame.SetProperty(__VSFPROPID.VSFPROPID_ViewHelper, New UnknownWrapper(Me)))
                 Else
-                    Debug.Fail("Unable to register our view helper")
+                    If _view IsNot Nothing Then
+                        'We don't have a window frame yet.  Need to delay this registration until we do.
+                        '  Easiest way is to use BeginInvoke.
+                        If _delayRegisteringViewHelper Then
+                            'This is already our second try
+                            Debug.Fail("Unable to delay-register our view helper")
+                            _delayRegisteringViewHelper = False
+                        Else
+                            'Try again, delayed.
+                            _delayRegisteringViewHelper = True
+
+                            ' VS Whidbey #260046 -- Make sure the control is created before calling Invoke/BeginInvoke                                                      
+                            If _view.Created = False Then
+                                _view.CreateControl()
+                            End If
+
+                            _view.BeginInvoke(New System.Windows.Forms.MethodInvoker(AddressOf RegisterViewHelper))
+                        End If
+                    Else
+                        Debug.Fail("View not set in RegisterViewHelper() - can't delay-register view helper")
+                    End If
                 End If
             Catch ex As Exception When ReportWithoutCrash(ex, NameOf(RegisterViewHelper), NameOf(ResourceEditorRootDesigner))
             End Try

--- a/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
+++ b/src/Microsoft.VisualStudio.Editors/ResourceEditor/ResourceEditorRootDesigner.vb
@@ -38,6 +38,9 @@ Namespace Microsoft.VisualStudio.Editors.ResourceEditor
         ' Contains information about the current state of Find/Replace
         Private ReadOnly _findReplace As New FindReplace(Me)
 
+        ' Indicates whether or not we are trying to register our view helper on a delayed basis
+        Private _delayRegisteringViewHelper As Boolean
+
         ' The ErrorListProvider to support error list window
         Private _errorListProvider As ErrorListProvider
 


### PR DESCRIPTION
See context in #9267 - we had bugs in both the Resource Designer and Settings Designer after #9265 was merged, and do not want to take the risk of additional issues appearing after P3. We can come back to async load at a future date.

cc: @rafaci 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9268)