### PR TITLE
Add CentralPackageFloatingVersionsEnabled property

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -20,6 +20,10 @@
   <StringProperty Name="CentralPackageVersionOverrideEnabled"
                   ReadOnly="True"
                   Visible="False" />
+                  
+  <StringProperty Name="CentralPackageFloatingVersionsEnabled"
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="CLRSupport"
                   ReadOnly="True"


### PR DESCRIPTION
This adds the new property from https://github.com/NuGet/NuGet.Client/pull/5440 to nomination so that it can be read by NuGet restore.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9295)