### PR TITLE
Build Acceleration handles duplicate copy items

### DIFF
--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -92,9 +92,11 @@ Build acceleration runs with the FUTDC, and outputs details of its operation in 
 > Tools | Options | Projects and Solutions | SDK-Style Projects
 
 _Traditional view:_
+
 <img src="repo/images/options.png" width="528" alt="SDK-style project options, in the legacy settings view">
 
 _Unified settings view:_
+
 <img src="repo/images/options-unified.png" width="528" alt="SDK-style project options, in the modern unified settings view">
 
 Setting _Logging Level_ to a value other than `None` results in messages prefixed with `FastUpToDate:` in Visual Studio's build output.

--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -144,6 +144,12 @@ Looking through the build output with the following points in mind:
 
 - ⛔ If you see:
 
+   > Build acceleration is not available for this project because it copies duplicate files to the output directory: '<path1>', '<path2>'
+
+   Then multiple projects want to copy the same file to the output directory. Currently, Build Acceleration does not attempt to discover which of these source files should win. Instead, when this situation occurs, Build Acceleration is disabled.
+
+- ⛔ If you see:
+
    > This project has enabled build acceleration, but not all referenced projects produce a reference assembly. Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': '&lt;path1&gt;', '&lt;path2&gt;'.
 
    Then build acceleration will not know whether it is safe to copy a modified output DLL from a referenced project or not. We rely on the use of reference assemblies to convey this information. To address this, ensure all referenced projects have the `ProduceReferenceAssembly` property set to `true`. You may like to add this to your `Directory.Build.props` file alongside the `AccelerateBuildsInVisualStudio` property. Note that projects targeting `net5.0` or later produce reference assemblies by default. Projects that target .NET Standard may require this to be specified manually (see https://github.com/dotnet/project-system/issues/8865).

--- a/spelling.dic
+++ b/spelling.dic
@@ -1,3 +1,4 @@
+appsettings
 args
 async
 awaiter
@@ -15,6 +16,7 @@ dirs
 docdata
 enum
 enums
+fsproj
 fsscript
 func
 futdcache
@@ -44,6 +46,7 @@ netcoreapp
 nuget
 pbstr
 phier
+pkgdef
 prev
 proj
 projectsystem

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -955,7 +955,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 // The subscription object calls GetLatestVersionAsync for project data, which can take a while.
                 // We separate out the wait time from the overall time, so we can more easily identify when the
                 // wait is long, versus the check's actual execution time.
-                var waitTime = sw.Elapsed;
+                TimeSpan waitTime = sw.Elapsed;
 
                 token.ThrowIfCancellationRequested();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -1180,11 +1180,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
                     bool isEnabled;
 
-                    if (isEnabledInProject is null)
+                    if (isEnabledInProject is bool b)
                     {
-                        // No value has been specified in the project. Look to the feature flag to determine
-                        // the default behavior in this case.
-
+                        isEnabled = b;
+                    }
+                    else
+                    {
+                        // No value has been specified in the project. Query the environment to decide (e.g. feature flag).
                         if (await _projectSystemOptions.IsBuildAccelerationEnabledByDefaultAsync(cancellationToken))
                         {
                             // The user has opted-in via feature flag. Set this to true and carry on with further checks.
@@ -1196,10 +1198,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                             logger.Info(nameof(VSResources.FUTD_BuildAccelerationIsNotEnabledForThisProject));
                             return null;
                         }
-                    }
-                    else
-                    {
-                        isEnabled = isEnabledInProject.Value;
                     }
 
                     if (isEnabled)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -1193,7 +1193,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                         }
                         else
                         {
-                            logger.Verbose(nameof(VSResources.FUTD_BuildAccelerationIsNotEnabledForThisProject));
+                            logger.Info(nameof(VSResources.FUTD_BuildAccelerationIsNotEnabledForThisProject));
                             return null;
                         }
                     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -1233,13 +1233,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             return _projectSystemOptions.GetIsFastUpToDateCheckEnabledAsync(cancellationToken);
         }
 
-        internal readonly struct TestAccessor
+        internal readonly struct TestAccessor(BuildUpToDateCheck check)
         {
-            private readonly BuildUpToDateCheck _check;
-
-            public TestAccessor(BuildUpToDateCheck check) => _check = check;
-
-            public void SetSubscription(ISubscription subscription) => _check._subscription = subscription;
+            public void SetSubscription(ISubscription subscription) => check._subscription = subscription;
         }
 
         /// <summary>For unit testing only.</summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -1202,21 +1202,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
                     if (isEnabled)
                     {
-                        if (isCopyItemsComplete)
-                        {
-                            if (isEnabledInProject is not null)
-                            {
-                                // Don't log if isEnabledInProject is null, as we already log that status above
-                                logger.Info(nameof(VSResources.FUTD_BuildAccelerationEnabledViaProperty));
-                            }
-
-                            return true;
-                        }
-                        else
+                        if (!isCopyItemsComplete)
                         {
                             logger.Info(nameof(VSResources.FUTD_AccelerationDisabledCopyItemsIncomplete));
                             return false;
                         }
+
+                        if (isEnabledInProject is not null)
+                        {
+                            // Don't log if isEnabledInProject is null, as we already log that status above.
+                            logger.Info(nameof(VSResources.FUTD_BuildAccelerationEnabledViaProperty));
+                        }
+
+                        return true;
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/CopyItemAggregator.cs
@@ -67,7 +67,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
                 if (!data.ProduceReferenceAssembly && project != targetPath)
                 {
                     // One of the referenced projects does not produce a reference assembly.
-                    referencesNotProducingReferenceAssembly ??= new();
+                    referencesNotProducingReferenceAssembly ??= [];
                     referencesNotProducingReferenceAssembly.Add(data.TargetPath);
                 }
 
@@ -78,7 +78,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
 
                 if (!data.CopyItems.IsEmpty)
                 {
-                    contributingProjects ??= new();
+                    contributingProjects ??= [];
                     contributingProjects.Add(data);
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/CopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/CopyItemAggregator.cs
@@ -62,7 +62,7 @@ internal class CopyItemAggregator : ICopyItemAggregator
                 if (!_projectData.TryGetValue(project, out ProjectCopyData data))
                 {
                     // We don't have a list of project references for this project, so we cannot continue
-                    // walking the project reference tree. As we might now know all possible copy items,
+                    // walking the project reference tree. As we might not know all possible copy items,
                     // we disable build acceleration. Note that we still walk the rest of the tree in order
                     // to detect copy items, so that we can decide whether the project is up to date.
                     logger.Verbose(nameof(VSResources.FUTDC_AccelerationDataMissingForProject_1), project);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/ICopyItemAggregator.cs
@@ -59,5 +59,5 @@ internal record struct ProjectCopyData(
     ImmutableArray<CopyItem> CopyItems,
     ImmutableArray<string> ReferencedProjectTargetPaths)
 {
-    public bool IsDefault => CopyItems.IsDefault;
+    public readonly bool IsDefault => CopyItems.IsDefault;
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/ICopyItemAggregator.cs
@@ -9,10 +9,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate;
 internal interface ICopyItemAggregator
 {
     /// <summary>
-    /// Stores the set of copy items produced by the calling project, and modelled
-    /// in <paramref name="projectCopyData"/>.
+    /// Integrates data from a project, for use within <see cref="TryGatherCopyItemsForProject"/>.
     /// </summary>
-    /// <param name="projectCopyData">The set of items to copy, and some details about the provider project.</param>
+    /// <param name="projectCopyData">All necessary data about the project that's providing the data.</param>
     void SetProjectData(ProjectCopyData projectCopyData);
 
     /// <summary>
@@ -20,8 +19,22 @@ internal interface ICopyItemAggregator
     /// from the project identified by <paramref name="targetPath"/>.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// We use the <c>TargetPath</c> property to identify projects, as that path takes
-    /// other dimensions (such as target framework) into account.
+    /// other dimensions (such as target framework, platform, etc.) into account when projects
+    /// have multiple configurations.
+    /// </para>
+    /// <para>
+    /// When multiple copy items want to write to the same relative output path, the set of duplicate
+    /// items is written to <see cref="CopyItemsResult.DuplicateCopyItemRelativeTargetPaths"/>.
+    /// Build Acceleration disables itself when items exist in this collection, as it does not
+    /// attempt to reproduce the full behaviour of MSBuild for this scenario.
+    /// </para>
+    /// <para>
+    /// If we find a reference to a project that did not call <see cref="SetProjectData"/> then
+    /// the returned <see cref="CopyItemsResult.IsComplete"/> will be <see langword="false"/>.
+    /// Build Acceleration disables itself when copy items from a reachable project is unavailable.
+    /// </para>
     /// </remarks>
     /// <param name="targetPath">The target path of the project to query from.</param>
     /// <param name="logger">An object for writing log messages.</param>
@@ -33,15 +46,23 @@ internal interface ICopyItemAggregator
 /// Results of gathering the items that must be copied as part of a project's build
 /// by <see cref="ICopyItemAggregator.TryGatherCopyItemsForProject(string, BuildUpToDateCheck.Log)"/>.
 /// </summary>
-/// <param name="ItemsByProject">A sequence of items by project, that are reachable from the current project</param>
 /// <param name="IsComplete">Indicates whether we have items from all reachable projects.</param>
+/// <param name="ItemsByProject">
+///     A sequence of items by project, that are reachable from the current project. The path is that
+///     of the project file, such as <c>c:\repos\MyProject\MyProject.csproj</c>.
+/// </param>
+/// <param name="DuplicateCopyItemRelativeTargetPaths">
+///     A list of relative target paths for which more than one project produces an item, or <see langword="null"/> if
+///     no duplicates exists.
+/// </param>
 /// <param name="TargetsWithoutReferenceAssemblies">
 ///     A list of target paths for projects that do not produce reference assemblies, or <see langword="null"/> if
 ///     all reachable projects do in fact produce reference assemblies.
 /// </param>
 internal record struct CopyItemsResult(
-    IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject,
     bool IsComplete,
+    IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> ItemsByProject,
+    IReadOnlyList<string>? DuplicateCopyItemRelativeTargetPaths,
     IReadOnlyList<string>? TargetsWithoutReferenceAssemblies);
 
 /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -259,6 +259,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}.
+        /// </summary>
+        internal static string FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1 {
+            get {
+                return ResourceManager.GetString("FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Build acceleration is disabled for this project via the &apos;AccelerateBuildsInVisualStudio&apos; MSBuild property. See https://aka.ms/vs-build-acceleration..
         /// </summary>
         internal static string FUTD_AccelerationDisabledForProject {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -543,6 +543,10 @@ In order to debug this project, add an executable project to this solution which
   <data name="FUTD_AccelerationDisabledCopyItemsIncomplete" xml:space="preserve">
     <value>Build acceleration is not available for this project because not all transitively referenced projects have provided acceleration data.</value>
   </data>
+  <data name="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1" xml:space="preserve">
+    <value>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</value>
+    <comment>{0} is a list of one or more relative file paths.</comment>
+  </data>
   <data name="FUTDC_AccelerationDataMissingForProject_1" xml:space="preserve">
     <value>Build acceleration data is unavailable for project with target '{0}'. See https://aka.ms/vs-build-acceleration.</value>
     <comment>{0} is a file path.</comment>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Název sestavení architektury</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Der Name der Frameworkassembly.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nombre del ensamblado del marco.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nom de l'assembly de framework.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nome dell'assembly del framework.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">フレームワーク アセンブリの名前です。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">프레임워크 어셈블리의 이름입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nazwa zestawu struktury.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">O nome do assembly de estrutura.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Имя сборки платформы.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Çerçeve bütünleştirilmiş kodunun adı.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">框架程序集的名称。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -25,6 +25,11 @@
       {1} is the profile command, which is usually an internal string but is helpful when diagnosing issues here.
     </note>
       </trans-unit>
+      <trans-unit id="FUTD_AccelerationDisabledDuplicateCopyItemsIncomplete_1">
+        <source>Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</source>
+        <target state="new">Build acceleration is not available for this project because it copies duplicate files to the output directory: {0}</target>
+        <note>{0} is a list of one or more relative file paths.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">架構組件的名稱。</target>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -135,9 +135,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     TimeSpan waitTime,
                     LogLevel logLevel) =>
                     {
-                        Assert.Equal(_expectedUpToDate, upToDate);
-                        Assert.Equal(_logLevel, logLevel);
-                        Assert.Equal(_expectedIsBuildAccelerationEnabled, buildAccelerationEnabled);
+                        if (_expectedUpToDate != upToDate)
+                        {
+                            Assert.Fail($"Expected up-to-date to be {_expectedUpToDate} but was {upToDate}.");
+                        }
+                        else if (_logLevel != logLevel)
+                        {
+                            Assert.Fail($"Expected log level to be {_logLevel} but was {logLevel}.");
+                        }
+                        else if (_expectedIsBuildAccelerationEnabled != buildAccelerationEnabled)
+                        {
+                            Assert.Fail($"Expected build acceleration enablement to be {_expectedIsBuildAccelerationEnabled} but was {buildAccelerationEnabled}.");
+                        }
                     });
 
             _buildUpToDateCheck = new BuildUpToDateCheck(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -912,6 +912,22 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     """,
                     "InputMarkerNewerThanOutputMarker");
             }
+            else
+            {
+                await AssertNotUpToDateAsync(
+                    $"""
+                    Build acceleration is not enabled for this project. See https://aka.ms/vs-build-acceleration.
+                    Comparing timestamps of inputs and outputs:
+                        No build outputs defined.
+                    Comparing timestamps of copy marker inputs and output:
+                        Write timestamp on output marker is {ToLocalTime(outputTime)} on 'C:\Dev\Solution\Project\OutputMarker'.
+                        Adding input reference copy markers:
+                            Reference1OriginalPath
+                    Input marker 'Reference1OriginalPath' is newer ({ToLocalTime(originalTime)}) than output marker 'C:\Dev\Solution\Project\OutputMarker' ({ToLocalTime(outputTime)}), not up-to-date.
+                    This project appears to be a candidate for build acceleration. To opt in, set the 'AccelerateBuildsInVisualStudio' MSBuild property to 'true'. See https://aka.ms/vs-build-acceleration.
+                    """,
+                    "InputMarkerNewerThanOutputMarker");
+            }
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -752,10 +752,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         [CombinatorialData]
         public async Task IsUpToDateAsync_CopyReference_InputsOlderThanMarkerOutput(bool? isBuildAccelerationEnabledInProject, bool allReferencesProduceReferenceAssemblies)
         {
-            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
-            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
-
-            _targetsWithoutReferenceAssemblies = allReferencesProduceReferenceAssemblies ? null : new[] { "WithoutReferenceAssembly1", "WithoutReferenceAssembly2" };
+            SetUpAcceleratedTestCase(isBuildAccelerationEnabledInProject, allReferencesProduceReferenceAssemblies);
 
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
             {
@@ -869,17 +866,15 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             };
 
             var lastBuildTime = DateTime.UtcNow.AddMinutes(-5);
-
-            // We only check copy markers when build acceleration is disabled (null or false).
-            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
-            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
-
-            await SetupAsync(projectSnapshot: projectSnapshot, lastSuccessfulBuildStartTimeUtc: lastBuildTime);
-
             var outputTime   = DateTime.UtcNow.AddMinutes(-4);
             var resolvedTime = DateTime.UtcNow.AddMinutes(-3);
             var markerTime   = DateTime.UtcNow.AddMinutes(-2);
             var originalTime = DateTime.UtcNow.AddMinutes(-1);
+
+            // We only check copy markers when build acceleration is disabled (null or false).
+            SetUpAcceleratedTestCase(isBuildAccelerationEnabledInProject, allReferencesProduceReferenceAssemblies: true);
+
+            await SetupAsync(projectSnapshot: projectSnapshot, lastSuccessfulBuildStartTimeUtc: lastBuildTime);
 
             _fileSystem.AddFile(@"C:\Dev\Solution\Project\OutputMarker", outputTime);
             _fileSystem.AddFile("Reference1ResolvedPath", resolvedTime);
@@ -1616,9 +1611,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         [CombinatorialData]
         public async Task IsUpToDateAsync_CopyToOutputDirectory_SourceIsNewerThanDestination(bool? isBuildAccelerationEnabledInProject, bool allReferencesProduceReferenceAssemblies)
         {
-            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
-            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
-            _targetsWithoutReferenceAssemblies = allReferencesProduceReferenceAssemblies ? null : new[] { "WithoutReferenceAssembly1", "WithoutReferenceAssembly2" };
+            SetUpAcceleratedTestCase(isBuildAccelerationEnabledInProject, allReferencesProduceReferenceAssemblies);
 
             var sourcePath1 = @"C:\Dev\Solution\Project\Item1";
             var sourcePath2 = @"C:\Dev\Solution\Project\Item2";
@@ -1734,9 +1727,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         [CombinatorialData]
         public async Task IsUpToDateAsync_CopyToOutputDirectory_SourceIsNewerThanDestination_TargetPath(bool? isBuildAccelerationEnabledInProject, bool allReferencesProduceReferenceAssemblies)
         {
-            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
-            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
-            _targetsWithoutReferenceAssemblies = allReferencesProduceReferenceAssemblies ? null : new[] { "WithoutReferenceAssembly1", "WithoutReferenceAssembly2" };
+            SetUpAcceleratedTestCase(isBuildAccelerationEnabledInProject, allReferencesProduceReferenceAssemblies);
 
             var sourcePath1 = @"C:\Dev\Solution\Project\Item1";
             var sourcePath2 = @"C:\Dev\Solution\Project\Item2";
@@ -1852,9 +1843,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         [CombinatorialData]
         public async Task IsUpToDateAsync_CopyToOutputDirectory_SourceIsNewerThanDestination_CustomOutDir(bool? isBuildAccelerationEnabledInProject, bool allReferencesProduceReferenceAssemblies)
         {
-            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
-            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
-            _targetsWithoutReferenceAssemblies = allReferencesProduceReferenceAssemblies ? null : new[] { "WithoutReferenceAssembly1", "WithoutReferenceAssembly2" };
+            SetUpAcceleratedTestCase(isBuildAccelerationEnabledInProject, allReferencesProduceReferenceAssemblies);
 
             const string outDirSnapshot = "newOutDir";
 
@@ -2029,9 +2018,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         [CombinatorialData]
         public async Task IsUpToDateAsync_CopyToOutputDirectory_DestinationDoesNotExist(bool? isBuildAccelerationEnabledInProject, bool allReferencesProduceReferenceAssemblies)
         {
-            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
-            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
-            _targetsWithoutReferenceAssemblies = allReferencesProduceReferenceAssemblies ? null : new[] { "WithoutReferenceAssembly1", "WithoutReferenceAssembly2" };
+            SetUpAcceleratedTestCase(isBuildAccelerationEnabledInProject, allReferencesProduceReferenceAssemblies);
 
             var sourcePath1 = @"C:\Dev\Solution\Project\Item1";
             var sourcePath2 = @"C:\Dev\Solution\Project\Item2";
@@ -2309,6 +2296,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
         private static string ToLocalTime(DateTime time)
         {
             return time.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss.fff");
+        }
+
+        private void SetUpAcceleratedTestCase(bool? isBuildAccelerationEnabledInProject, bool allReferencesProduceReferenceAssemblies)
+        {
+            _isBuildAccelerationEnabledInProject = isBuildAccelerationEnabledInProject;
+            _expectedIsBuildAccelerationEnabled = isBuildAccelerationEnabledInProject;
+            _targetsWithoutReferenceAssemblies = allReferencesProduceReferenceAssemblies ? null : new[] { "WithoutReferenceAssembly1", "WithoutReferenceAssembly2" };
         }
 
         private async Task AssertNotUpToDateAsync(string? expectedLogOutput = null, string? telemetryReason = null, BuildAction buildAction = BuildAction.Build, string ignoreKinds = "", string targetFramework = "", bool skipValidation = false)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -173,7 +173,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
             _lastSuccessfulBuildStartTime = lastSuccessfulBuildStartTimeUtc;
 
-            projectSnapshot ??= new Dictionary<string, IProjectRuleSnapshotModel>();
+            projectSnapshot ??= new Dictionary<string, IProjectRuleSnapshotModel>(StringComparers.RuleNames);
 
             if (!projectSnapshot.ContainsKey(ConfigurationGeneral.SchemaName))
             {


### PR DESCRIPTION
Fixes #9001

Build Acceleration gathers items to copy from referenced files, transitively. Each copy item includes a relative path, to which the file should be copied (relative to the output path of the project being built).

It's possible for multiple projects to specify copy items with the same relative target path. When this occurs, only one file will end up in the output directory at that location. The exact rules defining which file "wins" in this case are complex. The situation is relatively rare however.

This change makes Build Acceleration disable itself in cases where duplicate relative target paths exist. The project will fall back to calling MSBuild so that the correct behaviour is guaranteed.

---

Note to reviewers: There are some small cleanup commits that make the overall diff a little cluttered. The core change here is in 97539d8c73c8714b5f25ed13babd3dac70463d83.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9454)