### PR TITLE
Obsolete some IDependencyModel properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/IDependencyModel.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/IDependencyModel.cs
@@ -89,6 +89,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// In some cases dependency should be present in snapshot, but not displayed in the Tree.
         /// </summary>
+        [Obsolete("Property is unused. Implementation of this property may throw, as it should never be called.")]
         bool Visible { get; }
 
         /// <summary>
@@ -99,6 +100,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Gets the icon to use when the dependency is resolved and expanded.
         /// </summary>
+        [Obsolete("Property is unused. Implementation of this property may throw, as it should never be called.")]
         ImageMoniker ExpandedIcon { get; }
 
         /// <summary>
@@ -109,6 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies
         /// <summary>
         /// Gets the icon to use when the dependency is unresolved and expanded.
         /// </summary>
+        [Obsolete("Property is unused. Implementation of this property may throw, as it should never be called.")]
         ImageMoniker UnresolvedExpandedIcon { get; }
 
         /// <summary>


### PR DESCRIPTION
The `IDependencyModel` interface is used by legacy dependency providers. Several of the members on that interface are no longer used, and we mark them as obsolete to advertise this fact to implementers.

This change adds `[Obsolete]` to a few more unused properties that were missed during earlier work.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9384)