### PR TITLE
Fix warning in .NET 8 code around serialization

### DIFF
--- a/tests/Common/ThrowingTraceListener.cs
+++ b/tests/Common/ThrowingTraceListener.cs
@@ -32,7 +32,9 @@ namespace Microsoft.VisualStudio.Diagnostics
         {
         }
 
+#if !NET8_0_OR_GREATER
         [Serializable]
+#endif
         public class DebugAssertFailureException : Exception
         {
             public DebugAssertFailureException()
@@ -47,9 +49,11 @@ namespace Microsoft.VisualStudio.Diagnostics
             {
             }
 
+#if !NET8_0_OR_GREATER
             protected DebugAssertFailureException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
Fixes the following warning in .NET 8 builds (currently only via the integration test project):

> tests\Common\ThrowingTraceListener.cs(50,101,50,122): warning SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9410)