### PR TITLE
Remove NuGet cycle detection feature flag

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectSystemOptions.cs
@@ -74,11 +74,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             await settingsManager.SetValueAsync(name, value, isMachineLocal: false);
         }
 
-        public ValueTask<bool> IsNuGetRestoreCycleDetectionEnabledAsync(CancellationToken cancellationToken)
-        {
-            return IsFlagEnabledAsync(FeatureFlagNames.EnableNuGetRestoreCycleDetection, defaultValue: false, cancellationToken);
-        }
-
         public ValueTask<bool> IsIncrementalBuildFailureOutputLoggingEnabledAsync(CancellationToken cancellationToken)
         {
             return IsFlagEnabledAsync(FeatureFlagNames.EnableIncrementalBuildFailureOutputLogging, defaultValue: false, cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IProjectSystemOptions.cs
@@ -51,11 +51,6 @@ namespace Microsoft.VisualStudio.ProjectSystem
         Task<bool> GetPreferSingleTargetBuildsForStartupProjectsAsync(CancellationToken cancellationToken);
 
         /// <summary>
-        ///     Gets a value indicating if the project system should attempt to detect cycles in the NuGet restore process.
-        /// </summary>
-        ValueTask<bool> IsNuGetRestoreCycleDetectionEnabledAsync(CancellationToken cancellationToken);
-
-        /// <summary>
         ///     Gets whether incremental build failure detection should write to the output window when failures are detected.
         /// </summary>
         ValueTask<bool> IsIncrementalBuildFailureOutputLoggingEnabledAsync(CancellationToken cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreCycleDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreCycleDetector.cs
@@ -12,7 +12,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore;
 internal sealed class PackageRestoreCycleDetector(
     UnconfiguredProject unconfiguredProject,
     ITelemetryService telemetryService,
-    IProjectSystemOptions projectSystemOptions,
     INonModalNotificationService userNotificationService)
     : IPackageRestoreCycleDetector
 {
@@ -43,7 +42,6 @@ internal sealed class PackageRestoreCycleDetector(
 
     private readonly UnconfiguredProject _unconfiguredProject = unconfiguredProject;
     private readonly ITelemetryService _telemetryService = telemetryService;
-    private readonly IProjectSystemOptions _projectSystemOptions = projectSystemOptions;
     private readonly INonModalNotificationService _userNotificationService = userNotificationService;
 
     private Hash? _lastHash;
@@ -53,12 +51,6 @@ internal sealed class PackageRestoreCycleDetector(
 
     public async Task<bool> IsCycleDetectedAsync(Hash hash, CancellationToken cancellationToken)
     {
-        if (!await _projectSystemOptions.IsNuGetRestoreCycleDetectionEnabledAsync(cancellationToken))
-        {
-            // Cycle detection has been disabled. Take no further action.
-            return false;
-        }
-
         // Ensure we have a stopwatch running throughout restores. We will stop it when we either
         // have two consecutive restores at the same hash, or when we detect a cycle.
         _stopwatch.Start();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
@@ -22,14 +22,6 @@ public sealed class PackageRestoreCycleDetectorTests
         await ValidateAsync(instance, sequence, isCycleDetected);
     }
 
-    [Fact]
-    public async Task IsCycleDetectedAsync_CycleIgnoredWhenFeatureDisabled()
-    {
-        var instance = CreateInstance(isEnabled: false); // disabled
-
-        await ValidateAsync(instance, "ABABABABAB", isCycleDetected: false);
-    }
-
     private async Task ValidateAsync(PackageRestoreCycleDetector instance, string sequence, bool isCycleDetected)
     {
         for (var i = 0; i < sequence.Length; i++)
@@ -44,12 +36,11 @@ public sealed class PackageRestoreCycleDetectorTests
 
     private static Hash CreateHash(byte b) => new(new[] { b });
 
-    private static PackageRestoreCycleDetector CreateInstance(bool isEnabled = true)
+    private static PackageRestoreCycleDetector CreateInstance()
     {
         var project = UnconfiguredProjectFactory.CreateWithActiveConfiguredProjectProvider(IProjectThreadingServiceFactory.Create());
 
         var projectSystemOptions = new Mock<IProjectSystemOptions>();
-        projectSystemOptions.Setup(o => o.IsNuGetRestoreCycleDetectionEnabledAsync(It.IsAny<CancellationToken>())).ReturnsAsync(isEnabled);
 
         var telemetryService = new Mock<ITelemetryService>();
         var nonModelNotificationService = new Mock<INonModalNotificationService>();
@@ -57,7 +48,6 @@ public sealed class PackageRestoreCycleDetectorTests
         return new PackageRestoreCycleDetector(
             project,
             telemetryService.Object,
-            projectSystemOptions.Object,
             nonModelNotificationService.Object);
     }
 }


### PR DESCRIPTION
Fixes #9315

This feature is on by default and we have no reason to believe anyone would turn it off.

Remove the feature flag to reduce the number of flags.

This PR pairs with https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/510431, though we don't have to synchronise insertions.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9327)