### PR TITLE
Fix two compilation warnings in the solution

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
@@ -179,6 +179,7 @@ internal abstract class MSBuildDependencyFactoryBase : IMSBuildDependencyFactory
     /// Gets the <see cref="DiagnosticLevel"/> to set for a dependency, based on its resolved state and item properties.
     /// </summary>
     /// <param name="isResolved"><see langword="true"/> if the dependency is resolved, <see langword="false"/> if it is unresolved, or <see langword="null"/> if the status is not yet determined.</param>
+    /// <param name="hasBuildError">Whether the MSBuild invocation that produced this data also encountered an error or not.</param>
     /// <param name="properties">The properties of the item.</param>
     /// <param name="defaultLevel">The diagnostic level to use when the property is either missing or empty. Intended to receive a dependency's current diagnostic level when an evaluation-only update is being processed.</param>
     /// <returns></returns>

--- a/tests/Common/ThrowingTraceListener.cs
+++ b/tests/Common/ThrowingTraceListener.cs
@@ -32,7 +32,9 @@ namespace Microsoft.VisualStudio.Diagnostics
         {
         }
 
+#if !NET8_0_OR_GREATER
         [Serializable]
+#endif
         public class DebugAssertFailureException : Exception
         {
             public DebugAssertFailureException()
@@ -47,9 +49,11 @@ namespace Microsoft.VisualStudio.Diagnostics
             {
             }
 
+#if !NET8_0_OR_GREATER
             protected DebugAssertFailureException(SerializationInfo info, StreamingContext context) : base(info, context)
             {
             }
+#endif
         }
     }
 }


### PR DESCRIPTION
Fixes the following warning in .NET 8 builds (currently only via the integration test project):

> tests\Common\ThrowingTraceListener.cs(50,101,50,122): warning SYSLIB0051: 'Exception.Exception(SerializationInfo, StreamingContext)' is obsolete: 'This API supports obsolete formatter-based serialization. It should not be called or extended by application code.' (https://aka.ms/dotnet-warnings/SYSLIB0051)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9410)

Also fixes a missing parameter doc entry.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9411)