### PR TITLE
Bump xunit to 2.8.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -108,14 +108,14 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                                                 Version="17.5.0-preview-20221003-04" />
     <PackageVersion Include="Moq"                                                                    Version="4.16.1" />
     <PackageVersion Include="Verify.Xunit"                                                           Version="14.2.0" />
-    <PackageVersion Include="xunit"                                                                  Version="2.4.2" />
-    <PackageVersion Include="xunit.analyzers"                                                        Version="1.0.0"/>
-    <PackageVersion Include="xunit.assert"                                                           Version="2.4.2" />
-    <PackageVersion Include="xunit.combinatorial"                                                    Version="1.5.25" />
-    <PackageVersion Include="xunit.extensibility.core"                                               Version="2.4.2" />
-    <PackageVersion Include="xunit.extensibility.execution"                                          Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.console"                                                   Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio"                                              Version="2.4.5" />
+    <PackageVersion Include="xunit"                                                                  Version="2.8.0" />
+    <PackageVersion Include="xunit.analyzers"                                                        Version="1.13.0"/>
+    <PackageVersion Include="xunit.assert"                                                           Version="2.8.0" />
+    <PackageVersion Include="xunit.combinatorial"                                                    Version="1.6.24" />
+    <PackageVersion Include="xunit.extensibility.core"                                               Version="2.8.0" />
+    <PackageVersion Include="xunit.extensibility.execution"                                          Version="2.8.0" />
+    <PackageVersion Include="xunit.runner.console"                                                   Version="2.8.0" />
+    <PackageVersion Include="xunit.runner.visualstudio"                                              Version="2.8.0" />
 
     <!-- Integration Tests -->
     <PackageVersion Include="Microsoft.DotNet.Common.ProjectTemplates.1.x"                           Version="1.0.0-beta2-20170629-269" />

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/AssertEx.cs
@@ -9,12 +9,7 @@ namespace Xunit
     {
         public static void CollectionLength<T>(IEnumerable<T> collection, int expectedCount)
         {
-            int actualCount = collection.Count();
-
-            if (actualCount != expectedCount)
-            {
-                throw new CollectionException(collection, expectedCount, actualCount);
-            }
+            throw CollectionException.ForMismatchedItemCount(expectedCount, collection.Count(), "Collection lengths not equal.");
         }
 
         public static void CollectionLength(IEnumerable collection, int expectedCount)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectPropertiesFactory.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
             return mock;
         }
 
-        public static Mock<IProjectProperties> MockWithPropertyAndValue(string propertyName, string setValue)
+        public static Mock<IProjectProperties> MockWithPropertyAndValue(string propertyName, string? setValue)
         {
             return MockWithPropertiesAndValues(new Dictionary<string, string?>() { { propertyName, setValue } });
         }
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         public static IProjectProperties CreateWithProperty(string propertyName)
             => MockWithProperty(propertyName).Object;
 
-        public static IProjectProperties CreateWithPropertyAndValue(string propertyName, string setValue)
+        public static IProjectProperties CreateWithPropertyAndValue(string propertyName, string? setValue)
             => MockWithPropertyAndValue(propertyName, setValue).Object;
 
         public static IProjectProperties CreateWithPropertiesAndValues(IDictionary<string, string?> propertyNameAndValues, HashSet<string>? inheritedPropertyNames = null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/StartupProjectSingleTargetGlobalBuildPropertyProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/StartupProjectSingleTargetGlobalBuildPropertyProviderTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
 
             if (expectTargetFrameworkSet)
             {
-                Assert.Equal(expected: 1, actual: globalProperties.Count);
+                Assert.Single(globalProperties);
                 Assert.Equal(expected: "myFramework1.0", actual: globalProperties[ConfigurationGeneral.TargetFrameworkProperty]);
             }
             else

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Build/TargetFrameworkGlobalBuildPropertyProviderTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
             var provider = new TargetFrameworkGlobalBuildPropertyProvider(projectService, configuredProject);
 
             var properties = await provider.GetGlobalPropertiesAsync(CancellationToken.None);
-            Assert.Equal(0, properties.Count);
+            Assert.Empty(properties);
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/DebugTokenReplacerTests.cs
@@ -68,12 +68,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
         [InlineData("this is msbuild: %env3% $(msbuildProperty2) $(msbuildProperty3)",  "this is msbuild: Property6 Property2 Property3", true)]
         [InlineData(null, null, true)]
         [InlineData(" ", " ", true)]
-        public async Task ReplaceTokensInStringTests(string input, string expected, bool expandEnvVars)
+        public async Task ReplaceTokensInStringTests(string? input, string? expected, bool expandEnvVars)
         {
             var replacer = CreateInstance();
 
-            // Test msbuild vars
-            string result = await replacer.ReplaceTokensInStringAsync(input, expandEnvVars);
+            // Test MSBuild vars
+            string? result = await replacer.ReplaceTokensInStringAsync(input!, expandEnvVars);
             Assert.Equal(expected, result);
         }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/FileItemServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/FileItemServicesTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.VisualStudio.ProjectSystem
         [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "Folder\\..\\..\\Source.cs",                    null)]
         [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "D:\\Folder\\Source.cs",                        null)]
         [InlineData("C:\\Folder\\Project",                          "C:\\Folder\\Project\\Source.cs",        "C:\\Folder\\Project\\Source.cs",               null)]
-        public void GetLogicalFolderNames_Returns(string basePath, string fullPath, string link, params string[] expected)
+        public void GetLogicalFolderNames_Returns(string basePath, string fullPath, string? link, params string?[] expected)
         {
             var metadata = ImmutableDictionary<string, string>.Empty;
             if (link is not null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/OnceInitializedOnceDisposedUnderLockAsyncTests.cs
@@ -7,22 +7,22 @@ namespace Microsoft.VisualStudio.ProjectSystem
     public class OnceInitializedOnceDisposedUnderLockAsyncTests
     {
         [Fact]
-        public void ExecuteUnderLockAsync_NullAsAction_ThrowsArgumentNullException()
+        public async Task ExecuteUnderLockAsync_NullAsAction_ThrowsArgumentNullException()
         {
             var instance = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>(() =>
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
             {
                 return instance.ExecuteUnderLockAsync(null!, CancellationToken.None);
             });
         }
 
         [Fact]
-        public void ExecuteUnderLockAsyncOfT_NullAsAction_ThrowsArgumentNullException()
+        public async Task ExecuteUnderLockAsyncOfT_NullAsAction_ThrowsArgumentNullException()
         {
             var instance = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>(() =>
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
             {
                 return instance.ExecuteUnderLockAsync<string>(null!, CancellationToken.None);
             });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         private static TestProjectFileOrAssemblyInfoPropertiesProvider CreateProviderForProjectFileValidation(
             string code,
             string propertyName,
-            string propertyValueInProjectFile,
+            string? propertyValueInProjectFile,
             out Workspace workspace,
             Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>? interceptingProvider = null,
             Dictionary<string, string?>? additionalProps = null)
@@ -151,7 +151,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("""[assembly: System.Reflection.AssemblyDescriptionAttribute(true)]""", "Description", "MyDescription", "MyDescription")]
         [InlineData("""[assembly: System.Reflection.AssemblyDescriptionAttribute("MyDescription"]""", "Description", "", "")]
         [InlineData("""[assembly: System.Reflection.AssemblyDescriptionAttribute("MyDescription"]""", "Description", null, "")]
-        public async Task ProjectFileProperties_GetEvaluatedPropertyAsync(string code, string propertyName, string propertyValueInProjectFile, string expectedValue)
+        public async Task ProjectFileProperties_GetEvaluatedPropertyAsync(string code, string propertyName, string? propertyValueInProjectFile, string expectedValue)
         {
             var provider = CreateProviderForProjectFileValidation(code, propertyName, propertyValueInProjectFile, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
@@ -276,7 +276,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("""[assembly: System.Reflection.AssemblyInformationalVersionAttribute("2.0.0")]""", "Version", "2.0.0", null)]
         [InlineData("""[assembly: System.Reflection.AssemblyInformationalVersionAttribute("2.0.1-beta1")]""", "Version", "2.0.1-beta1", null)]
         [InlineData("""[assembly: System.Reflection.AssemblyInformationalVersionAttribute("2016.2")]""", "Version", "2016.2", null)]
-        internal async Task SourceFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue, Type interceptingProviderType)
+        internal async Task SourceFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string code, string propertyName, string expectedValue, Type? interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType is not null
                 ? new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
@@ -306,7 +306,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("MyApp", "Product", null, "")]
         [InlineData("MyApp", "Product", "", "")]
         [InlineData("MyApp", "Product", "ExistingValue", "ExistingValue")]
-        internal async Task ProjectFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string assemblyName, string propertyName, string existingPropertyValue, string expectedValue)
+        internal async Task ProjectFileProperties_DefaultValues_GetEvaluatedPropertyAsync(string assemblyName, string propertyName, string? existingPropertyValue, string expectedValue)
         {
             var additionalProps = new Dictionary<string, string?>() { { "AssemblyName", assemblyName } };
 
@@ -350,7 +350,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("Version", "1.1.1", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", "1.0.0", "1.0.0.0", "1.0.0.0", null)]
         [InlineData("Version", null, "2016.2", "2016.2", null)]
-        internal async Task ProjectFileProperties_WithInterception_SetEvaluatedPropertyAsync(string propertyName, string existingPropertyValue, string propertyValueToSet, string expectedValue, Type interceptingProviderType)
+        internal async Task ProjectFileProperties_WithInterception_SetEvaluatedPropertyAsync(string propertyName, string? existingPropertyValue, string propertyValueToSet, string expectedValue, Type? interceptingProviderType)
         {
             var interceptingProvider = interceptingProviderType is not null
                 ? new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationManifestValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationManifestValueProviderTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
         [InlineData("", "TRue", "NoManifest")]
         [InlineData("", "false", "DefaultManifest")]
         [InlineData("", null, "DefaultManifest")]
-        public async Task GetApplicationManifest(string appManifestPropValue, string noManifestValue, string expectedValue)
+        public async Task GetApplicationManifest(string appManifestPropValue, string? noManifestValue, string expectedValue)
         {
             var provider = new ApplicationManifestValueProvider(UnconfiguredProjectFactory.Create());
             var defaultProperties = IProjectPropertiesFactory.CreateWithPropertyAndValue("NoWin32Manifest", noManifestValue);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/References/AlwaysAllowValidProjectReferenceCheckerTests.cs
@@ -5,44 +5,44 @@ namespace Microsoft.VisualStudio.ProjectSystem.References
     public class AlwaysAllowValidProjectReferenceCheckerTests
     {
         [Fact]
-        public void CanAddProjectReferenceAsync_NullAsReferencedProject_ThrowsArgumentNull()
+        public async Task CanAddProjectReferenceAsync_NullAsReferencedProject_ThrowsArgumentNull()
         {
             var checker = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>("referencedProject", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("referencedProject", () =>
             {
                 return checker.CanAddProjectReferenceAsync(null!);
             });
         }
 
         [Fact]
-        public void CanAddProjectReferencesAsync_NullAsReferencedProjects_ThrowsArgumentNull()
+        public async Task CanAddProjectReferencesAsync_NullAsReferencedProjects_ThrowsArgumentNull()
         {
             var checker = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>("referencedProjects", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("referencedProjects", () =>
             {
                 return checker.CanAddProjectReferencesAsync(null!);
             });
         }
 
         [Fact]
-        public void CanAddProjectReferencesAsync_EmptyAsReferencedProjects_ThrowsArgument()
+        public async Task CanAddProjectReferencesAsync_EmptyAsReferencedProjects_ThrowsArgument()
         {
             var checker = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentException>("referencedProjects", () =>
+            await Assert.ThrowsAsync<ArgumentException>("referencedProjects", () =>
             {
                 return checker.CanAddProjectReferencesAsync(ImmutableHashSet<object>.Empty);
             });
         }
 
         [Fact]
-        public void CanBeReferencedAsync_NullAsReferencingProject_ThrowsArgumentNull()
+        public async Task CanBeReferencedAsync_NullAsReferencingProject_ThrowsArgumentNull()
         {
             var checker = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>("referencingProject", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("referencingProject", () =>
             {
                 return checker.CanBeReferencedAsync(null!);
             });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders
         [InlineData(@"My Project",              @"C:\Project\My Project")]
         [InlineData(@"Folder\AppDesigner",      @"C:\Project\Folder\AppDesigner")]
         [InlineData(@"",                        null)]
-        public async Task GetFile_WhenTreeWithoutAppDesignerFolder_ReturnsDefaultAppDesignerFolder(string input, string expected)
+        public async Task GetFile_WhenTreeWithoutAppDesignerFolder_ReturnsDefaultAppDesignerFolder(string input, string? expected)
         {
             var tree = ProjectTreeParser.Parse(
                 """

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/SequentialTaskExecutorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Threading/Tasks/SequentialTaskExecutorTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.VisualStudio.Threading.Tasks
             await Task.WhenAll(tasks);
             for (int i = 0; i < NumberOfTasks; i++)
             {
-                Assert.Equal(i, tasks[i].Result);
+                Assert.Equal(i, await tasks[i]);
             }
         }
 
@@ -110,11 +110,11 @@ namespace Microsoft.VisualStudio.Threading.Tasks
         }
 
         [Fact]
-        public void CallToDisposedObjectShouldThrow()
+        public async Task CallToDisposedObjectShouldThrow()
         {
             var sequencer = new SequentialTaskExecutor(new(_joinableTaskContext), "UnitTests");
             sequencer.Dispose();
-            Assert.ThrowsAsync<ObjectDisposedException>(() => sequencer.ExecuteTask(() => Task.CompletedTask));
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => sequencer.ExecuteTask(() => Task.CompletedTask));
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHierarchyFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsHierarchyFactory.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.Shell.Interop
             return mock.Object;
         }
 
-        public static IVsHierarchy ImplementGetProperty(object result)
+        public static IVsHierarchy ImplementGetProperty(object? result)
         {
             var mock = new Mock<IVsHierarchy>();
             mock.Setup(h => h.GetProperty(It.IsAny<uint>(), It.IsAny<int>(), out result))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
         [InlineData(@"C:\Path\To\TemplateFile", true)]
         [InlineData(@"C:\Path\To\TemplateFile", false)]
         [InlineData(null, false)]
-        public async Task CreateFile(string templateFilePath, bool expectedResult)
+        public async Task CreateFile(string? templateFilePath, bool expectedResult)
         {
             string templateName = "SettingsInternal.zip";
             string fileName = "Settings.settings";
@@ -54,7 +54,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
             var solution = (Solution)SolutionFactory.CreateWithGetProjectItemTemplate((templateFile, language) =>
             {
                 Assert.Equal(templateName, templateFile);
-                return templateFilePath;
+                return templateFilePath!;
             });
 
             var vsProject = (IVsProject4)IVsHierarchyFactory.Create();
@@ -63,7 +63,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS
                 Assert.Equal(VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, itemOperation);
                 Assert.Equal(fileName, itemName);
                 Assert.Equal((uint)1, cOpen);
-                Assert.Equal(new string[] { templateFilePath }, files);
+                Assert.Equal(new string?[] { templateFilePath }, files);
 
                 result[0] = expectedResult ? VSADDRESULT.ADDRESULT_Success : VSADDRESULT.ADDRESULT_Failure;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -84,7 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             Assert.Equal(@"c:\program files\dotnet\dotnet.exe", targets[0].Executable);
             Assert.Equal(DebugLaunchOperation.CreateProcess, targets[0].LaunchOperation);
             Assert.Equal(DebuggerEngines.ManagedCoreEngine, targets[0].LaunchDebugEngineGuid);
-            Assert.Equal(0, targets[0].AdditionalDebugEngines.Count);
+            Assert.Empty(targets[0].AdditionalDebugEngines);
             Assert.Equal("exec \"c:\\test\\project\\bin\\project.dll\" --someArgs", targets[0].Arguments);
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         [InlineData(@"bin\")]
         [InlineData(@"doesntExist\")]
         [InlineData(null)]
-        public async Task QueryDebugTargetsAsync_ExeProfileAsyncExeRelativeNoWorkingDir(string outdir)
+        public async Task QueryDebugTargetsAsync_ExeProfileAsyncExeRelativeNoWorkingDir(string? outdir)
         {
             var properties = new Dictionary<string, string?>
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractAddItemCommandHandlerTests.cs
@@ -8,11 +8,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     public class AbstractAddItemCommandHandlerTests
     {
         [Fact]
-        public void GetCommandStatusAsync_NullAsNodes_ThrowsArgumentNull()
+        public async Task GetCommandStatusAsync_NullAsNodes_ThrowsArgumentNull()
         {
             var command = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>("nodes", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("nodes", () =>
             {
                 return command.GetCommandStatusAsync(null!, TestAddItemCommand.CommandId, true, "commandText", CommandStatus.Enabled);
             });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/AbstractOpenProjectDesignerCommandTests.cs
@@ -7,11 +7,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Input.Commands
     public abstract class AbstractOpenProjectDesignerCommandTests
     {
         [Fact]
-        public void GetCommandStatusAsync_NullAsNodes_ThrowsArgumentNull()
+        public async Task GetCommandStatusAsync_NullAsNodes_ThrowsArgumentNull()
         {
             var command = CreateInstance();
 
-            Assert.ThrowsAsync<ArgumentNullException>("nodes", () =>
+            await Assert.ThrowsAsync<ArgumentNullException>("nodes", () =>
             {
                 return command.GetCommandStatusAsync(null!, GetCommandId(), true, "commandText", CommandStatus.Enabled);
             });

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/ProjectDesignerServiceTests.cs
@@ -24,13 +24,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties
         }
 
         [Fact]
-        public void ShowProjectDesignerAsync_WhenSupportsProjectDesignerFalse_ThrowsInvalidOperation()
+        public async Task ShowProjectDesignerAsync_WhenSupportsProjectDesignerFalse_ThrowsInvalidOperation()
         {
             var vsProjectDesignerPageService = IVsProjectDesignerPageServiceFactory.ImplementIsProjectDesignerSupported(() => false);
 
             var designerService = CreateInstance(vsProjectDesignerPageService);
 
-            Assert.ThrowsAsync<InvalidOperationException>(designerService.ShowProjectDesignerAsync);
+            await Assert.ThrowsAsync<InvalidOperationException>(designerService.ShowProjectDesignerAsync);
         }
 
         [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
         [InlineData("  ")]
         [InlineData(".NETFramework, Version=v4.5")]
         [InlineData(".NETFramework, Version=v4.5, Profile=Client")]
-        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsValue_SetsTargetFramework(string input)
+        public void GetTargetFramework_WhenUnderlyingGetPropertyReturnsValue_SetsTargetFramework(string? input)
         {
             var hierarchy = IVsHierarchyFactory.ImplementGetProperty(input);
             var resolution = CreateInstance(hierarchy);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/ExportedRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/ExportedRuleTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rules
                     return;
             }
 
-            Assert.True(false, $"'{GetTypeQualifiedName(member)}' must live in the PropertyPageContexts.BrowseObject context.");
+            Assert.Fail($"'{GetTypeQualifiedName(member)}' must live in the PropertyPageContexts.BrowseObject context.");
         }
 
         [Theory]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTrackerTests.cs
@@ -266,7 +266,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             {
                 if (_outputProduced.Count != numberOfOutputExpected)
                 {
-                    throw new AssertActualExpectedException(numberOfOutputExpected, _outputProduced.Count, $"Timed out after {TestTimeoutMillisecondsDelay}ms");
+                    throw NotEqualException.ForEqualValues(numberOfOutputExpected.ToString(), _outputProduced.Count.ToString(), $"Timed out after {TestTimeoutMillisecondsDelay}ms");
                 }
             }
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
@@ -329,7 +329,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
                 var actualDLLs = _compilationResults.Count - initialCompilations;
                 if (numberOfDLLsExpected != actualDLLs)
                 {
-                    throw new AssertActualExpectedException(numberOfDLLsExpected, actualDLLs, $"Timed out after {TestTimeoutMillisecondsDelay}ms");
+                    throw NotEqualException.ForEqualValues(numberOfDLLsExpected.ToString(), actualDLLs.ToString(), $"Timed out after {TestTimeoutMillisecondsDelay}ms");
                 }
             }
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.TempPE
             // The timeout here is annoying, but even though our test is "smart" and waits for data, unfortunately if the code breaks the test is more likely to hang than fail
             if (await Task.WhenAny(finished.Task, Task.Delay(TestTimeoutMillisecondsDelay)) != finished.Task)
             {
-                throw new AssertActualExpectedException(fileChangeNotificationsExpected.Length, notificationCount, $"Timed out after {TestTimeoutMillisecondsDelay}ms");
+                throw NotEqualException.ForEqualValues(fileChangeNotificationsExpected.Length.ToString(), notificationCount.ToString(), $"Timed out after {TestTimeoutMillisecondsDelay}ms");
             }
 
             // Observe the task in case of exceptions


### PR DESCRIPTION
Increases package versions. I'm hopeful this will make unit test discovery quicker in the solution.

Also fixes compile issues due to changes in xUnit's APIs, and addresses all diagnostics logged via new capabilities in xUnit's analyzers.