### PR TITLE
Upgrade packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,7 +48,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.4.0-preview-2-32826-307" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.7.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.10.3-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.2.2146" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.3.32804.24" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning"                                                 Version="3.6.79-alpha" />
     <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.10.69" />
-    <PackageVersion Include="System.IO.Pipelines"                                                    Version="7.0.0" />
+    <PackageVersion Include="System.IO.Pipelines"                                                    Version="8.0.0" />
 
     <!-- VS SDK -->
     <!-- https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk -->
@@ -37,7 +37,7 @@
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.3.32804.24" />
     <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.3.57" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.3.198" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.18" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.29" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -80,7 +80,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.8.0-3.final" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.8.0-3.final" />
     <PackageVersion Include="Microsoft.CSharp"                                                       Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.10.0-3.24157.9" />
     <PackageVersion Include="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
     <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.8.0-3.final" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -656,7 +656,7 @@
     <ItemGroup>
       <NpmContent Include="exports.json" />
       <!-- We have a runtime dependency on Microsoft.CodeAnalysis.dll in VS Code scenarios. -->
-      <NpmContent Include="$(PkgMicrosoft_CodeAnalysis_Common)\lib\net6.0\Microsoft.CodeAnalysis.dll" />
+      <NpmContent Include="$(PkgMicrosoft_CodeAnalysis_Common)\lib\net7.0\Microsoft.CodeAnalysis.dll" />
       <NpmContent Include="@(SatelliteDllsProjectOutputGroupOutput)">
         <PackagePath>%(SatelliteDllsProjectOutputGroupOutput.TargetPath)</PackagePath>
       </NpmContent>


### PR DESCRIPTION
Parallel work is attempting to bump Roslyn packages, but hitting failures. Here we make a few upgrades in an attempt to isolate the cause of those issues.

---

Bump some package versions.

Also, the particular version of the `Microsoft.CodeAnalysis` package we reference includes both `net6.0` and `net7.0` versions. Here we bump the one we reference, so that we're using the latest version available.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9429)