### PR TITLE
FUTDC detects changes to Pack items

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -443,7 +443,7 @@
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
   <PropertyGroup Condition="'$(CollectUpToDateCheckInputDesignTimeDependsOn)' == ''">
-    <CollectUpToDateCheckInputDesignTimeDependsOn>CompileDesignTime</CollectUpToDateCheckInputDesignTimeDependsOn>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>CompileDesignTime;_GetPackageFiles</CollectUpToDateCheckInputDesignTimeDependsOn>
     <!-- F# projects do not have the ResolveCodeAnalysisRuleSet target. -->
     <CollectUpToDateCheckInputDesignTimeDependsOn Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'">$(CollectUpToDateCheckInputDesignTimeDependsOn);ResolveCodeAnalysisRuleSet</CollectUpToDateCheckInputDesignTimeDependsOn>
   </PropertyGroup>
@@ -455,6 +455,8 @@
       <UpToDateCheckInput Condition=" '$(ApplicationManifest)' != '' " Include="$(ApplicationManifest)" />
       <!-- .ruleset file, if any -->
       <UpToDateCheckInput Condition=" '$(ResolvedCodeAnalysisRuleSet)' != '' " Include="$(ResolvedCodeAnalysisRuleSet)" />
+      <!-- Items that would be packaged during build. Note that we cannot condition this on GeneratePackageOnBuild as this property is forced to false during design-time builds via GeneratePackageOnBuildDesignTimeBuildPropertyProvider. -->
+      <UpToDateCheckInput Include="@(_PackageFiles)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Fixes #9433

When a project specifies `GeneratePackageOnBuild`, additional items must become inputs to the FUTDC. Without this, it's possible to change a `Content` item, for example, that has `Pack="true"` metadata, and not have those changes included in the generated NuGet package during builds.

This change includes all the items that NuGet would include in the package as inputs to the FUTDC.

Note that ideally we would only include these items when `GeneratePackageOnBuild` was `true`, however we force the property to `false` during design-time builds in `GeneratePackageOnBuildDesignTimeBuildPropertyProvider`, so instead we add these items unconditionally. It's possible that this could trigger a few extra builds for some uncommon project configurations, but that seems unlikely and is better than failing to build correctly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9437)