### PR TITLE
check other input data source version along with the project version

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreDataSourceMocked.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreDataSourceMocked.cs
@@ -19,6 +19,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
         {
         }
 
+        protected override bool IsRestoreDataVersionOutOfDate(IImmutableDictionary<NamedIdentity, IComparable> dataVersions)
+        {
+            return false;
+        }
+
         protected override bool IsProjectConfigurationVersionOutOfDate(IReadOnlyCollection<PackageRestoreConfiguredInput>? configuredInputs)
         {
             return false;


### PR DESCRIPTION
This PR is to add additional check to reduce the chance of restoring NuGet package with out of dated project state. it is essentially similar to the IsProjectConfigurationVersionOutOfDate check but extends the logic to additional data sources. On the other hand, because project version source is not registered as a normal data source, it does not cover the project version, so the original check is still necessary.


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9382)