### PR TITLE
Use production OptProf tooling

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -50,6 +50,8 @@ resources:
   - pipeline: DartLab.OptProf
     source: DartLab.OptProf
     branch: main
+    tags:
+    - production
   repositories:
   # This name is the default value for the 'dartLabTemplatesResourceName 'parameter in single-runsettings.yml.
   - repository: DartLabTemplates
@@ -60,7 +62,7 @@ resources:
   - repository: DartLabOptProfTemplates
     name: DartLab.OptProf
     type: git
-    ref: refs/heads/main
+    ref: refs/tags/Production
   # This repo is used to create the insertion PR into the vs-green repo.
   - repository: VSCodeExtensionRepo
     type: git


### PR DESCRIPTION
We pick up certain pipeline templates providing OptProf functionality from the DartLab.OptProf repository. Currently we get these from the "main" branch of that repo, but as with other repos "main" is the bleeding edge of OptProf changes. This potentially exposes us to bugs and instability.

Instead we want to use the "Production" tag rather than the latest main. This should be better tested and more stable.

This is based on
https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/515949.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9418)