### PR TITLE
Update repo documentation to reference Policy Service instead of FabricBot

### DIFF
--- a/.github/ISSUE_TEMPLATE/branch-checklist.md
+++ b/.github/ISSUE_TEMPLATE/branch-checklist.md
@@ -27,4 +27,4 @@ _Descriptions of these steps can be found in the team OneNote._
 - [ ] In the new branch, update the "Build VS Bootstrapper" task in [build-official-release.yml](https://github.com/dotnet/project-system/blob/main/eng/pipelines/templates/build-official-release.yml) and set `channelName` to match the VS insertion branch.
   - E.g., for VS `main` the `channelName` is "int.main"; for `rel/d17.8` it would be "int.d17.8"; etc.
 - [ ] To run manual insertions, use the [DotNet-Project-System pipeline](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=9675&_a=summary). Enter the GitHub branch as _Branch/tag_, the VS branch as _VS Insertion Branch Name_, and check _Create VS Insertion PR_.
-- [ ] Update [MSFTBot milestone tracking](https://aka.ms/fabricbotconfig)
+- [ ] Update [Policy Service milestone tracking](https://github.com/dotnet/project-system/blob/main/.github/policies)


### PR DESCRIPTION
This is follow-up to https://github.com/dotnet/project-system/pull/9387
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9414)