### PR TITLE
Don't NGEN for all architectures

### DIFF
--- a/setup/Directory.Build.props
+++ b/setup/Directory.Build.props
@@ -59,7 +59,6 @@
     <StartArguments>/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log</StartArguments>
 
     <Ngen>true</Ngen>
-    <NgenArchitecture>All</NgenArchitecture>
     <NgenPriority>3</NgenPriority>
   </PropertyGroup>
 

--- a/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
+++ b/setup/VisualStudioEditorsSetup/VisualStudioEditorsSetup.csproj
@@ -35,7 +35,6 @@
       <Name>%(Filename)</Name>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>true</Ngen>
-      <NgenArchitecture>All</NgenArchitecture>
       <NgenPriority>3</NgenPriority>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
Fixes AB#1987317

We currently specify that Microsoft.VisualStudio.Editors.dll and Microsoft.VisualStudio.AppDesigner.dll should be NGEN'd for all architectures. This means that on an x64 system NGEN will run twice for each: once to create a 32-bit version, and once to create a 64-bit version. As we no longer ship a 32-bit version of VS the former is unnecessary, and we're just wasting time and resources on that NGEN and potentially delaying useful NGEN work.

This commit removes the `<NGenArchitecture>all</NGenArchitecture>` MSBuild property affecting these binaries. Without this property being set, NGEN will default to the current system architecture (e.g. AMD64 on an AMD64 system).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9453)