### PR TITLE
Add Sign task reference link to build-official-release.yml

### DIFF
--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -29,6 +29,7 @@ jobs:
     condition: false
 
   # Necessary for signing the assemblies and packages.
+  # YAML reference: https://devdiv.visualstudio.com/Engineering/_git/MicroBuild?path=/src/Tasks/SigningPlugin/task.json
   - task: MicroBuildSigningPlugin@4
     displayName: Install Signing Plugin
     inputs:


### PR DESCRIPTION
## Summary
Added a comment to Sign task with the YAML reference link. This is useful when configuring the task.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9394)