### PR TITLE
Add a rule for AdditionalFiles

### DIFF
--- a/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/CommonFiles.swr
+++ b/setup/Microsoft.VisualStudio.ProjectSystem.Managed.CommonFiles/CommonFiles.swr
@@ -12,6 +12,7 @@ folder "InstallDir:MSBuild\Microsoft\VisualStudio\Managed"
   file source="$(VisualStudioXamlRulesDir)Microsoft.Managed.DesignTime.targets"
 
 folder "InstallDir:MSBuild\Microsoft\VisualStudio\Managed"
+  file source="$(VisualStudioXamlRulesDir)AdditionalFiles.xaml"
   file source="$(VisualStudioXamlRulesDir)AnalyzerReference.xaml"
   file source="$(VisualStudioXamlRulesDir)ApplicationPropertyPage.xaml"
   file source="$(VisualStudioXamlRulesDir)ApplicationPropertyPage.CSharp.xaml"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -253,6 +253,16 @@
 
   <!-- Items -->
   <ItemGroup>
+    <Compile Update="ProjectSystem\Rules\Items\AdditionalFiles.cs">
+      <DependentUpon>AdditionalFiles.xaml</DependentUpon>
+    </Compile>
+    <XamlPropertyRule Include="ProjectSystem\Rules\Items\AdditionalFiles.xaml">
+      <SubType>Designer</SubType>
+      <XlfInput>false</XlfInput>
+      <DataAccess>None</DataAccess>
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <RuleInjection>None</RuleInjection>
+    </XamlPropertyRule>
     <Compile Update="ProjectSystem\Rules\Items\Compile.cs">
       <DependentUpon>Compile.xaml</DependentUpon>
     </Compile>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    internal partial class AdditionalFiles
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/AdditionalFiles.xaml
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
+<Rule Name="AdditionalFiles"
+      PageTemplate="generic"
+      PropertyPagesHidden="true"
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="false"
+                ItemType="AdditionalFiles"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext" />
+  </Rule.DataSource>
+
+  <BoolProperty Name="ExcludeFromCurrentConfiguration"
+                Visible="False" />
+
+  <DynamicEnumProperty Name="{}{ItemType}"
+                       EnumProvider="ItemTypes" />
+
+  <BoolProperty Name="AutoGen"
+                Visible="false" />
+
+  <EnumProperty Name="CopyToOutputDirectory">
+    <EnumValue Name="Never" />
+    <EnumValue Name="Always" />
+    <EnumValue Name="PreserveNewest" />
+  </EnumProperty>
+
+  <StringProperty Name="CustomTool"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource HasConfigurationCondition="False"
+                  ItemType="AdditionalFiles"
+                  PersistedName="Generator"
+                  Persistence="ProjectFile"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <StringProperty Name="CustomToolNamespace" />
+
+  <StringProperty Name="DependentUpon"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
+  <BoolProperty Name="DesignTime"
+                Visible="false" />
+
+  <BoolProperty Name="DesignTimeSharedInput"
+                Visible="false" />
+
+  <StringProperty Name="Generator" />
+
+  <StringProperty Name="LastGenOutput"
+                  Visible="false" />
+
+  <StringProperty Name="Link"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource PersistenceStyle="Attribute"
+                  SourceOfDefaultValue="AfterContext" />
+    </StringProperty.DataSource>
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
+  <StringProperty Name="NuGetPackageId"
+                  Visible="false">
+    <StringProperty.Metadata>
+      <NameValuePair Name="DoNotCopyAcrossProjects"
+                     Value="true" />
+    </StringProperty.Metadata>
+  </StringProperty>
+
+  <StringProperty Name="SubType"
+                  Visible="false">
+    <StringProperty.DataSource>
+      <DataSource Persistence="DesignTimeItemPropertiesStorage"
+                  ItemType="AdditionalFiles"
+                  PersistedName="SubType"
+                  HasConfigurationCondition="false"/>
+    </StringProperty.DataSource>
+  </StringProperty>
+
+  <BoolProperty Name="Visible"
+                Visible="false" />
+
+</Rule>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/ItemRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/ItemRuleTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rules
             // First fix up the Name as we know they'll differ.
             rule.Attribute("Name").Value = "None";
 
-            if (ruleName is "Compile" or "EditorConfigFiles")
+            if (ruleName is "AdditionalFiles" or "Compile" or "EditorConfigFiles")
             {
                 // Remove the "TargetPath" element for these types
                 var targetPathElement = none.XPathSelectElement(@"/msb:Rule/msb:StringProperty[@Name=""TargetPath""]", namespaceManager);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/PackageContentTests.CommonFiles.verified.txt
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Setup/PackageContentTests.CommonFiles.verified.txt
@@ -2,6 +2,7 @@
   [Content_Types].xml,
   _rels/.rels,
   _rels/manifest.json.rels,
+  Contents/MSBuild/Microsoft/VisualStudio/Managed/AdditionalFiles.xaml,
   Contents/MSBuild/Microsoft/VisualStudio/Managed/AnalyzerReference.xaml,
   Contents/MSBuild/Microsoft/VisualStudio/Managed/ApplicationPropertyPage.CSharp.xaml,
   Contents/MSBuild/Microsoft/VisualStudio/Managed/ApplicationPropertyPage.VisualBasic.xaml,


### PR DESCRIPTION
To ensure the language service can get the same link metadata and handling as Compile items, I'm updating the VS Code project system to reuse the same logic. This requires having a new rule to grab the items during evaluation, so I'm copy/pasting the Compile item and updating as appropriate.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9354)