### PR TITLE
Remove /warnaserror

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -19,7 +19,7 @@ if not defined MSBuildPath (
 @REM The configuration is not known at this point. It could either use the default from Build.proj or be passed in as an MSBuild argument.
 set "BinlogPath=%~dp0artifacts\Build.binlog"
 @REM https://stackoverflow.com/a/16144756/294804
-"%MSBuildPath%" "%~dp0eng\Build.proj" /m /warnAsError /noLogo /clp:Summary /bl:"%BinlogPath%" /ll %*
+"%MSBuildPath%" "%~dp0eng\Build.proj" /m /noLogo /clp:Summary /bl:"%BinlogPath%" /ll %*
 set MSBuildErrorLevel=%ERRORLEVEL%
 
 @REM Move the binlog into the appropriate configuration directory.


### PR DESCRIPTION
_This is a cherry pick of 8cc89bfa60364612576373be98de3ed214904f2e._

Our PR builds have been hit with https://github.com/dotnet/sdk/issues/35768, where an issue in the template engine causes `dotnet new` to report an error and return an exit code. We use MSBuild to script `dotnet new` to create a solution to build on the fly, and that invocation of MSBuild takes `/warnaserror` as an argument. When MSBuild reports a warning for the exit code, that becomes an error that fails the whole build.

This issue is fixed in newer versions of the SDK, but present in the version still installed on the PR build machine images. By removing /warnaserror for the moment we hope to get past the issue in the SDK.

We will need to add /warnaserror back in later, once the build systems have a version of the SDK with the fix. Otherwise we risk other warnings being introduced without noticing.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9303)