### PR TITLE
Update branch-checklist.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/branch-checklist.md
+++ b/.github/ISSUE_TEMPLATE/branch-checklist.md
@@ -21,10 +21,10 @@ _Descriptions of these steps can be found in the team OneNote._
 - [ ] For branches not matching `dev*` or `feature/*` (usually we skip these)
   - [ ] Update the [pull-request.yml](https://github.com/dotnet/project-system/blob/main/eng/pipelines/pull-request.yml) (via `pr`) to support PR builds
   - [ ] Update the [official.yml](https://github.com/dotnet/project-system/blob/main/eng/pipelines/official.yml) (via `trigger`) to have signed builds the new branch
-- [ ] Update Roslyn Tools [config.xml](https://github.com/dotnet/roslyn-tools/blob/main/src/GitHubCreateMergePRs/config.xml) file to flow branch changes to the latest dev branch
-  - [ ] dotnet/roslyn-tools PR: https://github.com/dotnet/roslyn-tools/pull/❓
 - [ ] Update [version.json](https://github.com/dotnet/project-system/blob/main/version.json) (via `"version"`) to match the version of VS, if needed
-    - [ ] In new branch: https://github.com/dotnet/project-system/blob/dev17.❓.x/version.json
-    - [ ] In `main`: https://github.com/dotnet/project-system/blob/main/version.json
+  - [ ] In new branch: https://github.com/dotnet/project-system/blob/dev17.❓.x/version.json
+  - [ ] In `main`: https://github.com/dotnet/project-system/blob/main/version.json
+- [ ] In the new branch, update the "Build VS Bootstrapper" task in [build-official-release.yml](https://github.com/dotnet/project-system/blob/main/eng/pipelines/templates/build-official-release.yml) and set `channelName` to match the VS insertion branch.
+  - E.g., for VS `main` the `channelName` is "int.main"; for `rel/d17.8` it would be "int.d17.8"; etc.
 - [ ] To run manual insertions, use the [DotNet-Project-System pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9675&_a=summary). Enter the GitHub branch as _Branch/tag_, the VS branch as _VS Insertion Branch Name_, and check _Create VS Insertion PR_.
 - [ ] Update [MSFTBot milestone tracking](https://aka.ms/fabricbotconfig)


### PR DESCRIPTION
Update branch-checklist.md to include instructions on updating the VS installer channel to be used in the "Build VS Bootstrapper" task. This bootstrapper is used to install VS for capturing optimization data, and combines a baseline VS build (from the specified channel) with the Project System components produced by the build. The versions of these two inputs need to match--e.g., if we're building the `dev17.8.x` branch of dotnet/project-system, the baseline VS build needs to come from the 17.8 channel. Combining mismatched versions may prevent the project system from loading during the test and producing useful optimization data.

This also removes the step to setup automatic PRs from release branches back to `main`. These automatic PRs are rarely useful; once we've created a release branch we're generally late in the release cycle and expect to take few, if any, changes to the release branch. And for servicing fixes _after_ release we have to test them first in `main` anyway, and so the automatic PR won't do anything useful. On the other hand we definitely _don't_ want any changes to the bootstrapper channel to go back into our `main` branch.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9377)