### PR TITLE
Use explicit string comparers

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -993,14 +993,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
                 logger.FileSystemOperations = fileSystemOperations;
 
-                HashSet<string> copyItemPaths = new();
+                HashSet<string> copyItemPaths = new(StringComparers.Paths);
 
                 try
                 {
                     HashSet<string>? ignoreKinds = null;
                     if (ignoreKindsString is not null)
                     {
-                        ignoreKinds = new HashSet<string>(new LazyStringSplit(ignoreKindsString, ';'), StringComparer.OrdinalIgnoreCase);
+                        ignoreKinds = new HashSet<string>(new LazyStringSplit(ignoreKindsString, ';'), KindNameComparer);
 
                         if (requestedLogLevel >= LogLevel.Info && ignoreKinds.Count != 0)
                         {


### PR DESCRIPTION
Avoids the potential for treating file paths that differ only by case as different items. On Windows, they are the same path.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9326)