### PR TITLE
Use strongly-typed error reporter

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -74,18 +74,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 handled = await _workspaceWriter.WriteAsync(workspace =>
                 {
-                    var errorReporter = (IVsLanguageServiceBuildErrorReporter2)workspace.HostSpecificErrorReporter;
-
                     try
                     {
-                        errorReporter.ReportError2(details.Message,
-                                                   details.Code,
-                                                   details.Priority,
-                                                   details.LineNumberForErrorList,
-                                                   details.ColumnNumberForErrorList,
-                                                   details.EndLineNumberForErrorList,
-                                                   details.EndColumnNumberForErrorList,
-                                                   details.GetFileFullPath(_project.FullPath));
+                        workspace.ErrorReporter.ReportError2(
+                            details.Message,
+                            details.Code,
+                            details.Priority,
+                            details.LineNumberForErrorList,
+                            details.ColumnNumberForErrorList,
+                            details.EndLineNumberForErrorList,
+                            details.EndColumnNumberForErrorList,
+                            details.GetFileFullPath(_project.FullPath));
+
                         return TaskResult.True;
                     }
                     catch (NotImplementedException)
@@ -111,7 +111,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 await _workspaceWriter.WriteAsync(workspace =>
                 {
-                    ((IVsLanguageServiceBuildErrorReporter2)workspace.HostSpecificErrorReporter).ClearErrors();
+                    workspace.ErrorReporter.ClearErrors();
 
                     return Task.CompletedTask;
                 });

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/IWorkspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/IWorkspace.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -20,11 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
         IWorkspaceProjectContext Context { get; }
 
         /// <summary>
-        ///     Gets an object that represents a host-specific error reporter.
+        ///     Gets the language service build error reporter object.
         /// </summary>
-        /// <remarks>
-        ///     Within a Visual Studio host, this is typically an object implementing IVsLanguageServiceBuildErrorReporter2.
-        /// </remarks>
-        object HostSpecificErrorReporter { get; }
+        IVsLanguageServiceBuildErrorReporter2 ErrorReporter { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.OperationProgress;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
@@ -84,7 +85,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
     public string ContextId => _contextId ?? throw new InvalidOperationException("Workspace has not been initialized.");
 
-    public object HostSpecificErrorReporter => Context;
+    public IVsLanguageServiceBuildErrorReporter2 ErrorReporter => (IVsLanguageServiceBuildErrorReporter2)Context;
 
     #endregion
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceMockFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceMockFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.LanguageServices.ProjectSystem;
+using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
 {
@@ -29,11 +30,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return mock.Object;
         }
 
-        public static IWorkspace ImplementHostSpecificErrorReporter(Func<object> action)
+        public static IWorkspace ImplementErrorReporter(Func<IVsLanguageServiceBuildErrorReporter2> action)
         {
             var mock = new Mock<IWorkspace>();
 
-            mock.SetupGet(c => c.HostSpecificErrorReporter)
+            mock.SetupGet(c => c.ErrorReporter)
                 .Returns(action);
 
             return mock.Object;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceWriterFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceWriterFactory.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
@@ -18,9 +19,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices
             return new WorkspaceWriter(workspace);
         }
 
-        public static IWorkspaceWriter ImplementHostSpecificErrorReporter(Func<object> func)
+        public static IWorkspaceWriter ImplementErrorReporter(Func<IVsLanguageServiceBuildErrorReporter2> func)
         {
-            var workspace = IWorkspaceMockFactory.ImplementHostSpecificErrorReporter(func);
+            var workspace = IWorkspaceMockFactory.ImplementErrorReporter(func);
 
             return new WorkspaceWriter(workspace);
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/LanguageServiceErrorListProviderTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public void ClearAllAsync_WhenNoHostSpecificErrorReporter_ReturnsCompletedTask()
+        public void ClearAllAsync_WhenNoErrorReporter_ReturnsCompletedTask()
         {
             var provider = CreateInstance();
 
@@ -33,7 +33,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public void ClearMessageFromTargetAsync_WhenNoHostSpecificErrorReporter_ReturnsCompletedTask()
+        public void ClearMessageFromTargetAsync_WhenNoErrorReporter_ReturnsCompletedTask()
         {
             var provider = CreateInstance();
 
@@ -43,11 +43,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async Task ClearAllAsync_WhenHostSpecificErrorReporter_CallsClearErrors()
+        public async Task ClearAllAsync_WhenErrorReporter_CallsClearErrors()
         {
             int callCount = 0;
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementClearErrors(() => { callCount++; return 0; });
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var task = CreateDefaultTask();
             var provider = CreateInstance(host);
 
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async Task AddMessageAsync_WhenNoHostSpecificErrorReporter_ReturnsNotHandled()
+        public async Task AddMessageAsync_WhenNoErrorReporter_ReturnsNotHandled()
         {
             var provider = CreateInstance();
 
@@ -106,14 +106,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async Task AddMessageAsync_WhenHostSpecificErrorReporterThrowsNotImplemented_ReturnsNotHandled()
+        public async Task AddMessageAsync_WhenErrorReporterThrowsNotImplemented_ReturnsNotHandled()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) =>
             {
                 throw new NotImplementedException();
             });
 
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host);
             var task = CreateDefaultTask();
 
@@ -123,14 +123,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         }
 
         [Fact]
-        public async Task AddMessageAsync_WhenHostSpecificErrorReporterThrows_Throws()
+        public async Task AddMessageAsync_WhenErrorReporterThrows_Throws()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) =>
             {
                 throw new Exception();
             });
 
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host);
             var task = CreateDefaultTask();
 
@@ -144,7 +144,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         public async Task AddMessageAsync_ReturnsHandledAndStopProcessing()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => { });
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host);
             var task = CreateDefaultTask();
 
@@ -161,7 +161,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 result = nPriority;
             });
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host);
 
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildWarningEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender")));
@@ -177,7 +177,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 result = nPriority;
             });
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host);
 
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender")));
@@ -193,7 +193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
             {
                 result = nPriority;
             });
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host);
 
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new CriticalBuildMessageEventArgs(null, "Code", "File", 1, 1, 1, 1, "Message", "HelpKeyword", "Sender")));
@@ -220,7 +220,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 errorIdResult = bstrErrorId;
             });
 
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, code, "File", 0, 0, 0, 0, errorMessage, "HelpKeyword", "Sender")));
@@ -250,7 +250,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 columnResult = iColumn;
             });
 
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", lineNumber, columnNumber, 0, 0, "ErrorMessage", "HelpKeyword", "Sender")));
@@ -281,7 +281,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 endColumnResult = iEndColumn;
             });
 
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
             await provider.AddMessageAsync(new TargetGeneratedError("Test", new BuildErrorEventArgs(null, "Code", "File", lineNumber, columnNumber, endLineNumber, endColumnNumber, "ErrorMessage", "HelpKeyword", "Sender")));
@@ -314,7 +314,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
                 fileNameResult = bstrFileName;
             });
 
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
 
             var provider = CreateInstance(host);
 
@@ -331,7 +331,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build
         public async Task AddMessageAsync_WithLspPullDiagnosticsEnabled_ReturnsNotHandled()
         {
             var reporter = IVsLanguageServiceBuildErrorReporter2Factory.ImplementReportError((string bstrErrorMessage, string bstrErrorId, VSTASKPRIORITY nPriority, int iLine, int iColumn, int iEndLine, int iEndColumn, string bstrFileName) => { });
-            var host = IWorkspaceWriterFactory.ImplementHostSpecificErrorReporter(() => reporter);
+            var host = IWorkspaceWriterFactory.ImplementErrorReporter(() => reporter);
             var provider = CreateInstance(host, lspPullDiagnosticsFeatureFlag: true);
             var task = CreateDefaultTask();
 


### PR DESCRIPTION
Historically, the `IWorkspace` type was in the host-agnostic layer, meaning that the error-reporing type was specific to the host. Since the introduction of C# DevKit, `IWorkspace` moved into the VS layer, and we no longer need this property to be of type `object`. Instead, it can be typed as `IVsLanguageServiceBuildErrorReporter2`, which simplifies consuming code.

NOTE there's a bunch more layer-change tidying that could be done here, but we'd want to validate it wouldn't impact C# DevKit first. cc @tmeschter to validate that this change is safe there.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9412)