### PR TITLE
Ensure warning message uses local time

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.Log.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.Log.cs
@@ -209,6 +209,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 });
 
                 // Remember the failure reason and description for use in IncrementalBuildFailureDetector.
+                // First, ensure times are converted to local time (in case logging is not enabled).
+                ConvertToLocalTimes(values);
                 FailureReason = reason;
                 FailureDescription = string.Format(GetResourceString(resourceName), values);
 


### PR DESCRIPTION
Fixes #9279

When incremental build failure detection is enabled, we can log a warning that includes paths and timestamps. However if FUTDC logging is disabled, the conversion from UTC to local time could be bypassed, making the log message harder to understand and potentially misleading (as there's no mention of UTC in the message).

This change fixes that issue by ensuring any times are converted to local time prior to being displayed.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9280)