### PR TITLE
Re-enable unit tests

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -1312,7 +1312,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 """);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/8642")]
+        [Fact]
         public async Task IsUpToDateAsync_False_Kinds_InputNewerThanOutput_WithIgnoredKind()
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
@@ -1357,7 +1357,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 ignoreKinds: "Ignored");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/8642")]
+        [Fact]
         public async Task IsUpToDateAsync_False_Kinds_InputNewerThanOutput_NoKindIgnored()
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
@@ -1406,7 +1406,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 ignoreKinds: "");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/8642")]
+        [Fact]
         public async Task IsUpToDateAsync_True_Kinds_InputNewerThanOutput_WithIgnoredKind()
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>
@@ -1452,7 +1452,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 ignoreKinds: "Ignored");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/project-system/issues/8642")]
+        [Fact]
         public async Task IsUpToDateAsync_True_Kinds_InputNewerThanOutput_NoKindIgnored()
         {
             var projectSnapshot = new Dictionary<string, IProjectRuleSnapshotModel>


### PR DESCRIPTION
Fixes #8642.

Re-enable a number of Fast Up-to-Date Check unit tests that have been disabled for a while. I am no longer able to reproduce the problematic behavior that originally led me to disable them; it looks like the underlying issue (non-deterministic output) has been resolved.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9456)