### PR TITLE
Revert "FUTDC detects changes to Pack items"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -443,7 +443,7 @@
   <Target Name="CollectResolvedCompilationReferencesDesignTime" DependsOnTargets="CompileDesignTime" Returns="@(ReferencePathWithRefAssemblies)" />
 
   <PropertyGroup Condition="'$(CollectUpToDateCheckInputDesignTimeDependsOn)' == ''">
-    <CollectUpToDateCheckInputDesignTimeDependsOn>CompileDesignTime;_GetPackageFiles</CollectUpToDateCheckInputDesignTimeDependsOn>
+    <CollectUpToDateCheckInputDesignTimeDependsOn>CompileDesignTime</CollectUpToDateCheckInputDesignTimeDependsOn>
     <!-- F# projects do not have the ResolveCodeAnalysisRuleSet target. -->
     <CollectUpToDateCheckInputDesignTimeDependsOn Condition="'$(Language)' == 'C#' or '$(Language)' == 'VB'">$(CollectUpToDateCheckInputDesignTimeDependsOn);ResolveCodeAnalysisRuleSet</CollectUpToDateCheckInputDesignTimeDependsOn>
   </PropertyGroup>
@@ -455,8 +455,6 @@
       <UpToDateCheckInput Condition=" '$(ApplicationManifest)' != '' " Include="$(ApplicationManifest)" />
       <!-- .ruleset file, if any -->
       <UpToDateCheckInput Condition=" '$(ResolvedCodeAnalysisRuleSet)' != '' " Include="$(ResolvedCodeAnalysisRuleSet)" />
-      <!-- Items that would be packaged during build. Note that we cannot condition this on GeneratePackageOnBuild as this property is forced to false during design-time builds via GeneratePackageOnBuildDesignTimeBuildPropertyProvider. -->
-      <UpToDateCheckInput Include="@(_PackageFiles)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Reverts dotnet/project-system#9437

This is causing issues:

1. Some projects are seeing errors about a missing `_GetPackageFiles` target.
2. It can lead to overbuild (see comments in the original issue which has since been re-openend).

I'll take another swing at this shortly.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9450)