### PR TITLE
Bump VSSDK version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -61,8 +61,8 @@
     <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.7.36307-preview.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.3.32804.24" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.5.18-preview1" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="7.0.0" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.11.54-preview1" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="8.0.0" />
     <PackageVersion Include="Microsoft.VSDesigner"                                                   Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="VsWebSite.Interop"                                                      Version="16.8.30523.219" />
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/UnconfiguredProjectFactory.cs
@@ -75,6 +75,10 @@ namespace Microsoft.VisualStudio.ProjectSystem
                 unconfiguredProjectServicesMock.Setup(u => u.ProjectAsynchronousTasks)
                                            .Returns(projectAsynchronousTasksService!);
 
+                var projectThreadingService = IProjectThreadingServiceFactory.Create(verifyOnUIThread: false);
+                unconfiguredProjectServicesMock.Setup(u => u.ThreadingPolicy)
+                                           .Returns(projectThreadingService);
+
                 unconfiguredProjectServices = unconfiguredProjectServicesMock.Object;
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/project-system/issues/9424

We bump the VSSDK to 17.11. As part of this, we receive warnings to replace `AsyncSemaphore` with `ReentrantSemaphore`. This PR includes that recommended change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9460)