### PR TITLE
Update "Build VS Bootstrapper"

### DIFF
--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -133,7 +133,7 @@ jobs:
     inputs:
       bootstrapperCoreVersion: latest
       vsMajorVersion: $(SetVisualStudioMinimumVersionVariable.VisualStudioMinimumVersion)
-      channelName: int.rel/d17.8
+      channelName: int.d17.8
       manifests: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/VSSetup/Insertion/SetupManifest.vsman
       # Outputting to the Insertion folder allows the bootstrapper to be published to the Products drop, along with our insertion files.
       # The merged .vsman (OverlaidInstallerManifest.vsman) created by the bootstrapper assumes the bootstrapper will be output to the same drop (Products) as the insertion files.

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -133,7 +133,7 @@ jobs:
     inputs:
       bootstrapperCoreVersion: latest
       vsMajorVersion: $(SetVisualStudioMinimumVersionVariable.VisualStudioMinimumVersion)
-      channelName: int.main
+      channelName: int.rel/d17.8
       manifests: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/VSSetup/Insertion/SetupManifest.vsman
       # Outputting to the Insertion folder allows the bootstrapper to be published to the Products drop, along with our insertion files.
       # The merged .vsman (OverlaidInstallerManifest.vsman) created by the bootstrapper assumes the bootstrapper will be output to the same drop (Products) as the insertion files.


### PR DESCRIPTION
Related to [AB#1939807](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1939807).

To perform partial NGEN of our installed assemblies--where NGEN only pre-JITs the methods we need for a scenario, rather than every method--we need optimization data produced by OptProf runs. We run our own little test that produces this optimization data on every scheduled build of our `main` branch. This test is pretty straightforward--it loads a solution with a handful of projects in VS. We run the test out of our `main` branch so that it can incorporate our latest changes without the need for us to insert into VS. However, this means the test needs to install and run a build of VS that actually has those changes. We accomplish this with the `MicroBuildBuildVSBootstrapper` task. We give it a build channel and it uses the latest build from that channel as a baseline. We also point it at our locally-produced .vsman file describing our setup components, and it merges the two to produce a new VS installer (e.g. vs_enterprise.exe) that combines the two.

The channel we specify in this "Build VS Bootstrapper" task is "int.main" which tracks builds out of the VS "main" branch. This is generally what we want as most of our builds and insertions are from the dotnet/project-system "main" branch into the VS "main" branch. However, it is completely wrong when it comes to release/servicing branches. In the case of our "dev17.8.x" branch, for example, we're producing binaries that target the 17.8 release of VS but end up incorporating them into an installer based on VS "main", which is currently a 17.10 branch. This results in our package not loading properly, which in turn means the test fails and any optimization data we produce does not cover our assemblies. Without that data we get full NGEN of our assemblies at install-time.

Since the "dev17.8.x" branch is a 17.8 servicing branch, this commit updates us to target the "int.rel/d17.8" channel instead. This means the installer will be based on builds out of the VS "rel/d17.8" branch, which is what we want.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9376)