### PR TITLE
Fix double logging of BA feature flag

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -1206,9 +1206,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     {
                         if (isCopyItemsComplete)
                         {
-                            logger.Info(isEnabledInProject is null
-                                ? nameof(VSResources.FUTD_BuildAccelerationEnabledViaFeatureFlag)
-                                : nameof(VSResources.FUTD_BuildAccelerationEnabledViaProperty));
+                            if (isEnabledInProject is not null)
+                            {
+                                // Don't log if isEnabledInProject is null, as we already log that status above
+                                logger.Info(nameof(VSResources.FUTD_BuildAccelerationEnabledViaProperty));
+                            }
+
                             return true;
                         }
                         else


### PR DESCRIPTION
Previously code would log the following message twice if FUTDC logging was enabled along with the BA feature flag.

> Build acceleration is enabled for this project via a feature flag. See "Tools | Options | Environment | Preview Features" to control this setting. See https://aka.ms/vs-build-acceleration.

This change ensures it's only logged once in the output per project.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9340)