### PR TITLE
Support string[] launchSettings.json properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -307,6 +307,7 @@ internal static class LaunchSettingsJsonEncoding
                     JsonToken.Boolean => (bool)reader.Value!,
                     JsonToken.Integer => checked((int)(long)reader.Value!),
                     JsonToken.StartObject => (jsonSerializer ??= JsonSerializer.CreateDefault()).Deserialize<Dictionary<string, object>>(reader),
+                    JsonToken.StartArray => (jsonSerializer ??= JsonSerializer.CreateDefault()).Deserialize<string[]>(reader),
                     JsonToken.String => (string)reader.Value!,
                     _ => null
                 };


### PR DESCRIPTION
To improve performance of script debugging VSCode supports a launch.json property called skipFiles . This property is a string array which allows customers to define a set of globbing patterns to skip looking for map files.  I am adding the equivalent property to launchsettings.json in Visual Studio, however the launchsettings.json serializer in the managed project system ignores string array types.  This is a small change to support properties which define string arrays.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9393)