### PR TITLE
Use dependency ID in project tree flags correctly

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
@@ -352,7 +352,7 @@ internal abstract class MSBuildDependencyFactoryBase : IMSBuildDependencyFactory
             DiagnosticLevel diagnosticLevel = GetDiagnosticLevel(isResolved, properties);
             string caption = GetResolvedCaption(itemSpec, dependency.Id, properties);
             ProjectImageMoniker icon = GetIcon(isImplicit, diagnosticLevel);
-            ProjectTreeFlags flags = UpdateTreeFlags(itemSpec, FlagCache.Get(isResolved, isImplicit));
+            ProjectTreeFlags flags = UpdateTreeFlags(dependency.Id, FlagCache.Get(isResolved, isImplicit));
 
             updated = dependency.With(
                 isResolved: isResolved,


### PR DESCRIPTION
Dependency nodes in the tree have various flags, which allow other code to inspect dependencies in order to interact with them (commands, attaching children, etc.).

Flags are computed via the virtual `UpdateTreeFlags` method, and certain MSBuild dependency factories override this method to include additional logic.

For package dependencies, the dependency's ID is added as a flag of form `$ID:MyPackage`.

An unresolved package dependency has item spec `MyPackage`, whereas the resolved form includes the version `MyPackage/1.2.3`. The code was incorrectly passing the resolved form, including the version. This change ensures we pass the ID, which is consistent regardless of whether the dependency is resolved or not.

This fix could, under certain timing conditions, fix issues where child nodes are not attached correctly to package nodes in the tree.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9371)