### PR TITLE
Avoid main thread switch in UpToDateCheckHost

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,7 +98,7 @@
     <PackageVersion Include="Microsoft.IO.Redist"                                                    Version="6.0.0" />
 
     <!-- MSBuild (for tests only) -->
-    <PackageVersion Include="Microsoft.Build"                                                        Version="17.9.5" />
+    <PackageVersion Include="Microsoft.Build"                                                        Version="17.11.0-preview-24229-04" />
 
     <!-- Hot Reload -->
     <PackageVersion Include="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21380.4" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,39 +28,39 @@
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.Vsman"                       Version="2.0.115" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning"                                                 Version="3.6.79-alpha" />
-    <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.10.69" />
+    <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.11.72" />
     <PackageVersion Include="System.IO.Pipelines"                                                    Version="8.0.0" />
 
     <!-- VS SDK -->
     <!-- https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk -->
-    <PackageVersion Include="EnvDTE"                                                                 Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.3.57" />
-    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.3.198" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.7.29" />
+    <PackageVersion Include="EnvDTE"                                                                 Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.5.37" />
+    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.11.111-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.10.39" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.Contracts"                              Version="17.4.0-beta.22470.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Debugger.UI.Interfaces"                          Version="17.4.0-beta.22470.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.4.0-preview-2-32826-307" />
+    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.10.3-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.3.32804.24" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.11.3-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.2.2146" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design"                                    Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.8.9" />
-    <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.9.28" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.9.28" />
-    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.7.36307-preview.2" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design"                                    Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.11.8" />
+    <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.11.6-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.11.6-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
-    <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
+    <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.11.0-preview-1-34901-010" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.11.54-preview1" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="8.0.0" />
     <PackageVersion Include="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -97,6 +97,9 @@
     <!-- Framework packages -->
     <PackageVersion Include="Microsoft.IO.Redist"                                                    Version="6.0.0" />
 
+    <!-- MSBuild (for tests only) -->
+    <PackageVersion Include="Microsoft.Build"                                                        Version="17.9.5" />
+
     <!-- Hot Reload -->
     <PackageVersion Include="Microsoft.VisualStudio.HotReload.Components"                            Version="6.0.0-preview.6.21380.4" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using Microsoft.Internal.VisualStudio.AppId.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
@@ -8,31 +10,34 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     [Export(typeof(IUpToDateCheckHost))]
     internal sealed class UpToDateCheckHost : IUpToDateCheckHost
     {
-        private readonly IVsUIService<IVsShell> _vsShell;
-        private readonly IVsUIService<IVsAppCommandLine> _vsAppCommandLine;
+        private readonly IVsService<IVsAppId, IVsAppId> _vsAppId;
+        private readonly IVsService<IVsAppCommandLine> _vsAppCommandLine;
         private readonly JoinableTaskContext _joinableTaskContext;
 
         private bool? _hasDesignTimeBuild;
 
         [ImportingConstructor]
-        public UpToDateCheckHost(IVsUIService<SVsShell, IVsShell> vsShell, IVsUIService<SVsAppCommandLine, IVsAppCommandLine> vsAppCommandLine, JoinableTaskContext joinableTaskContext)
+        public UpToDateCheckHost(
+            IVsService<IVsAppId, IVsAppId> vsAppId,
+            IVsService<SVsAppCommandLine, IVsAppCommandLine> vsAppCommandLine,
+            JoinableTaskContext joinableTaskContext)
         {
-            _vsShell = vsShell;
+            _vsAppId = vsAppId;
             _vsAppCommandLine = vsAppCommandLine;
             _joinableTaskContext = joinableTaskContext;
         }
 
         public async ValueTask<bool> HasDesignTimeBuildsAsync(CancellationToken cancellationToken)
         {
-            _hasDesignTimeBuild ??= await ComputeValueAsync();
+            _hasDesignTimeBuild ??= await HasDesignTimeBuildsInternalAsync();
 
             return _hasDesignTimeBuild.Value;
 
-            async ValueTask<bool> ComputeValueAsync()
+            async Task<bool> HasDesignTimeBuildsInternalAsync()
             {
-                await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
+                IVsAppCommandLine vsAppCommandLine = await _vsAppCommandLine.GetValueAsync(cancellationToken);
 
-                if (ErrorHandler.Succeeded(_vsAppCommandLine.Value.GetOption("populateSolutionCache", out int populateSolutionCachePresent, out string _)))
+                if (ErrorHandler.Succeeded(vsAppCommandLine.GetOption("populateSolutionCache", out int populateSolutionCachePresent, out string _)))
                 {
                     if (populateSolutionCachePresent != 0)
                     {
@@ -41,7 +46,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     }
                 }
 
-                if (ErrorHandler.Succeeded(_vsShell.Value.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object value)))
+                IVsAppId vsAppId = await _vsAppId.GetValueAsync(cancellationToken);
+
+                if (ErrorHandler.Succeeded(vsAppId.GetProperty((int)__VSAPROPID10.VSAPROPID_IsInCommandLineMode, out object value)))
                 {
                     if (value is bool isInCommandLineMode)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     [Export(typeof(IUpToDateCheckHost))]
     internal sealed class UpToDateCheckHost : IUpToDateCheckHost
     {
-        private readonly IVsService<IVsAppId, IVsAppId> _vsAppId;
+        private readonly IVsService<IVsAppId> _vsAppId;
         private readonly IVsService<IVsAppCommandLine> _vsAppCommandLine;
         private readonly JoinableTaskContext _joinableTaskContext;
 
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
         [ImportingConstructor]
         public UpToDateCheckHost(
-            IVsService<IVsAppId, IVsAppId> vsAppId,
+            IVsService<IVsAppId> vsAppId,
             IVsService<SVsAppCommandLine, IVsAppCommandLine> vsAppCommandLine,
             JoinableTaskContext joinableTaskContext)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckHost.cs
@@ -12,9 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
     {
         private readonly IVsService<IVsAppId> _vsAppId;
         private readonly IVsService<IVsAppCommandLine> _vsAppCommandLine;
-
         private readonly AsyncLazy<bool> _hasDesignTimeBuild;
-        private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         [ImportingConstructor]
         public UpToDateCheckHost(
@@ -30,16 +28,12 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
         public async ValueTask<bool> HasDesignTimeBuildsAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.Register(_cancellationTokenSource.Cancel);
-
             return await _hasDesignTimeBuild.GetValueAsync(cancellationToken);
         }
 
         private async Task<bool> HasDesignTimeBuildsInternalAsync()
         {
-            CancellationToken token = _cancellationTokenSource.Token;
-
-            IVsAppCommandLine vsAppCommandLine = await _vsAppCommandLine.GetValueAsync(token);
+            IVsAppCommandLine vsAppCommandLine = await _vsAppCommandLine.GetValueAsync();
 
             if (ErrorHandler.Succeeded(vsAppCommandLine.GetOption("populateSolutionCache", out int populateSolutionCachePresent, out string _)))
             {
@@ -50,7 +44,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 }
             }
 
-            IVsAppId vsAppId = await _vsAppId.GetValueAsync(token);
+            IVsAppId vsAppId = await _vsAppId.GetValueAsync();
 
             if (ErrorHandler.Succeeded(vsAppId.GetProperty((int)__VSAPROPID10.VSAPROPID_IsInCommandLineMode, out object value)))
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -15,8 +15,4 @@
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="ProjectSystem\VS\PackageRestore\Snapshots\" />
-  </ItemGroup>
-
 </Project>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests.csproj
@@ -15,4 +15,8 @@
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.ProjectSystem.Managed\Microsoft.VisualStudio.ProjectSystem.Managed.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes #9424

Replaces API usage:

- From `_vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, ...)`
- To `vsAppId.GetProperty((int)__VSAPROPID10.VSAPROPID_IsInCommandLineMode, ...)`

The latter is free-threaded, as described in: https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/40079/Free-threaded-replacements

This requires bumping several VS packages to 17.11, in order to use `__VSAPROPID10.VSAPROPID_IsInCommandLineMode`.

Also, `IVsAppCommandLine` is free-threaded, so don't use `IVsUIService` for that, as given in: https://github.com/microsoft/VSSDK-Analyzers/blob/614165cfdca3245dd8c19530bd054e24cd80be32/src/Microsoft.VisualStudio.SDK.Analyzers.CodeFixes/build/AdditionalFiles/vs-threading.MembersRequiringMainThread.txt#L84

Together, these changes mean we don't need to switch to the main thread in `UpToDateCheckHost` 👍 

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9458)