### PR TITLE
Avoid per-call lambda allocation

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/TemporaryPropertyStorage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/TemporaryPropertyStorage.cs
@@ -19,7 +19,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
         public void AddOrUpdatePropertyValue(string propertyName, string propertyValue)
         {
-            ImmutableInterlocked.AddOrUpdate(ref _properties, propertyName, propertyValue, (_, _) => propertyValue);
+            ImmutableInterlocked.Update(
+                ref _properties,
+                static (dic, pair) => dic.SetItem(pair.Key, pair.Value),
+                (Key: propertyName, Value: propertyValue));
         }
 
         public string? GetPropertyValue(string propertyName)


### PR DESCRIPTION
This change passes the captured state on the stack, to avoid a heap-allocated closure object. The delegate will then be cached and reused.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9452)