### PR TITLE
Build acceleration clears read only flag of copied files

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -175,7 +175,7 @@ internal sealed partial class BuildUpToDateCheck
                             // TODO add retry logic in case of failed copies? MSBuild does this with CopyRetryCount and CopyRetryDelayMilliseconds
 
                             // Copy the file
-                            _fileSystem.CopyFile(source, destination, overwrite: true);
+                            _fileSystem.CopyFile(source, destination, overwrite: true, clearReadOnly: true);
 
                             copyCount++;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -27,7 +27,7 @@ namespace Microsoft.VisualStudio.IO
         bool FileExists(string path);
 
         void RemoveFile(string path);
-        void CopyFile(string source, string destination, bool overwrite);
+        void CopyFile(string source, string destination, bool overwrite, bool clearReadOnly = false);
         Task<string> ReadAllTextAsync(string path);
         Stream OpenTextStream(string path);
         Task WriteAllTextAsync(string path, string content);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -36,9 +36,18 @@ namespace Microsoft.VisualStudio.IO
             }
         }
 
-        public void CopyFile(string source, string destination, bool overwrite)
+        public void CopyFile(string source, string destination, bool overwrite, bool clearReadOnly)
         {
             File.Copy(source, destination, overwrite);
+
+            if (clearReadOnly)
+            {
+                FileAttributes attributes = File.GetAttributes(destination);
+                if ((attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                {
+                    File.SetAttributes(destination, attributes & ~FileAttributes.ReadOnly);
+                }
+            }
         }
 
         public async Task<string> ReadAllTextAsync(string path)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -113,7 +113,7 @@ namespace Microsoft.VisualStudio.IO
             Files.Remove(path);
         }
 
-        public void CopyFile(string source, string destination, bool overwrite)
+        public void CopyFile(string source, string destination, bool overwrite, bool clearReadOnly)
         {
             if (!FileExists(destination))
             {


### PR DESCRIPTION
Fixes [AB#1934681](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1934681)

When a `CopyToOutputDirectory` source item is read only, MSBuild copies the file but clears the read only attribute.

Build Acceleration is a feature that mimics builds in MSBuild and therefore must also clear this flag.

Without doing so, errors can be seen in the output window during build:

```
Build started at 4:35 PM...
1>FastUpToDate: Exception copying file, scheduling MSBuild: System.UnauthorizedAccessException: Access to the path 'D:\repos\issues\Ticket1934681BuildAccelerationCopyReadOnlyFiles\Ticket1934681BuildAccelerationCopyReadOnlyFiles\bin\Debug\net8.0\ReadOnly.txt' is denied.
1>   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
1>   at System.IO.File.InternalCopy(String sourceFileName, String destFileName, Boolean overwrite, Boolean checkHost)
1>   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.BuildUpToDateCheck.FileSystemOperationAggregator.TryApplyFileSystemOperations() (Ticket1934681BuildAccelerationCopyReadOnlyFiles)
1>------ Build started: Project: Ticket1934681BuildAccelerationCopyReadOnlyFiles, Configuration: Debug Any CPU ------
1>C:\Program Files\dotnet\sdk\8.0.200-preview.23620.12\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.RuntimeIdentifierInference.targets(311,5): message NETSDK1057: You are using a preview version of .NET. See: https://aka.ms/dotnet-support-policy
1>C:\Program Files\Microsoft Visual Studio\2022\Preview\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets(5239,5): error MSB3021: Unable to copy file "D:\repos\issues\Ticket1934681BuildAccelerationCopyReadOnlyFiles\Ticket1934681BuildAccelerationCopyReadOnlyFiles\ReadOnly.txt" to "bin\Debug\net8.0\ReadOnly.txt". Access to the path 'bin\Debug\net8.0\ReadOnly.txt' is denied.
1>Done building project "Ticket1934681BuildAccelerationCopyReadOnlyFiles.csproj" -- FAILED.
========== Build: 0 succeeded, 1 failed, 0 up-to-date, 0 skipped ==========
========== Build completed at 4:35 PM and took 00.569 seconds ==========
Visual Studio accelerated 1 project(s), copying 0 file(s). See https://aka.ms/vs-build-acceleration.
```

This problem is particularly important for users of version control systems that lock files on disk, such as VSS and Perforce.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9358)