### PR TITLE
Rename the legacy "Managed Resource Editor" editor factory

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/VSPackage.resx
+++ b/src/Microsoft.VisualStudio.Editors/VSPackage.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="1100" xml:space="preserve">
-    <value>Managed Resources Editor</value>
+    <value>Managed Resources Editor (Legacy)</value>
     <comment>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</comment>
   </data>
   <data name="1200" xml:space="preserve">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.cs.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.cs.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Editor spravovaných prostředků</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Editor spravovaných prostředků</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.de.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.de.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="de" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Editor für verwaltete Ressourcen</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Editor für verwaltete Ressourcen</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.es.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.es.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="es" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Editor de recursos administrados</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Editor de recursos administrados</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.fr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.fr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Éditeur de ressources managées</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Éditeur de ressources managées</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.it.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.it.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="it" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Editor risorse gestite</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Editor risorse gestite</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.ja.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.ja.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">マネージド リソース エディター</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">マネージド リソース エディター</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.ko.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.ko.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">관리되는 리소스 편집기</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">관리되는 리소스 편집기</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.pl.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.pl.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Edytor zarządzanych zasobów</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Edytor zarządzanych zasobów</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.pt-BR.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Editor de Recursos Gerenciados</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Editor de Recursos Gerenciados</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.ru.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.ru.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Редактор управляемых ресурсов</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Редактор управляемых ресурсов</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.tr.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.tr.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">Yönetilen Kaynak Düzenleyicisi</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">Yönetilen Kaynak Düzenleyicisi</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.zh-Hans.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">托管资源编辑器</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">托管资源编辑器</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">

--- a/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.Editors/xlf/VSPackage.zh-Hant.xlf
@@ -3,8 +3,8 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../VSPackage.resx">
     <body>
       <trans-unit id="1100">
-        <source>Managed Resources Editor</source>
-        <target state="translated">受控資源編輯器</target>
+        <source>Managed Resources Editor (Legacy)</source>
+        <target state="needs-review-translation">受控資源編輯器</target>
         <note>Used for the resource editor in the shell's "Open With..." dialog plus the editor name for the key-binding it the Tools | Options | Environment | Keyboard | Use new shourtcut.</note>
       </trans-unit>
       <trans-unit id="1200">


### PR DESCRIPTION
When a user right-clicks a `.resx` file in Solution Explorer and selects "Open With..." they are presented with a list of editor factories.

With the forthcoming introduction of the Resource Explorer, users are now presented with (among other options):

- "Resource Explorer"
- "Managed Resources Editor"

The second is the legacy experience. This change appends a "(Legacy)" to the name of the editor to help differentiate between the two, and to help users find the improved editor.

---

This is the UI that will be updated by this change:

![image](https://github.com/dotnet/project-system/assets/350947/fe7dd477-59c0-4d92-a44a-995eeb99fdec)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9468)