### PR TITLE
Save startup object correctly; show correct dropdown entries.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 // The AppliesTo metadata has no effect given the limitations described in https://github.com/dotnet/project-system/issues/8170.
-[ExportInterceptingPropertyValueProvider(InterceptedStartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+[ExportInterceptingPropertyValueProvider(StartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 [AppliesTo(ProjectCapability.WPF + "|" + ProjectCapability.WindowsForms)]
 internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBase
 {
@@ -17,7 +17,6 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     private const string DisabledValue = "WindowsFormsWithCustomSubMain";
 
     internal const string UseWinFormsProperty = "UseWindowsForms";
-    internal const string InterceptedStartupObjectProperty = "StartupObjectVB";
     internal const string StartupObjectProperty = "StartupObject";
     internal const string RootNamespaceProperty = "RootNamespace";
 
@@ -62,13 +61,11 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
             {
                 // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
                 // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-                await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, rootNameSpace + "." + unevaluatedPropertyValue);
-                return null;
+                return rootNameSpace + "." + unevaluatedPropertyValue;
             }
         }
         // This check can be removed when https://github.com/dotnet/project-system/issues/8170 is addressed.
-        await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, unevaluatedPropertyValue);
-        return null;
+        return rootNameSpace + "." + unevaluatedPropertyValue;
     }
 
     public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -45,7 +45,6 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
 
                 if (string.Compare(applicationFrameworkValue, EnabledValue) == 0)
                 {
-                    // Set the startup object in the myapp file.
                     if (unevaluatedPropertyValue.StartsWith(rootNameSpace + ".", StringComparison.OrdinalIgnoreCase))
                     {
                         unevaluatedPropertyValue = unevaluatedPropertyValue.Substring(rootNameSpace.Length + 1);
@@ -63,11 +62,13 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
             {
                 // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
                 // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-                return rootNameSpace + "." + unevaluatedPropertyValue;
+                await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, rootNameSpace + "." + unevaluatedPropertyValue);
+                return null;
             }
         }
         // This check can be removed when https://github.com/dotnet/project-system/issues/8170 is addressed.
-        return unevaluatedPropertyValue;
+        await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, unevaluatedPropertyValue);
+        return null;
     }
 
     public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
 
             // Remove My.MyApplication entry if any.
-            enumValues = enumValues.Where(ep => !ep.Name.Contains("My.MyApplication")).ToList();
+            enumValues.RemoveAll(ep => ep.Name.Contains("My.MyApplication"));
 
             return enumValues;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -94,6 +94,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 }));
             }
 
+            // Remove My.MyApplication entry if any.
+            enumValues = enumValues.Where(ep => !ep.Name.Contains("My.MyApplication")).ToList();
+
             return enumValues;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -36,7 +36,7 @@
        For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
        We specify this by setting the SearchForEntryPointsInFormsOnly to true.
        We also want to ensure that the property always has a value. -->
-  <DynamicEnumProperty Name="StartupObjectVB"
+  <DynamicEnumProperty Name="StartupObject"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"
@@ -48,9 +48,7 @@
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
-          (and
-            (is-vb)
-            (not (has-evaluated-value "Application" "OutputType" "Library")))
+            (not (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -36,7 +36,7 @@
        For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
        We specify this by setting the SearchForEntryPointsInFormsOnly to true.
        We also want to ensure that the property always has a value. -->
-  <DynamicEnumProperty Name="StartupObject"
+  <DynamicEnumProperty Name="StartupObjectVB"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"
@@ -47,7 +47,11 @@
     </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (is-vb)
+            (not (has-evaluated-value "Application" "OutputType" "Library")))
+        </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
     <DynamicEnumProperty.ProviderSettings>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -226,7 +226,11 @@
                        EnumProvider="StartupObjectsEnumProvider">
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (not (is-vb))
+            (not (has-evaluated-value "Application" "OutputType" "Library")))
+        </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
     <DynamicEnumProperty.ProviderSettings>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -227,9 +227,7 @@
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
-          (and
-            (not (is-vb))
-            (not (has-evaluated-value "Application" "OutputType" "Library")))
+            (not (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Úvodní obrazovka</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.cs.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Úvodní obrazovka</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Definuje vstupní bod, který se má volat při načtení aplikace. Obecně je tato možnost nastavena buď na hlavní formulář v aplikaci, nebo na proceduru Main, která se má spustit při spuštění aplikace. Knihovny tříd vstupní bod nedefinují.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Spouštěcí objekt</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Begrüßungsbildschirm</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Hiermit wird der Einstiegspunkt definiert, der beim Laden der Anwendung aufgerufen werden soll. Im Allgemeinen wird dies entweder auf das Hauptformular in Ihrer Anwendung oder auf die Main-Prozedur festgelegt, die beim Starten der Anwendung ausgeführt werden soll. Klassenbibliotheken definieren keinen Einstiegspunkt.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Startobjekt</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.de.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Begrüßungsbildschirm</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Pantalla de presentación</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.es.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Pantalla de presentación</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Define el punto de entrada al que se va a llamar cuando se cargue la aplicación. Normalmente, se establece en el formulario principal de la aplicación o en el procedimiento "Principal" que debe ejecutarse cuando se inicia la aplicación. Las bibliotecas de clases no definen ningún punto de entrada.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Objeto de inicio</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Écran de démarrage</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Définit le point d'entrée à appeler au chargement de l'application. En règle générale, il s'agit du formulaire principal de votre application ou de la procédure 'Main' qui doit s'exécuter au démarrage de l'application. Les bibliothèques de classes ne définissent pas de point d'entrée.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Objet de démarrage</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.fr.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Écran de démarrage</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Schermata iniziale</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Definisce il punto di ingresso da chiamare quando l'applicazione viene caricata. In genere viene impostato sul modulo principale dell'applicazione o sulla routine 'Main' che deve essere eseguita all'avvio dell'applicazione. Le librerie di classi non definiscono un punto di ingresso.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Oggetto di avvio</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.it.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Schermata iniziale</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -72,14 +72,14 @@
         <target state="translated">スプラッシュ スクリーン</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">アプリケーションの読み込み時に呼び出されるエントリ ポイントを定義します。通常、これはアプリケーションのメイン フォームか、アプリケーションの起動時に実行する必要がある 'Main' プロシージャに設定されます。クラス ライブラリではエントリ ポイントが定義されていません。</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">スタートアップ オブジェクト</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ja.xlf
@@ -72,12 +72,12 @@
         <target state="translated">スプラッシュ スクリーン</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -72,14 +72,14 @@
         <target state="translated">시작 화면</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">애플리케이션이 로드될 때 호출할 진입점을 정의합니다. 일반적으로 애플리케이션의 기본 양식 또는 애플리케이션이 시작할 때 실행되어야 하는 '기본' 프로시저로 설정됩니다. 클래스 라이브러리는 진입점을 정의하지 않습니다.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">시작 개체</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ko.xlf
@@ -72,12 +72,12 @@
         <target state="translated">시작 화면</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Ekran powitalny</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pl.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Ekran powitalny</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Definiuje punkt wejścia do wywołania, gdy aplikacja zostanie załadowana. Ta opcja jest zazwyczaj ustawiana na formularz główny w aplikacji lub na procedurę „Main”, która ma być uruchamiana po uruchomieniu aplikacji. Biblioteki klas nie definiują punktu wejścia.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Obiekt startowy</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Tela inicial</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.pt-BR.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Tela inicial</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Define o ponto de entrada a ser chamado quando o aplicativo é carregado. Geralmente, essa opção é definida como o formulário principal no aplicativo ou como o procedimento 'Main' que deve ser executado quando o aplicativo é iniciado. As bibliotecas de classe não definem um ponto de entrada.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Objeto de inicialização</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Экран-заставка</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Определяет точку входа, вызываемую при загрузке приложения. Обычно в качестве этой точки входа задается главная форма приложения или процедура "Main", которая должна выполняться при запуске приложения. В библиотеках классов точка входа не определяется.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Автоматически запускаемый объект</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.ru.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Экран-заставка</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -72,12 +72,12 @@
         <target state="translated">Giriş ekranı</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.tr.xlf
@@ -72,14 +72,14 @@
         <target state="translated">Giriş ekranı</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">Uygulama yüklediğinde çağrılacak giriş noktasını tanımlar. Bu, genellikle uygulamanızda ana form olarak veya uygulama başladığında çalışması gereken 'Ana' yordam olarak ayarlanır. Sınıf kitaplıkları bir giriş noktası tanımlamaz.</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">Başlangıç nesnesi</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -72,14 +72,14 @@
         <target state="translated">初始屏幕</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">定义在加载应用程序时要调用的入口点。通常，此项设置为应用程序中的主窗体或应用程序启动时运行的 "Main" 过程。类库不定义入口点。</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">启动对象</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hans.xlf
@@ -72,12 +72,12 @@
         <target state="translated">初始屏幕</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -72,12 +72,12 @@
         <target state="translated">啟動顯示畫面</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
         <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
         <source>Startup object</source>
         <target state="new">Startup object</target>
         <note />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.VisualBasic.xaml.zh-Hant.xlf
@@ -72,14 +72,14 @@
         <target state="translated">啟動顯示畫面</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|Description">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|Description">
         <source>Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</source>
-        <target state="translated">定義應用程式載入時要呼叫的進入點。通常會設定為應用程式的主表單，或應用程式啟動時應執行的 'Main' 程序。類別庫未定義進入點。</target>
+        <target state="new">Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point.</target>
         <note />
       </trans-unit>
-      <trans-unit id="DynamicEnumProperty|StartupObject|DisplayName">
+      <trans-unit id="DynamicEnumProperty|StartupObjectVB|DisplayName">
         <source>Startup object</source>
-        <target state="translated">啟始物件</target>
+        <target state="new">Startup object</target>
         <note />
       </trans-unit>
       <trans-unit id="DynamicEnumProperty|StartupURI|Description">


### PR DESCRIPTION
Fixes #9262

- Don't show an entry for 'My.MyApplication' value. That is only set in the project file but should not be surfaced to the UI. Value should come from the myapp file.
- Show correct StartupObject property. ~~Seems like we had 2 properties, one in the base Application.xaml rule and another in the vb-specific Application.xaml rule. Ensured that they have different names and have a visibility condition that would show/hide the correct one, depending on the project language.~~ Interceptor had the wrong property name `InterceptedStartupObjectProperty`; it now uses the correct property name.

The only thing missing is to ensure the VB WinForms template contains the correct value in the StartupObject: right now it has 'Sub Main', but should be '[rootnamespace].My.MyApplication'.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9300)