### PR TITLE
Further fixes in intercept provider supporting code

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/ProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         public ProjectFileOrAssemblyInfoPropertiesProvider(
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectPropertiesProvider delegatedProvider,
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
-            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders,
+            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders,
             UnconfiguredProject project,
             IWorkspaceWriter workspaceWriter,
             VisualStudioWorkspace workspace,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/AssemblyAttributeProperties/AbstractProjectFileOrAssemblyInfoPropertiesProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         protected AbstractProjectFileOrAssemblyInfoPropertiesProvider(
             IProjectPropertiesProvider delegatedProvider,
             IProjectInstancePropertiesProvider instanceProvider,
-            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders,
+            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders,
             UnconfiguredProject project,
             Func<ProjectId?> getActiveProjectId,
             Workspace workspace,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     /// <summary>
@@ -14,6 +16,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         /// This must match <see cref="ExportInterceptingPropertyValueProviderAttribute.PropertyNames" />.
         /// </summary>
         string[] PropertyNames { get; }
+
+        /// <summary>
+        /// Gets the expression that indicates where this export should be applied.
+        /// </summary>
+        [DefaultValue(null)]
+        string? AppliesTo { get; }
 
 #pragma warning restore CA1819 // Properties should not return arrays
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata2.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/IInterceptingPropertyValueProviderMetadata2.cs
@@ -1,20 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.ComponentModel;
+
 namespace Microsoft.VisualStudio.ProjectSystem.Properties
 {
     /// <summary>
     /// Metadata mapping interface for the <see cref="ExportInterceptingPropertyValueProviderAttribute"/>.
     /// </summary>
-    public interface IInterceptingPropertyValueProviderMetadata
+    internal interface IInterceptingPropertyValueProviderMetadata2 : IInterceptingPropertyValueProviderMetadata
     {
-#pragma warning disable CA1819 // Properties should not return arrays
-
         /// <summary>
-        /// Property names handled by the provider.
-        /// This must match <see cref="ExportInterceptingPropertyValueProviderAttribute.PropertyNames" />.
+        /// Gets the expression that indicates where this export should be applied.
         /// </summary>
-        string[] PropertyNames { get; }
-
-#pragma warning restore CA1819 // Properties should not return arrays
+        [DefaultValue(null)]
+        string? AppliesTo { get; }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedProjectPropertiesProviderBase.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectPropertiesProvider provider,
             IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
-            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders)
             : base(provider, instanceProvider, project, interceptingValueProviders)
         {
             _project = project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
@@ -36,10 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     }
                     else
                     {
-                    entry.Exports.Add(valueProvider);
+                        entry.Exports.Add(valueProvider);
+                    }
                 }
             }
-        }
         }
 
         protected bool HasInterceptingValueProvider => _interceptingValueProviders.Count > 0;
@@ -64,15 +64,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             Func<string, bool> appliesToEvaluator)
         {
             // todo consider caching this based on capability
-            var foundExports = Exports.Where(lazyProvider =>
-            {
-                string? appliesToExpression = lazyProvider.Value.GetType()
-                    .GetCustomAttributes(typeof(AppliesToAttribute), inherit: true)
-                    .OfType<AppliesToAttribute>()
-                    .FirstOrDefault()?.AppliesTo;
-
-                return appliesToExpression is null || appliesToEvaluator(appliesToExpression);
-            })
+            var foundExports = Exports
+                .Where(lazyProvider =>
+                    {
+                        string? appliesToExpression = lazyProvider.Metadata.AppliesTo;
+                        return appliesToExpression is null || appliesToEvaluator(appliesToExpression);
+                    })
                 .GroupBy(x => x.Value.GetType()) // in case we end up importing multiple of the same provider, which *has happened with TargetFrameworkMoniker* 
                 .Select(x => x.First())
                 .ToList();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
@@ -34,10 +34,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                         entry = new Providers(new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> { valueProvider });
                         _interceptingValueProviders.Add(propertyName, entry);
                     }
-
+                    else
+                    {
                     entry.Exports.Add(valueProvider);
                 }
             }
+        }
         }
 
         protected bool HasInterceptingValueProvider => _interceptingValueProviders.Count > 0;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptedPropertiesProviderBase.cs
@@ -16,12 +16,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             IProjectPropertiesProvider provider,
             IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
-            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders)
             : base(provider, instanceProvider, project)
         {
             Requires.NotNullOrEmpty(interceptingValueProviders);
 
-            foreach (Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> valueProvider in interceptingValueProviders)
+            foreach (Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2> valueProvider in interceptingValueProviders)
             {
                 string[] propertyNames = valueProvider.Metadata.PropertyNames;
 
@@ -31,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
                     if (!_interceptingValueProviders.TryGetValue(propertyName, out Providers? entry))
                     {
-                        entry = new Providers(new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>>(1) { valueProvider });
+                        entry = new Providers(new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>>(1) { valueProvider });
                         _interceptingValueProviders.Add(propertyName, entry);
                     }
                     else
@@ -52,12 +52,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
     internal class Providers
     {
-        public Providers(List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> exports)
+        public Providers(List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> exports)
         {
             Exports = exports;
         }
 
-        public List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> Exports { get; }
+        public List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> Exports { get; }
 
         public IInterceptingPropertyValueProvider? GetFilteredProvider(
             string propertyName,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedProjectPropertiesProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectPropertiesProvider provider,
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
-            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders)
             : base(provider, instanceProvider, project, interceptingValueProviders)
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedViaSnapshotProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ProjectFileInterceptedViaSnapshotProjectPropertiesProvider.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectPropertiesProvider provider,
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
-            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            [ImportMany(ContractNames.ProjectPropertyProviders.ProjectFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders)
             : base(provider, instanceProvider, project, interceptingValueProviders)
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileInterceptedProjectPropertiesProvider.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             // provider as the ProjectFile, and is exported as the ProjectFile provider.
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
-            [ImportMany(ContractNames.ProjectPropertyProviders.UserFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            [ImportMany(ContractNames.ProjectPropertyProviders.UserFile)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders)
             : base(provider, instanceProvider, project, interceptingValueProviders)
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/UserFileWithXamlDefaultsInterceptedProjectPropertiesProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             // provider as the ProjectFile, and is exported as the ProjectFile provider.
             [Import(ContractNames.ProjectPropertyProviders.ProjectFile)] IProjectInstancePropertiesProvider instanceProvider,
             UnconfiguredProject project,
-            [ImportMany(ContractNames.ProjectPropertyProviders.UserFileWithXamlDefaults)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>> interceptingValueProviders)
+            [ImportMany(ContractNames.ProjectPropertyProviders.UserFileWithXamlDefaults)]IEnumerable<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>> interceptingValueProviders)
             : base(provider, instanceProvider, project, interceptingValueProviders)
         {
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -193,4 +193,3 @@ static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Dependenc
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.SupportsFolderBrowse -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.SupportsRemove -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.UnresolvedDependencyFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
-Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.AppliesTo.get -> string?

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -193,3 +193,4 @@ static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Dependenc
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.SupportsFolderBrowse -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.SupportsRemove -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.UnresolvedDependencyFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
+Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.AppliesTo.get -> string?

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -187,3 +187,4 @@ static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Dependenc
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.SupportsRemove -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.UnresolvedDependencyFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.DependenciesChangedEventArgs.DependenciesChangedEventArgs(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.IProjectDependenciesSubTreeProvider provider, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.IDependenciesChanges changes, System.Threading.CancellationToken token) -> void
+Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.AppliesTo.get -> string?

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -187,4 +187,3 @@ static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Dependenc
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.SupportsRemove -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 static readonly Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.DependencyTreeFlags.UnresolvedDependencyFlags -> Microsoft.VisualStudio.ProjectSystem.ProjectTreeFlags
 Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.DependenciesChangedEventArgs.DependenciesChangedEventArgs(Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.IProjectDependenciesSubTreeProvider provider, Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.IDependenciesChanges changes, System.Threading.CancellationToken token) -> void
-Microsoft.VisualStudio.ProjectSystem.Properties.IInterceptingPropertyValueProviderMetadata.AppliesTo.get -> string?

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderFactory.cs
@@ -44,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock.Object;
         }
 
-        public static Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata> Create(
+        public static Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2> Create(
             string propertyName,
             Func<string, IProjectProperties, string>? onGetEvaluatedPropertyValue = null,
             Func<string, IProjectProperties, string>? onGetUnevaluatedPropertyValue = null,
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             var mockMetadata = IInterceptingPropertyValueProviderMetadataFactory.Create(propertyName);
             var mockProvider = Create(onGetEvaluatedPropertyValue, onGetUnevaluatedPropertyValue, onSetPropertyValue);
-            return new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(() => mockProvider, mockMetadata);
+            return new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(() => mockProvider, mockMetadata);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
@@ -6,9 +6,9 @@ namespace Microsoft.VisualStudio.ProjectSystem
 {
     internal static class IInterceptingPropertyValueProviderMetadataFactory
     {
-        public static IInterceptingPropertyValueProviderMetadata Create(string propertyName)
+        public static IInterceptingPropertyValueProviderMetadata2 Create(string propertyName)
         {
-            var mock = new Mock<IInterceptingPropertyValueProviderMetadata>();
+            var mock = new Mock<IInterceptingPropertyValueProviderMetadata2>();
 
             mock.SetupGet(s => s.PropertyNames)
                 .Returns(new[] { propertyName });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
     {
         public TestProjectFileOrAssemblyInfoPropertiesProvider(
             UnconfiguredProject? project = null,
-            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? interceptingProvider = null,
+            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>? interceptingProvider = null,
             Workspace? workspace = null,
             IProjectThreadingService? threadingService = null,
             IProjectProperties? defaultProperties = null,
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         public TestProjectFileOrAssemblyInfoPropertiesProvider(
             Workspace workspace,
             UnconfiguredProject project,
-            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? interceptingProvider = null,
+            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>? interceptingProvider = null,
             IProjectThreadingService? threadingService = null,
             IProjectProperties? defaultProperties = null,
             IProjectInstancePropertiesProvider? instanceProvider = null,
@@ -37,7 +37,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             : base(delegatedProvider: IProjectPropertiesProviderFactory.Create(defaultProperties ?? IProjectPropertiesFactory.MockWithProperty("").Object),
                   instanceProvider: instanceProvider ?? IProjectInstancePropertiesProviderFactory.Create(),
                   interceptingValueProviders: interceptingProvider is null
-                    ? new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
+                    ? new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
                         () => IInterceptingPropertyValueProviderFactory.Create(),
                         IInterceptingPropertyValueProviderMetadataFactory.Create("TestPropertyName")) }
                     : new[] { interceptingProvider },
@@ -56,7 +56,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private static TestProjectFileOrAssemblyInfoPropertiesProvider CreateProviderForSourceFileValidation(
             string code,
             out Workspace workspace,
-            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? interceptingProvider = null,
+            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>? interceptingProvider = null,
             Dictionary<string, string?>? additionalProps = null)
         {
             var language = code.Contains("[") ? LanguageNames.CSharp : LanguageNames.VisualBasic;
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             string propertyName,
             string propertyValueInProjectFile,
             out Workspace workspace,
-            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>? interceptingProvider = null,
+            Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>? interceptingProvider = null,
             Dictionary<string, string?>? additionalProps = null)
         {
             var language = code.Contains("[") ? LanguageNames.CSharp : LanguageNames.VisualBasic;
@@ -279,7 +279,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal async Task SourceFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType is not null
-                ? new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
+                ? new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
                     valueFactory: () => (IInterceptingPropertyValueProvider)Activator.CreateInstance(interceptingProviderType),
                     metadata: IInterceptingPropertyValueProviderMetadataFactory.Create(propertyName))
                 : null;
@@ -353,7 +353,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         internal async Task ProjectFileProperties_WithInterception_SetEvaluatedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType is not null
-                ? new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
+                ? new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
                     valueFactory: () => (IInterceptingPropertyValueProvider)Activator.CreateInstance(interceptingProviderType),
                     metadata: IInterceptingPropertyValueProviderMetadataFactory.Create(propertyName))
                 : null;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/AssemblyOriginatorKeyFileValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/AssemblyOriginatorKeyFileValueProviderTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.ProjectPropertiesProviders
             var delegateProvider = IProjectPropertiesProviderFactory.Create();
             var keyFileProvider = new AssemblyOriginatorKeyFileValueProvider(project);
             var providerMetadata = IInterceptingPropertyValueProviderMetadataFactory.Create(AssemblyOriginatorKeyFilePropertyName);
-            var lazyArray = new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
+            var lazyArray = new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
                 () => keyFileProvider, providerMetadata) };
             var interceptedProvider = new ProjectFileInterceptedViaSnapshotProjectPropertiesProvider(delegateProvider, instanceProvider, project, lazyArray);
             var propertyNames = await properties.GetPropertyNamesAsync();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/InterceptedProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/InterceptedProjectPropertiesTests.cs
@@ -12,13 +12,13 @@ public class InterceptedProjectPropertiesTests
     [Fact]
     public void InterceptedProjectProperties_GetValueProviderBasedOnCapability_WithNonEmptyAndEmptyAppliesTo()
     {
-        var mockProviderMetadata = new Mock<IInterceptingPropertyValueProviderMetadata>();
+        var mockProviderMetadata = new Mock<IInterceptingPropertyValueProviderMetadata2>();
         mockProviderMetadata.Setup(x => x.PropertyNames).Returns(new[] { MockPropertyName });
         var metadata = mockProviderMetadata.Object;
 
         var providersWithEmptyAndNonEmptyAppliesTo =
             new Providers(
-                new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>>
+                new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>>
                 {
                     new(() => new MockPropertyFilteredInterceptor1(), metadata),
                     new(() => new MockPropertyFilteredInterceptor2(), metadata),
@@ -33,7 +33,7 @@ public class InterceptedProjectPropertiesTests
         Assert.Equal(typeof(MockPropertyFilteredInterceptor3), providersWithEmptyAndNonEmptyAppliesTo.GetFilteredProvider(MockPropertyName, AppliesToFunction(Capability3))?.GetType());
 
         var providersWithNonEmptyAppliesTo = new Providers(
-            new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>>
+            new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>>
             {
                 new(() => new MockPropertyFilteredInterceptor1(), metadata), 
                 new(() => new MockPropertyFilteredInterceptor2(), metadata)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/InterceptedProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/InterceptedProjectPropertiesTests.cs
@@ -12,17 +12,24 @@ public class InterceptedProjectPropertiesTests
     [Fact]
     public void InterceptedProjectProperties_GetValueProviderBasedOnCapability_WithNonEmptyAndEmptyAppliesTo()
     {
-        var mockProviderMetadata = new Mock<IInterceptingPropertyValueProviderMetadata2>();
-        mockProviderMetadata.Setup(x => x.PropertyNames).Returns(new[] { MockPropertyName });
-        var metadata = mockProviderMetadata.Object;
+        var metadataCollection = new IInterceptingPropertyValueProviderMetadata2[3];
+        var capabilities = new string?[] { Capability1, Capability2, null };
+
+        for (int i = 0; i < capabilities.Length; i++)
+        {
+            var mockProviderMetadata = new Mock<IInterceptingPropertyValueProviderMetadata2>();
+            mockProviderMetadata.Setup(x => x.PropertyNames).Returns(new[] { MockPropertyName });
+            mockProviderMetadata.Setup(x => x.AppliesTo).Returns(capabilities[i]);
+            metadataCollection[i] = mockProviderMetadata.Object;
+        }
 
         var providersWithEmptyAndNonEmptyAppliesTo =
             new Providers(
                 new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>>
                 {
-                    new(() => new MockPropertyFilteredInterceptor1(), metadata),
-                    new(() => new MockPropertyFilteredInterceptor2(), metadata),
-                    new(() => new MockPropertyFilteredInterceptor3(), metadata)
+                    new(() => new MockPropertyFilteredInterceptor1(), metadataCollection[0]),
+                    new(() => new MockPropertyFilteredInterceptor2(), metadataCollection[1]),
+                    new(() => new MockPropertyFilteredInterceptor3(), metadataCollection[2])
                 });
       
         Assert.Throws<ArgumentException>(() =>
@@ -35,8 +42,8 @@ public class InterceptedProjectPropertiesTests
         var providersWithNonEmptyAppliesTo = new Providers(
             new List<Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>>
             {
-                new(() => new MockPropertyFilteredInterceptor1(), metadata), 
-                new(() => new MockPropertyFilteredInterceptor2(), metadata)
+                new(() => new MockPropertyFilteredInterceptor1(), metadataCollection[0]), 
+                new(() => new MockPropertyFilteredInterceptor2(), metadataCollection[1])
             });
         
         Assert.Equal(typeof(MockPropertyFilteredInterceptor1), providersWithNonEmptyAppliesTo.GetFilteredProvider(MockPropertyName, AppliesToFunction(Capability1))?.GetType());

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/TargetFrameworkValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/TargetFrameworkValueProviderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.ProjectPropertiesProviders
 
             var targetFrameworkProvider = new TargetFrameworkValueProvider(properties);
             var providerMetadata = IInterceptingPropertyValueProviderMetadataFactory.Create(TargetFrameworkPropertyName);
-            var lazyArray = new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata>(
+            var lazyArray = new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
                 () => targetFrameworkProvider, providerMetadata) };
             return new ProjectFileInterceptedViaSnapshotProjectPropertiesProvider(delegateProvider, instanceProvider, project, lazyArray);
         }


### PR DESCRIPTION
This PR is to address further issues showing in performance traces.

Due to the code is in the hot path to load solution, some further works:

1, first export was added twice in the list, which might be the reason of complex LINQ code later. This PR fixes the issue, but I keep the original LINQ code just to prevent changing behaviors.

2, Use MEF metadata instead of reflection APIs. MEF can cache strings efficiently, while reflection is slow, and also the code would load components then checking the capabilities, which is incorrect.

3, prevent using LINQ in this hot path, i updated it to a normal loop.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9447)