### PR TITLE
Log when multiple up-to-date checks exist

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -997,6 +997,24 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to - {0}.
+        /// </summary>
+        internal static string OtherUpToDateCheckProviderInfo_1 {
+            get {
+                return ResourceManager.GetString("OtherUpToDateCheckProviderInfo_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Note that other checks may still determine the project is not up-to-date. The following checks are present:.
+        /// </summary>
+        internal static string OtherUpToDateCheckProvidersPresent {
+            get {
+                return ResourceManager.GetString("OtherUpToDateCheckProvidersPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &amp;Pack.
         /// </summary>
         internal static string PackCommand {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -562,4 +562,11 @@ In order to debug this project, add an executable project to this solution which
     <value>Build acceleration has been disabled for this project due to known incompatible NuGet package reference(s) {0}. See https://aka.ms/vs-build-acceleration.</value>
     <comment>{0} is a comma-separated list of NuGet package names.</comment>
   </data>
+  <data name="OtherUpToDateCheckProvidersPresent" xml:space="preserve">
+    <value>Note that other checks may still determine the project is not up-to-date. The following checks are present:</value>
+  </data>
+  <data name="OtherUpToDateCheckProviderInfo_1" xml:space="preserve">
+    <value>- {0}</value>
+    <comment>{0} is the .NET type name of the implementation of an up-to-date check.</comment>
+  </data>
 </root>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -480,6 +480,16 @@
         <target state="translated">UPOZORNĚNÍ: Potenciální problém s výkonem sestavení v projektu {0}. Projekt se po úspěšném sestavení nezobrazuje jako aktuální: {1}. Viz https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Připojování k procesu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -480,6 +480,16 @@
         <target state="translated">WARNUNG: Potenzielles Problem mit der Buildleistung in '{0}'. Das Projekt erscheint nach einem erfolgreichen Build nicht aktuell: {1}. Siehe https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Anhängen an den Prozess.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -480,6 +480,16 @@
         <target state="translated">ADVERTENCIA: posible problema de rendimiento de compilación en '{0}'. El proyecto no aparece actualizado después de una compilación correcta: {1}. Ver https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Adjuntando al proceso.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -480,6 +480,16 @@
         <target state="translated">AVERTISSEMENT : problème potentiel de performances de build dans '{0}'. Le projet n’apparaît pas à jour après une build réussie : {1}. Voir https://aka.ms/incremental-build-failure</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Attachement au processus</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -480,6 +480,16 @@
         <target state="translated">AVVISO: possibile problema di prestazioni di compilazione in '{0}'. Il progetto non viene visualizzato aggiornato dopo una compilazione riuscita: {1}. Vedi https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Connessione al processo.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -480,6 +480,16 @@
         <target state="translated">警告: '{0}' でビルド パフォーマンスの問題が発生する可能性があります。プロジェクトは、ビルドが成功した後に最新の状態になりません: {1}。https://aka.ms/incremental-build-failure を参照してください。</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">プロセスにアタッチしています。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -480,6 +480,16 @@
         <target state="translated">경고: '{0}'에서의 잠재적 빌드 성능 문제입니다. 빌드가 성공한 후에는 프로젝트가 최신 상태로 표시되지 않습니다. {1}. https://aka.ms/incremental-build-failure를 참조하세요.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">프로세스에 연결하는 중입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -480,6 +480,16 @@
         <target state="translated">OSTRZEŻENIE: potencjalny problem z wydajnością kompilacji w „{0}”. Projekt wydaje się być nieaktualny po pomyślnej kompilacji: {1}. Zobacz stronę https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Dołączanie do procesu.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -480,6 +480,16 @@
         <target state="translated">AVISO: potencial problema de desempenho de compilação em '{0}'. O projeto não aparece atualizado após uma compilação bem sucedida: {1}. Ver https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Anexando ao processo.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -480,6 +480,16 @@
         <target state="translated">ПРЕДУПРЕЖДЕНИЕ. Возможная проблема с производительностью сборки в "{0}". Проект не отображается обновленным после успешной сборки: {1}. Сведения см. на странице https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">Выполняется подключение к процессу.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -480,6 +480,16 @@
         <target state="translated">UYARI: '{0}' içinde olası derleme performansı sorunu var. Proje, başarılı bir derlemeden sonra güncel görünmüyor: {1}. Bkz. https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">İşleme ekleniyor.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -480,6 +480,16 @@
         <target state="translated">警告: "{0}" 中可能存在生成性能问题。成功生成后，项目不会显示为最新版本: {1}。请参阅 https://aka.ms/incremental-build-failure。</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">正在附加到流程。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -480,6 +480,16 @@
         <target state="translated">警告: '{0}'中可能發生組建效能問題。成功建置之後，此專案未顯示為最新狀態: {1}。請參閱https://aka.ms/incremental-build-failure.</target>
         <note>{0} is the file name of the project. {1} is a description of the failure. The period '.' after {1} is intentional and should be kept.</note>
       </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProviderInfo_1">
+        <source>- {0}</source>
+        <target state="new">- {0}</target>
+        <note>{0} is the .NET type name of the implementation of an up-to-date check.</note>
+      </trans-unit>
+      <trans-unit id="OtherUpToDateCheckProvidersPresent">
+        <source>Note that other checks may still determine the project is not up-to-date. The following checks are present:</source>
+        <target state="new">Note that other checks may still determine the project is not up-to-date. The following checks are present:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ProjectHotReloadSessionManager_AttachingToProcess">
         <source>Attaching to process.</source>
         <target state="translated">正在附加至處理序。</target>


### PR DESCRIPTION
Fixes #9322

CPS supports projects having multiple `IBuildUpToDateCheckProvider` implementations being active. When multiple exist, any one of them can declare the project as out of date.

This can cause confusion when there are multiple checks, as the log output from this check will declare the project up to date, then another check determines the project is out of date but doesn't log anything. In such cases, the output resembles:

```
1>FastUpToDate: Project is up-to-date. (MauiLib1)
1>------ Build started: Project: MauiLib1, Configuration: Debug Any CPU ------
1>MauiLib1 -> C:\Users\emafern\source\repos\MauiApp9\MauiLib1\bin\Debug\net8.0-ios\MauiLib1.dll
```

This change detects when multiple checks are present, and includes the following output:

```
1>FastUpToDate: Note that other checks may still determine the project is not up-to-date. The following checks are present: (MauiLib1)
1>FastUpToDate: - Microsoft.VisualStudio.OtherComponent.OtherCheck (MauiLib1)
```

This extra information avoids confusion and directs the reader to a specific implementation for further investigation.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9325)