### PR TITLE
Rename NativeAOTProperties to NativeAOT.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.xaml
@@ -196,7 +196,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-            (has-project-capability "NativeAOTProperties")
+            (has-project-capability "NativeAOT")
             (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
@@ -216,7 +216,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-            (has-project-capability "NativeAOTProperties")
+            (has-project-capability "NativeAOT")
             (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
@@ -446,7 +446,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-            (has-project-capability "NativeAOTProperties")
+            (has-project-capability "NativeAOT")
             (not (has-evaluated-value "Application" "OutputType" "Library")))
         </NameValuePair.Value>
       </NameValuePair>
@@ -465,7 +465,7 @@
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
           (and
-            (has-project-capability "NativeAOTProperties")
+            (has-project-capability "NativeAOT")
             (not (has-evaluated-value "Application" "OutputType" "Library")))
         </NameValuePair.Value>
       </NameValuePair>


### PR DESCRIPTION
We changed the name of the `ProjectCapability` in the SDK side, so this just renames what we expect on the rule file.
https://github.com/dotnet/sdk/pull/35710

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9273)