### PR TITLE
The look-up table for intecepting providers can be shared, instead of…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
@@ -6,20 +6,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     /// An intercepting project properties provider that validates and/or transforms the default <see cref="IProjectProperties"/>
     /// using the exported <see cref="IInterceptingPropertyValueProvider"/>s.
     /// </summary>
-    internal abstract class InterceptedProjectPropertiesProviderBase : DelegatedProjectPropertiesProviderBase
+    internal abstract class InterceptedProjectPropertiesProviderBase : InterceptedPropertiesProviderBase
     {
         private readonly UnconfiguredProject _project;
-        private readonly ImmutableArray<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> _interceptingValueProviders;
 
         protected InterceptedProjectPropertiesProviderBase(
             IProjectPropertiesProvider provider,
             IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
             IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
-            : base(provider, instanceProvider, project)
+            : base(provider, instanceProvider, project, interceptingValueProviders)
         {
             _project = project;
-            _interceptingValueProviders = interceptingValueProviders.ToImmutableArray();
         }
 
         public override IProjectProperties GetProperties(string file, string? itemType, string? item)
@@ -30,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         protected IProjectProperties InterceptProperties(IProjectProperties defaultProperties)
         {
-            return _interceptingValueProviders.IsDefaultOrEmpty ? defaultProperties : new InterceptedProjectProperties(_interceptingValueProviders, defaultProperties, _project);
+            return HasInterceptingValueProvider ? new InterceptedProjectProperties(this, defaultProperties, _project) : defaultProperties;
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
@@ -1,0 +1,86 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem.Properties
+{
+    /// <summary>
+    /// An intercepting project properties provider that validates and/or transforms the default <see cref="IProjectProperties"/>
+    /// using the exported <see cref="IInterceptingPropertyValueProvider"/>s.
+    /// </summary>
+    internal class InterceptedPropertiesProviderBase : DelegatedProjectPropertiesProviderBase
+    {
+        private readonly Dictionary<string, Providers> _interceptingValueProviders = new(StringComparers.PropertyNames);
+
+        protected InterceptedPropertiesProviderBase(
+            IProjectPropertiesProvider provider,
+            IProjectInstancePropertiesProvider instanceProvider,
+            UnconfiguredProject project,
+            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            : base(provider, instanceProvider, project)
+        {
+            Requires.NotNullOrEmpty(interceptingValueProviders);
+
+            foreach (Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider in interceptingValueProviders)
+            {
+                string[] propertyNames = valueProvider.Metadata.PropertyNames;
+
+                foreach (string propertyName in propertyNames)
+                {
+                    Requires.Argument(!string.IsNullOrEmpty(propertyName), nameof(valueProvider), "A null or empty property name was found");
+
+                    if (!_interceptingValueProviders.TryGetValue(propertyName, out Providers? entry))
+                    {
+                        entry = new Providers(new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> { valueProvider });
+                        _interceptingValueProviders.Add(propertyName, entry);
+                    }
+
+                    entry.Exports.Add(valueProvider);
+                }
+            }
+        }
+
+        protected bool HasInterceptingValueProvider => _interceptingValueProviders.Count > 0;
+
+        internal bool TryGetInterceptingValueProvider(string propertyName, [NotNullWhen(returnValue: true)] out Providers? propertyValueProviders)
+        {
+            return _interceptingValueProviders.TryGetValue(propertyName, out propertyValueProviders);
+        }
+    }
+
+    internal class Providers
+    {
+        public Providers(List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> exports)
+        {
+            Exports = exports;
+        }
+
+        public List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> Exports { get; private set; }
+
+        public IInterceptingPropertyValueProvider? GetFilteredProvider(
+            string propertyName,
+            Func<string, bool> appliesToEvaluator)
+        {
+            // todo consider caching this based on capability
+            var foundExports = Exports.Where(lazyProvider =>
+            {
+                string? appliesToExpression = lazyProvider.Value.GetType()
+                    .GetCustomAttributes(typeof(AppliesToAttribute), inherit: true)
+                    .OfType<AppliesToAttribute>()
+                    .FirstOrDefault()?.AppliesTo;
+
+                return appliesToExpression is null || appliesToEvaluator(appliesToExpression);
+            })
+                .GroupBy(x => x.Value.GetType()) // in case we end up importing multiple of the same provider, which *has happened with TargetFrameworkMoniker* 
+                .Select(x => x.First())
+                .ToList();
+
+            return foundExports.Count switch
+            {
+                0 => null,
+                1 => foundExports.First().Value,
+                _ => throw new ArgumentException($"Duplicate property value providers for same property name: {propertyName}")
+            };
+        }
+    }
+}


### PR DESCRIPTION
… being created on every InterceptProperties.

It is basically a MEF extension look-up table. Ideally, it could be shared among projects, but we can at least share the dictionary within a project with little changes.

The problem is that the product would create one InterceptProperties for almost every property, just to read the value, and it throws away the instance immediately, and create a new one for another property. Recreating the dicitonary becomes a heavy cost during solution loading time
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9439)