### PR TITLE
Simplify using non-generic TaskCompletionSource polyfill

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -6,10 +6,6 @@ using Microsoft.VisualStudio.LanguageServices.ProjectSystem; // Roslyn
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Threading;
 
-// .NET Core defines a non-generic TaskCompletionSource but .NETFramework does not.
-// For consistency, always use the one we define.
-using TaskCompletionSource = Microsoft.VisualStudio.Threading.Tasks.TaskCompletionSource;
-
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 
 /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -8,10 +8,6 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 using Microsoft.VisualStudio.Threading;
 
-// .NET Core defines a non-generic TaskCompletionSource but .NETFramework does not.
-// For consistency, always use the one we define.
-using TaskCompletionSource = Microsoft.VisualStudio.Threading.Tasks.TaskCompletionSource;
-
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 
 /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSolutionEventListener.cs
@@ -3,7 +3,6 @@
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyActiveConfiguredProjectReadyToBuild.cs
@@ -1,9 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-// .NET Core defines a non-generic TaskCompletionSource but .NETFramework does not.
-// For consistency, always use the one we define.
-using TaskCompletionSource = Microsoft.VisualStudio.Threading.Tasks.TaskCompletionSource;
-
 namespace Microsoft.VisualStudio.ProjectSystem.Build
 {
     [Export(typeof(IConfiguredProjectReadyToBuild))]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -6,10 +6,6 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Threading.Tasks;
 
-// .NET Core defines a non-generic TaskCompletionSource but .NETFramework does not.
-// For consistency, always use the one we define.
-using TaskCompletionSource = Microsoft.VisualStudio.Threading.Tasks.TaskCompletionSource;
-
 namespace Microsoft.VisualStudio.ProjectSystem.Debug
 {
     /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -2,10 +2,6 @@
 
 using Microsoft.VisualStudio.Threading;
 
-// .NET Core defines a non-generic TaskCompletionSource but .NETFramework does not.
-// For consistency, always use the one we define.
-using TaskCompletionSource = Microsoft.VisualStudio.Threading.Tasks.TaskCompletionSource;
-
 namespace Microsoft.VisualStudio.ProjectSystem
 {
     [Export]

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskCompletionSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Threading/Tasks/TaskCompletionSource.cs
@@ -1,8 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+#if NETFRAMEWORK
+
 using System.ComponentModel;
 
-namespace Microsoft.VisualStudio.Threading.Tasks
+namespace System.Threading.Tasks
 {
     /// <inheritdoc cref="TaskCompletionSource{TResult}"/>
     /// <remarks>
@@ -54,3 +56,5 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         }
     }
 }
+
+#endif

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
@@ -1,6 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
@@ -4,7 +4,6 @@ using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 using Microsoft.VisualStudio.Telemetry;
-using Microsoft.VisualStudio.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.Threading.Tasks;
 using Xunit.Sdk;
 
 // Nullable annotations don't add a lot of value to this class, and until https://github.com/dotnet/roslyn/issues/33199 is fixed

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/TestUtil.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Utilities/TestUtil.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.VisualStudio.Threading.Tasks;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Utilities
 {
     internal static class TestUtil


### PR DESCRIPTION
.NET Core defines a non-generic `System.Threading.Tasks.TaskCompletionSource`. This would be handy in .NET Framework too, so we defined our own version of this as a polyfill. However ours was in the `Microsoft.VisualStudio.Threading.Tasks` namespace.

Once we started multi-targeting to .NET Framework and .NET Core, this mismatch created issues. That was worked around with an alias. The approach in this change reduces the friction and improves discoverability of this type. With this, we won't see "ambiguous type" warnings in new code any more.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9277)