### PR TITLE
Prevent fault in ImportTreeProvider

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectFileClassifier.cs
@@ -136,7 +136,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
 
         private static void EnsureTrailingSlash([AllowNull] ref string path)
         {
-            if (path is not null)
+            if (!Strings.IsNullOrEmpty(path))
             {
                 path = PathHelper.EnsureTrailingSlash(path);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/ProjectImports/ImportTreeProvider.cs
@@ -182,12 +182,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports
                         {
                             if (e.Value.Item2.CurrentState.TryGetValue(ConfigurationGeneral.SchemaName, out IProjectRuleSnapshot snapshot))
                             {
-                                if (snapshot.Properties.TryGetValue(ConfigurationGeneral.MSBuildProjectExtensionsPathProperty, out string projectExtensionsPath))
+                                if (snapshot.Properties.TryGetStringProperty(ConfigurationGeneral.MSBuildProjectExtensionsPathProperty, out string projectExtensionsPath))
                                 {
                                     _projectFileClassifier.ProjectExtensionsPath = projectExtensionsPath;
                                 }
 
-                                if (snapshot.Properties.TryGetValue(ConfigurationGeneral.NuGetPackageFoldersProperty, out string nuGetPackageFolders))
+                                if (snapshot.Properties.TryGetStringProperty(ConfigurationGeneral.NuGetPackageFoldersProperty, out string nuGetPackageFolders))
                                 {
                                     _projectFileClassifier.NuGetPackageFolders = nuGetPackageFolders;
                                 }


### PR DESCRIPTION
We had a report of an error with this stack:

```
System.AggregateException: Project system data flow 'Import Tree Action: 30768406' closed because of an exception: 'path' cannot be an empty string ("") or start with the null character.
Parameter name: path.
---> (Inner Exception #0) System.ArgumentException: 'path' cannot be an empty string ("") or start with the null character.
Parameter name: path
   at Microsoft.Requires.NotNullOrEmpty(String value, String parameterName)
   at Microsoft.VisualStudio.ProjectSystem.PathHelper.EnsureTrailingSlash(String path)
   at Microsoft.VisualStudio.ProjectSystem.Tree.ProjectImports.ImportTreeProvider.<set_ShowAllFiles>g__SyncTree|22_5(IProjectVersionedValue`1 e)
   at Microsoft.VisualStudio.ProjectSystem.ActionBlockSlimSync`1.ProcessInputAsync(TInput input)
   at Microsoft.VisualStudio.ProjectSystem.DataReceivingBlockSlim`1.<ProcessInputQueueAsync>d__5.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.VisualStudio.ProjectSystem.CommonProjectSystemTools.Rethrow(Exception ex)
   at Microsoft.VisualStudio.ProjectSystem.ExceptionFilter.<>c__DisplayClass2_0.<Guard>g__Action|0()
   at GuardMethodClass.GuardMethod(Func`1 , Func`2 , Func`2 )
<--- (Inner Exception #0)
```

The problem seems to actually be in the `ProjectFileClassifier`, where we checked for null but not empty strings. The call to `EnsureTrailingSlash` would throw on either. We need to check for both.

This fixes that.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9355)