### PR TITLE
Use correct package capitalisation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -72,7 +72,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Analyzers"                         Version="$(CPSPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Query"                             Version="$(CPSPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.SDK"                               Version="$(CPSPackageVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools"                         Version="$(CPSPackageVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.Sdk.Tools"                         Version="$(CPSPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.VS"                                Version="$(CPSPackageVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes"                         Version="$(CPSPackageVersion)" />
 

--- a/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
+++ b/docs/repo/property-pages/how-to-add-a-new-launch-profile-kind.md
@@ -122,15 +122,15 @@ In this option the XAML file is embedded in an assembly as a resource and discov
 
 ### Step 1: Add the Project System SDK
 
-Use the NuGet Package Manager to add the Microsoft.VisualStudio.ProjectSystem.Sdk package package to your project.
+Use the NuGet Package Manager to add the Microsoft.VisualStudio.ProjectSystem.SDK package package to your project.
 
 ### Step 2: (optional): Add the Microsoft.Build.Framework package
 
 Use the NuGet Package Manager to add the Microsoft.Build.Framework package to your project. This is an optional step, but it will allow the XAML editor to find the [Rule](https://docs.microsoft.com/en-us/dotnet/api/microsoft.build.framework.xamltypes.rule) type (and related types) and provide code completion, tool tips, Go to Definition, and other features while you type.
 
-### Step 3: Add the Microsoft.VisualStudio.ProjectSystem.SDK.Tools package
+### Step 3: Add the Microsoft.VisualStudio.ProjectSystem.Sdk.Tools package
 
-Use the NuGet Package Manager to add the Microsoft.VisualStudio.ProjectSystem.SDK.Tools package to your project. This is required to correctly embed the XAML rule at build time.
+Use the NuGet Package Manager to add the Microsoft.VisualStudio.ProjectSystem.Sdk.Tools package to your project. This is required to correctly embed the XAML rule at build time.
 
 ### Step 4: Define the XAML file
 

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -28,7 +28,7 @@
     <!-- CPS -->
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK.Tools" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Sdk.Tools" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />


### PR DESCRIPTION
CPS has the following two packages:

1. [`Microsoft.VisualStudio.ProjectSystem.SDK`](https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk/NuGet/Microsoft.VisualStudio.ProjectSystem.SDK/17.9.544-pre-gca00260a2a)
2. [`Microsoft.VisualStudio.ProjectSystem.Sdk.Tools`](https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk/NuGet/Microsoft.VisualStudio.ProjectSystem.Sdk.Tools/overview/17.9.544-pre-gca00260a2a)

Before this commit, we would reference:

1. `Microsoft.VisualStudio.ProjectSystem.SDK`
2. `Microsoft.VisualStudio.ProjectSystem.SDK.Tools` (incorrect)

Note how we use different capitalisation.

This should be supported through all the tooling, but it's nice to have them match reality. See also #9360.