### PR TITLE
Move to Archive Symbols task v4

### DIFF
--- a/eng/pipelines/templates/publish-symbols.yml
+++ b/eng/pipelines/templates/publish-symbols.yml
@@ -4,11 +4,6 @@ jobs:
 - job: PublishSymbols
   displayName: Publish Symbols
   timeoutInMinutes: 10
-  pool:
-    # Publishing symbols requires a specific agent pool for access to our file share. Defining the pool information within the job allows us to use that agent pool only for symbol publishing.
-    # Agent Queue: https://devdiv.visualstudio.com/DevDiv/_settings/agentqueues?queueId=3316&view=jobs
-    name: VSEng-ReleasePool-1ES
-    demands: Cmd
   steps:
 
   ###################################################################################################################################################################
@@ -60,12 +55,10 @@ jobs:
 
   # The symbols archived here are checked as part of the VS Insertion PR to ensure they are available.
   # https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb
-  - task: MicroBuildArchiveSymbols@1
+  - task: MicroBuildArchiveSymbols@4
     displayName: Publish to Symweb
     inputs:
       SymbolsFeatureName: MS.VS.ProjectSystem.Managed
-      SymbolsSymwebProject: VS
-      # This value is provided from the DotNet-Project-System variable group, defined in the stage variables.
-      SymbolsUncPath: $(SymbolsUncPath)
-      SymbolsEmailContacts: dotnetdevexproj
+      SymbolsProject: VS
       SymbolsAgentPath: $(Pipeline.Workspace)/$(Build.BuildNumber)
+      azureSubscription: Symbols Upload (DevDiv)


### PR DESCRIPTION
_This is a manual port of fb97ec7b738c9566893d6d2f89e0bbdd39e45050 to the dev17.8.x branch._

v1 of task is being deprecated. We are asked to move to v4.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9306)