### PR TITLE
Improve perf of dependency tree updates

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilder.cs
@@ -80,6 +80,15 @@ internal sealed class DependenciesTreeBuilder
 
         await BuildUnconfiguredNodesAsync();
 
+        dependenciesNode = RemoveUnexpectedChildren(dependenciesNode, expectedChildren);
+
+        ProjectImageMoniker rootIcon = snapshot.MaximumDiagnosticLevel switch
+        {
+            DiagnosticLevel.Error => KnownProjectImageMonikers.ReferenceGroupError,
+            DiagnosticLevel.Warning => KnownProjectImageMonikers.ReferenceGroupWarning,
+            _ => KnownProjectImageMonikers.ReferenceGroup
+        };
+
         if (cancellationToken.IsCancellationRequested)
         {
             // We return the original tree on cancellation. This is because the cancellation can indicate
@@ -89,15 +98,6 @@ internal sealed class DependenciesTreeBuilder
             // unmodified, CPS will not perform additional work as part of the update.
             return originalNode;
         }
-
-        dependenciesNode = RemoveUnexpectedChildren(dependenciesNode, expectedChildren);
-
-        ProjectImageMoniker rootIcon = snapshot.MaximumDiagnosticLevel switch
-        {
-            DiagnosticLevel.Error => KnownProjectImageMonikers.ReferenceGroupError,
-            DiagnosticLevel.Warning => KnownProjectImageMonikers.ReferenceGroupWarning,
-            _ => KnownProjectImageMonikers.ReferenceGroup
-        };
 
         return dependenciesNode.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilder.cs
@@ -99,7 +99,16 @@ internal sealed class DependenciesTreeBuilder
             return originalNode;
         }
 
-        return dependenciesNode.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
+        if (dependenciesNode.Icon == rootIcon && dependenciesNode.ExpandedIcon == rootIcon)
+        {
+            // The icon is unchanged, so avoid creating an additional tree item.
+            return dependenciesNode;
+        }
+        else
+        {
+            // The icon changed. Apply it.
+            return dependenciesNode.SetProperties(icon: rootIcon, expandedIcon: rootIcon);
+        }
 
         IProjectTree CreateDependenciesNode()
         {


### PR DESCRIPTION
Two commits here, easily reviewed separately:

1. Improve chances of cancelation avoiding redundant work.
2. Avoid tree mutations/allocations in the common case that the node's icons are unchanged.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9362)