### PR TITLE
Add NuGetAuditMode to NuGet nominations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -65,6 +65,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="NuGetAuditMode"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="NuGetLockFilePath"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
Add `NuGetAuditMode` to the properties that are sent to NuGet during nomination, for restore.

This actually should have been done in VS17.8, so this property isn't going to work in VS in 17.8, but will on the command line! 🤦‍♂️

At least this can be fixed in 17.9

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9320)