### PR TITLE
Specify PrivateAssets="all"

### DIFF
--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -12,7 +12,7 @@
     <!-- Path Property: PkgMicrosoft_DiaSymReader_Pdb2Pdb -->
     <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb"      ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.XliffTasks"         PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset"     PrivateAssets="all" />
     <!--
       The SourceLink package depends on the repo provider used.
       https://github.com/dotnet/sourcelink#using-source-link-in-net-projects


### PR DESCRIPTION
The Microsoft.Net.Compilers.Toolset package does not contain libraries to reference; rather, it allows us to pick up different versions of the C# compiler and associated MSBuild files than what we would normally get from the SDK. As a NuGet package, however, it is subject to the same transitive reference rules as every other package and that means that consumers of our Microsoft.VisualStudio.ProjectSystem.Managed NuGet package _also_ end up depending on Microsoft.Net.Compilers.Toolset whether or not they want to.

This means we're changing how consuming projects build in a way that has nothing to do with the functionality they need from Microsoft.VisualStudio.ProjectSystem.Managed which is not what was intended. We see this in other repos using Microsoft.Net.Compilers.Toolset; NuGet complains if they are not using the same version of the package.

Here we fix this by specify that all the assets of the package are private, meaning that they will be used by projects that reference Microsoft.Net.Compilers.Toolset but will not be passed on transitively. We already do this with other packages that are used strictly to modify the build.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9328)