### PR TITLE
Increase concurrency of unit tests

### DIFF
--- a/ProjectSystem.sln
+++ b/ProjectSystem.sln
@@ -41,6 +41,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7349958E
 		tests\.editorconfig = tests\.editorconfig
 		tests\Directory.Build.props = tests\Directory.Build.props
 		tests\Directory.Build.targets = tests\Directory.Build.targets
+		Shared.cs = Shared.cs
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1FF0293B-6808-4BB1-8370-1FE222986654}"

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.cs" Link="Shared.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
   </ItemGroup>
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.cs" Link="Shared.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests" />
   </ItemGroup>
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Shared.cs" Link="Shared.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\setup\ProjectSystemSetup\ProjectSystemSetup.csproj" ReferenceOutputAssembly="false" />
     <ProjectReference Include="..\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests\Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed.VS\Microsoft.VisualStudio.ProjectSystem.Managed.VS.csproj" />

--- a/tests/Shared.cs
+++ b/tests/Shared.cs
@@ -1,0 +1,3 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
xUnit runs all tests within a "collection" concurrently. However the default behaviour is to have one collection per test class. This commit changes the default to be one collection per assembly (unless a specific collection is defined). This means that, but default, most tests in the assembly will now be able to run concurrently.

It's possible that this introduces test instability, though if generally we shouldn't have tests that require isolation from other parts of the system. We will monitor for such instability, and also check whether this change improves test execution times.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9451)