### PR TITLE
Avoid DTE construction where possible

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/PackagePropPage.vb
@@ -58,7 +58,7 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
         Private Shared Function GetUnconfiguredProject(hierarchy As IVsHierarchy) As UnconfiguredProject
             Dim context = DirectCast(hierarchy, IVsBrowseObjectContext)
-            If context IsNot Nothing Then
+            If context Is Nothing Then
                 Dim dteProject = DirectCast(GetDTEProject(hierarchy), EnvDTE.Project)
                 If dteProject IsNot Nothing Then
                     context = DirectCast(dteProject.Object, IVsBrowseObjectContext)


### PR DESCRIPTION
This code is trying to access the `UnconfiguredProject` for a given `IVsHierarchy`.

It first attempts to cast the hierarchy to `IVsBrowseObjectContext`. It looks like the intention was then to use that if present, otherwise use DTE.

The code incorrectly checks for null (`Nothing`) to see if the first conversion failed, and only then try DTE. As it was written, it would only check DTE if the first conversion succeeded, meaning that _both_ the first cast and the DTE approach have to work.

By fixing the null check, we avoid calling DTE in the common case.

There is only one caller of this private method and I've reviewed it for correctness.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9375)