### PR TITLE
Install .NET runtime

### DIFF
--- a/eng/pipelines/templates/build-pull-request.yml
+++ b/eng/pipelines/templates/build-pull-request.yml
@@ -24,6 +24,14 @@ jobs:
   - powershell: npm --version
     displayName: Check npm version
 
+  # Ensure the .NET runtime needed by our unit tests is installed.
+  - task: UseDotNet@2
+    displayName: Install .NET Runtime
+    inputs:
+      packageType: runtime
+      # This should match the target of our unit test projects.
+      version: 7.0.x
+
   # Allows for accessing the internal AzDO feed (vs-impl-internal) for project restore via Azure Artifacts Credential Provider.
   # See: https://github.com/microsoft/artifacts-credprovider#automatic-usage
   # YAML reference: https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops


### PR DESCRIPTION
_This is a cherry-pick of 18d5bfbe4ff6732c8bc1a9d7292154b1d83f143b._

Update the PR build to install the version of the .NET runtime used in our unit test runs, specifically, 7.0.x. This wasn't previously needed, so I can only guess that the build system image we were using came with it preinstalled. It seems we can no longer count on that, so now we will explicitly install it.

Without this our unit tests fail to run due to a lack of a runtime.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9305)