### PR TITLE
Use the correct string comparer in MSBuildDependencyCollection

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions.M
 /// </summary>
 internal sealed class MSBuildDependencyCollection
 {
-    private readonly Dictionary<string, MSBuildDependency> _dependencyById = new();
+    private readonly Dictionary<string, MSBuildDependency> _dependencyById = new(StringComparers.DependencyIds);
     private readonly MSBuildDependencyFactoryBase _factory;
 
     public DependencyGroupType DependencyGroupType => _factory.DependencyGroupType;


### PR DESCRIPTION
Fixes #9360

This fixes an issue where dependencies having different capitalisation between unresolved and resolved forms can cause multiple entries in the collection for the same dependency, where one of those may be out of date, causing a previous error to still be reported at the group level, despite only one dependency tree item being shown for the pair.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9361)