### PR TITLE
Don't show yellow triangles when DTB fails

### DIFF
--- a/docs/dependencies-tree.md
+++ b/docs/dependencies-tree.md
@@ -49,7 +49,3 @@ Resolved items are produced by MSBuild targets. The target to inspect depends up
 Inspecting a design-time build's `.binlog` with the [MSBuild Structured Log Viewer](https://msbuildlog.com/) and tracing back from the relevant target will reveal why the original reference was not produces as a resolved reference. Some familiarity with [MSBuild concepts](https://learn.microsoft.com/visualstudio/msbuild/msbuild-concepts) is required to do this.
 
 Note that for package references, you may also look in the `obj` folder for the `project.assets.json` file. Towards the end of that file there may be some messages in the `logs` property that provide insight into why packages were not resolved, though this information should be displayed in the Dependencies tree directly, along with the Package pane of the Output window, and the Error List.
-
-## My whole tree has yellow triangles!
-
-If all dependencies in the tree appear with a yellow triangle, it's most likely that the [design-time build](design-time-builds.md) failed completely. As above, [capture a design-time build log](design-time-builds.md#diagnosing-design-time-builds) and look for the cause of the failure. It may be something completely unrelated to your project's dependencies.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
@@ -48,6 +48,8 @@ internal sealed class MSBuildDependencyCollection
             return false;
         }
 
+        bool hasBuildError = !evaluationProjectChange.After.IsEvaluationSucceeded() || buildProjectChange?.After.IsEvaluationSucceeded() == false;
+
         System.Diagnostics.Debug.Assert(evaluationProjectChange.Difference.RenamedItems.Count == 0, "Evaluation ProjectChange should not contain renamed items");
         System.Diagnostics.Debug.Assert(buildProjectChange?.Difference.RenamedItems.Count is null or 0, "Build ProjectChange should not contain renamed items");
 
@@ -99,7 +101,7 @@ internal sealed class MSBuildDependencyCollection
                 if (_dependencyById.TryGetValue(id, out MSBuildDependency? dependency))
                 {
                     // Updating an existing dependency.
-                    if (_factory.TryUpdate(dependency, update.Evaluation, update.Build, projectFullPath, isEvaluationOnlySnapshot: buildProjectChange is null, out MSBuildDependency? updated))
+                    if (_factory.TryUpdate(dependency, update.Evaluation, update.Build, projectFullPath, isEvaluationOnlySnapshot: buildProjectChange is null, hasBuildError, out MSBuildDependency? updated))
                     {
                         if (updated is not null)
                         {
@@ -116,7 +118,7 @@ internal sealed class MSBuildDependencyCollection
                 else
                 {
                     // Creating a new dependency.
-                    dependency = _factory.CreateDependency(id, update.Evaluation, update.Build, projectFullPath, isEvaluationOnlySnapshot: buildProjectChange is null);
+                    dependency = _factory.CreateDependency(id, update.Evaluation, update.Build, projectFullPath, hasBuildError, isEvaluationOnlySnapshot: buildProjectChange is null);
 
                     if (dependency is not null)
                     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollectionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollectionTests.cs
@@ -382,7 +382,7 @@ public sealed class MSBuildDependencyCollectionTests
         factory.Setup(f => f.GetUnresolvedCaption("Item1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("UnresolvedCaption");
         factory.Setup(f => f.GetResolvedCaption("ResolvedItem1", "Item1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("ResolvedCaption");
         factory.Setup(f => f.UpdateTreeFlags(It.IsAny<string>(), It.IsAny<ProjectTreeFlags>())).Returns((string id, ProjectTreeFlags f) => f);
-        factory.Setup(f => f.GetDiagnosticLevel(It.IsAny<bool?>(), It.IsAny<ImmutableDictionary<string, string>>(), It.IsAny<DiagnosticLevel>())).CallBase();
+        factory.Setup(f => f.GetDiagnosticLevel(It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<ImmutableDictionary<string, string>>(), It.IsAny<DiagnosticLevel>())).CallBase();
 
         return new MSBuildDependencyCollection(factory.Object);
     }


### PR DESCRIPTION
A common user complaint is the appearance of yellow triangles in the dependencies tree with no explanation as to what is wrong or how to resolve the issue.

When a design-time build fails, the dependencies tree often shows all dependencies with a yellow triangle. This happens because the evaluated value was observed, but the resolved item is not found in the build results (due to the failure).

With the semi-recent rewrite of the dependencies tree, we're taking a more cautious approach to displaying these warnings. For example, we don't show yellow triangles during project load, instead waiting until it seems that there's really a reason for concern (i.e. we received build results and the item actually was missing).

This change here takes into account whether the build failed. When it does, no warning icons are added to items.

Ideally, design-time build failures would be surfaced elsewhere, such as in the error list. That work can be done separately.

---

Today I stumbled upon a repro for the above. A DDRITs solution in the VS repo (`ProjectSystemOpenClose.sln`) won't open in VS due to:

> MSB4019	The imported project "D:\build\Microsoft.CodeIndex.EnvVarDump.targets" was not found. Confirm that the expression in the Import declaration "\build\Microsoft.CodeIndex.EnvVarDump.targets" is correct, and that the file exists on disk.

That comes from this target:

```xml
  <Import
    Condition="'$(RichCodeNavTargetImported)'=='' AND '$(IsMSBuildRetail)' != 'true'"
    Project="$(PkgMicrosoft_CodeIndex_EnvVarDump)\build\Microsoft.CodeIndex.EnvVarDump.targets" />
```

The `PkgMicrosoft_CodeIndex_EnvVarDump` property is not defined, because the `Microsoft.CodeIndex.EnvVarDump` package is not referenced in this solution. The path it really wants is `D:\NuGetPackages\microsoft.codeindex.envvardump\0.1.2330-alpha-g5c81d269c8\build\Microsoft.CodeIndex.EnvVarDump.targets`.

So, given that DTB failure, here's the before/after:

## Before

![image](https://github.com/dotnet/project-system/assets/350947/73eedb63-8a12-4723-a960-8452f8e135cc)

## After

![image](https://github.com/dotnet/project-system/assets/350947/b88ad51c-39e7-4ba3-abfc-6c79216798f7)

In this case, the error impacts normal user-requested builds too, so it's obvious to the user that something is wrong with the solution. If it were a failure in a DTB-only target, for example, it wouldn't be possible to see the source of the error. We should surface DTB errors in the UI somewhere as a future improvement.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/dotnet/project-system/pull/9396)