### PR TITLE
Update channelName

### DIFF
--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -133,7 +133,7 @@ jobs:
     inputs:
       bootstrapperCoreVersion: latest
       vsMajorVersion: $(SetVisualStudioMinimumVersionVariable.VisualStudioMinimumVersion)
-      channelName: int.main
+      channelName: int.d17.9
       manifests: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/VSSetup/Insertion/SetupManifest.vsman
       # Outputting to the Insertion folder allows the bootstrapper to be published to the Products drop, along with our insertion files.
       # The merged .vsman (OverlaidInstallerManifest.vsman) created by the bootstrapper assumes the bootstrapper will be output to the same drop (Products) as the insertion files.


### PR DESCRIPTION
Update the channel used for the baseline VS build for OptProf collection runs. The latest build of the specified channel is combined with the project system binaries built out of our repo to create the installer used in the run. Since our `dev17.9.x` branch inserts into the `rel/d17.9` branch in the VS repo we need to use the `int.d17.9` channel. Using `int.main` might work for a while, but eventually we're get to the point where our 17.9 builds are no longer compatible with VS `main` builds and our OptProf test will fail. By updating now we avoid that problem.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9378)