### PR TITLE
Removed old links to dotnet/xliff-tasks repo

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -92,7 +92,7 @@
     <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
     <!-- This tells XliffTasks to produce updated XLF files when building a project. -->
     <!-- We set this off in CI so that the CI build will fail if updated XLF files were not committed to the repo. -->
-    <!-- https://github.com/dotnet/xliff-tasks/tree/main#using-microsoftdotnetxlifftasks -->
+    <!-- https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.XliffTasks/README.md#using-microsoftdotnetxlifftasks -->
     <UpdateXlfOnBuild Condition="'$(CIBuild)' != 'true'">true</UpdateXlfOnBuild>
   </PropertyGroup>
 

--- a/docs/repo/property-pages/localization.md
+++ b/docs/repo/property-pages/localization.md
@@ -15,7 +15,7 @@ These CPS mechanisms do not provide their own means of handling localized `Rule`
 
 Both of these approaches assume that you have localized copies of the original .xaml `Rule` file, one per supported locale. The process of creating these files is beyond the scope of this document, and will depend on the specific localization tools and processes used by your component.
 
-That being said, this particular repo makes use of [xliff-tasks](https://github.com/dotnet/xliff-tasks) to extract the localizable parts of .xaml `Rule` files into .xlf files for translation, and to incorporate the translated .xlf files back into the build.
+That being said, this particular repo makes use of [xliff-tasks](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.XliffTasks/README.md) to extract the localizable parts of .xaml `Rule` files into .xlf files for translation, and to incorporate the translated .xlf files back into the build.
 
 
 ## Integrating localized XAML files on disk

--- a/docs/repo/property-pages/property-specification.md
+++ b/docs/repo/property-pages/property-specification.md
@@ -614,4 +614,4 @@ It is possible to achieve this by authoring a property whose data source uses `P
 
 ## Localization
 
-XAML files in the dotnet/project-system repo are configured for automatic localization via XLF files, which are automatically generated and updated during build via [xliff-tasks](https://github.com/dotnet/xliff-tasks) MSBuild tasks/targets.
+XAML files in the dotnet/project-system repo are configured for automatic localization via XLF files, which are automatically generated and updated during build via [xliff-tasks](https://github.com/dotnet/arcade/blob/main/src/Microsoft.DotNet.XliffTasks/README.md) MSBuild tasks/targets.


### PR DESCRIPTION
The repo was merged into dotnet/arcade

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9336)