### PR TITLE
[17.8] Save startup object correctly; show correct dropdown entries.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -19,7 +19,7 @@ if not defined MSBuildPath (
 @REM The configuration is not known at this point. It could either use the default from Build.proj or be passed in as an MSBuild argument.
 set "BinlogPath=%~dp0artifacts\Build.binlog"
 @REM https://stackoverflow.com/a/16144756/294804
-"%MSBuildPath%" "%~dp0eng\Build.proj" /m /warnAsError /noLogo /clp:Summary /bl:"%BinlogPath%" /ll %*
+"%MSBuildPath%" "%~dp0eng\Build.proj" /m /noLogo /clp:Summary /bl:"%BinlogPath%" /ll %*
 set MSBuildErrorLevel=%ERRORLEVEL%
 
 @REM Move the binlog into the appropriate configuration directory.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 // The AppliesTo metadata has no effect given the limitations described in https://github.com/dotnet/project-system/issues/8170.
-[ExportInterceptingPropertyValueProvider(InterceptedStartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
+[ExportInterceptingPropertyValueProvider(StartupObjectProperty, ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 [AppliesTo(ProjectCapability.WPF + "|" + ProjectCapability.WindowsForms)]
 internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBase
 {
@@ -17,7 +17,6 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
     private const string DisabledValue = "WindowsFormsWithCustomSubMain";
 
     internal const string UseWinFormsProperty = "UseWindowsForms";
-    internal const string InterceptedStartupObjectProperty = "StartupObjectVB";
     internal const string StartupObjectProperty = "StartupObject";
     internal const string RootNamespaceProperty = "RootNamespace";
 
@@ -62,13 +61,11 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
             {
                 // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
                 // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-                await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, rootNameSpace + "." + unevaluatedPropertyValue);
-                return null;
+                return rootNameSpace + "." + unevaluatedPropertyValue;
             }
         }
         // This check can be removed when https://github.com/dotnet/project-system/issues/8170 is addressed.
-        await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, unevaluatedPropertyValue);
-        return null;
+        return rootNameSpace + "." + unevaluatedPropertyValue;
     }
 
     public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/StartupObjectValueProvider.cs
@@ -45,7 +45,6 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
 
                 if (string.Compare(applicationFrameworkValue, EnabledValue) == 0)
                 {
-                    // Set the startup object in the myapp file.
                     if (unevaluatedPropertyValue.StartsWith(rootNameSpace + ".", StringComparison.OrdinalIgnoreCase))
                     {
                         unevaluatedPropertyValue = unevaluatedPropertyValue.Substring(rootNameSpace.Length + 1);
@@ -63,11 +62,13 @@ internal class StartupObjectValueProvider : InterceptingPropertyValueProviderBas
             {
                 // Else, if it's other than a Windows Forms project, save the StartupObject property in the project file as usual.
                 // Or if the ApplicationFramework property is disabled, save the StartupObject property in the project file as usual.
-                return rootNameSpace + "." + unevaluatedPropertyValue;
+                await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, rootNameSpace + "." + unevaluatedPropertyValue);
+                return null;
             }
         }
         // This check can be removed when https://github.com/dotnet/project-system/issues/8170 is addressed.
-        return unevaluatedPropertyValue;
+        await defaultProperties.SetPropertyValueAsync(StartupObjectProperty, unevaluatedPropertyValue);
+        return null;
     }
 
     public override async Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -95,7 +95,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             }
 
             // Remove My.MyApplication entry if any.
-            enumValues = enumValues.Where(ep => !ep.Name.Contains("My.MyApplication")).ToList();
+            enumValues.RemoveAll(ep => ep.Name.Contains("My.MyApplication"));
 
             return enumValues;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -94,6 +94,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                 }));
             }
 
+            // Remove My.MyApplication entry if any.
+            enumValues = enumValues.Where(ep => !ep.Name.Contains("My.MyApplication")).ToList();
+
             return enumValues;
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -36,7 +36,7 @@
        For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
        We specify this by setting the SearchForEntryPointsInFormsOnly to true.
        We also want to ensure that the property always has a value. -->
-  <DynamicEnumProperty Name="StartupObjectVB"
+  <DynamicEnumProperty Name="StartupObject"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"
@@ -48,9 +48,7 @@
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
-          (and
-            (is-vb)
-            (not (has-evaluated-value "Application" "OutputType" "Library")))
+            (not (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.VisualBasic.xaml
@@ -36,7 +36,7 @@
        For VB projects, we expect to see every Form in the assembly directly or indirectly inherited from Form.
        We specify this by setting the SearchForEntryPointsInFormsOnly to true.
        We also want to ensure that the property always has a value. -->
-  <DynamicEnumProperty Name="StartupObject"
+  <DynamicEnumProperty Name="StartupObjectVB"
                        DisplayName="Startup object"
                        Description="Defines the entry point to be called when the application loads. Generally this is set either to the main form in your application or to the 'Main' procedure that should run when the application starts. Class libraries do not define an entry point."
                        Category="General"
@@ -47,7 +47,11 @@
     </DynamicEnumProperty.DataSource>
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (is-vb)
+            (not (has-evaluated-value "Application" "OutputType" "Library")))
+        </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
     <DynamicEnumProperty.ProviderSettings>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -226,7 +226,11 @@
                        EnumProvider="StartupObjectsEnumProvider">
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
-        <NameValuePair.Value>(not (has-evaluated-value "Application" "OutputType" "Library"))</NameValuePair.Value>
+        <NameValuePair.Value>
+          (and
+            (not (is-vb))
+            (not (has-evaluated-value "Application" "OutputType" "Library")))
+        </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>
     <DynamicEnumProperty.ProviderSettings>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -227,9 +227,7 @@
     <DynamicEnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">
         <NameValuePair.Value>
-          (and
-            (not (is-vb))
-            (not (has-evaluated-value "Application" "OutputType" "Library")))
+            (not (has-evaluated-value "Application" "OutputType" "Library"))
         </NameValuePair.Value>
       </NameValuePair>
     </DynamicEnumProperty.Metadata>


### PR DESCRIPTION
Cherry-picks commits from #9300 to 17.8.x branch.

I went back to those commits to exclude changes to the localization files, which were changed due to the rename of the property from `StartupObject` -> `StartupObjectVB` -> `StartupObject`. Since there is no actual change, there's no need to bring those localization changes.

Also included the changes from #9296 to remove `/warnaserror` argument to avoid hitting https://github.com/dotnet/sdk/issues/35768 in our build PR.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9302)