### PR TITLE
Fix NU1701 warnings

### DIFF
--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -27,8 +27,7 @@
 
     <!-- CPS -->
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.SDK" />
-    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Sdk.Tools" />
+    <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.Sdk.Tools" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes" Condition="'$(TargetFramework)' == 'net7.0'" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -16,9 +16,6 @@
     <Summary>Microsoft VisualStudio Managed Project System</Summary>
     <PackageTags>Roslyn Managed Project System VisualStudio</PackageTags>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
-
-    <!-- TODO: Remove this when the port to net7.0 is complete -->
-    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -10,9 +10,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net7.0</TargetFrameworks>
-
-    <!-- TODO: Remove this when the port to net7.0 is complete -->
-    <NoWarn>$(NoWarn);NU1701;NU1702</NoWarn>
   </PropertyGroup>
 
   <!-- TODO: Re-enable nullability and clean up warnings. -->
@@ -37,10 +34,6 @@
     <Compile Remove="Mocks\IProjectDependenciesSubTreeProviderFactory.cs" />
     <Compile Remove="Mocks\IProjectImageProviderFactory.cs" />
   </ItemGroup>
-
-  <!-- <ItemGroup>
-    <Reference Include="WindowsBase" />
-  </ItemGroup> -->
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />


### PR DESCRIPTION
Nuget raises the NU1701 warning when a referenced package does not contain an assembly that is compatible with the project's target framework. E.g., if the project targets .NET 7 but the package only contains assemblies targeting .NET Framework 4.7.2 then you'll get this warning. The restore will still complete but you may end up referencing an assembly that may fail to run correctly at runtime.

Early in our C# Dev Kit efforts we needed to turn off this warning because CPS didn't have .NET 7-compatible binaries yet and we _wanted_ to build against the available .NET Framework 4.7.2 binaries while we worked through our own multi-targeting plan. CPS has now had proper .NET 7/8 binaries for a while so we can turn the warning back on--but we also need to adjust our package references.

Currently we depend on the Microsoft.VisualStudio.ProjectSystem.SDK "metapackage" which brings in transitive references to the MS.VS.ProjectSystem, MS.VS.ProjectSystem.VS, and MS.VS.ProjectSystem.Sdk.Tools packages. The first has .NET 7/8 binaries available, and the third brings in build tools but no assemblies. The second is VS-specific and depends on .NET Framework 4.7.2 and it also depends on a bunch of other binaries that are also .NET Framework 4.7.2-specific. This is where all of our current NU1701 warnings would come from.

Here we remove the dependency on Microsoft.VisualStudio.ProjectSystem.SDK in favor of the specific packages we need; this allows us to turn the warning back on.

Note that this has benefits for consumers of our package as well. They would have gotten a transitive reference to the Microsoft.VisualStudio.ProjectSystem.VS package and had all the same NU1701 warnings, but would not have been in a position to fix it, just suppress it.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9381)