### PR TITLE
Fix "Primary workspace unknown" bug in language service

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -310,6 +310,8 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
 
         await WhenProjectLoaded(cancellationToken);
 
+        await WhenInitialized(cancellationToken);
+
         return _primaryWorkspace ?? throw Assumes.Fail("Primary workspace unknown.");
     }
 


### PR DESCRIPTION
Fixes #9339 
Fixes [AB#1907473](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1907473)
Fixes [AB#1872265](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1872265)

Previous code would wait for prioritized project load (via `PrioritizedProjectLoadedInHost`), however this left a race where the primary workspace might still not have been initialized.

This change adds a wait for that initialization before returning the primary workspace, to ensure it's not null and our assertion doesn't fire.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9343)