### PR TITLE
Avoid contention in Roslyn language service

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
+  <!--
+      NOTE packages and their versions listed here must be specified in the dotnet-project-system-public-packages feed here:
+      https://dev.azure.com/azure-public/vside/_artifacts/feed/dotnet-project-system-public-packages
+  -->
+
   <ItemGroup>
     <!-- Infrastructure -->
     <!-- This package is deprecated. CodecovUploader is now the recommended package. -->
@@ -30,6 +35,7 @@
     <PackageVersion Include="Nerdbank.GitVersioning"                                                 Version="3.6.79-alpha" />
     <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.11.72" />
     <PackageVersion Include="System.IO.Pipelines"                                                    Version="8.0.0" />
+    <PackageVersion Include="StreamJsonRpc"                                                          Version="2.18.53" />
 
     <!-- VS SDK -->
     <!-- https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk -->
@@ -77,18 +83,18 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes"                         Version="$(CPSPackageVersion)" />
 
     <!-- Roslyn -->
-    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.8.0-3.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.11.0-1.24225.10" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.11.0-1.24225.10" />
     <PackageVersion Include="Microsoft.CSharp"                                                       Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.10.0-3.24157.9" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.11.0-1.24225.10" />
     <PackageVersion Include="Microsoft.VisualStudio.IntegrationTest.Utilities"                       Version="2.6.0-beta1-62113-02" />
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.11.0-1.24225.10" />
 
     <!-- Analyzers -->
     <PackageVersion Include="CSharpIsNullAnalyzer"                                                   Version="0.1.329" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.11.0-beta1.23472.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.8.0-3.final" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.8.0-3.final" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.11.0-1.24225.10" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.11.0-1.24225.10" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers"                                           Version="3.11.0-beta1.23472.1" />
 
     <!-- NuGet -->

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -58,6 +58,9 @@
 
     <!-- Host-Agnostic Visual Studio -->
     <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" />
+
+    <!-- To resolve assembly versioning issue by pinning a specific version. Should remove in future when packages fixed. -->
+    <PackageReference Include="StreamJsonRpc" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsUnitTestProject)' == 'true'">

--- a/spelling.dic
+++ b/spelling.dic
@@ -71,6 +71,7 @@ unescape
 unescapes
 ushort
 usings
+vbproj
 vswhidbey
 watson
 xaml

--- a/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
+++ b/src/Microsoft.VisualStudio.AppDesigner/Microsoft.VisualStudio.AppDesigner.vbproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <PackageReference Remove="Microsoft.VisualStudio.ProjectSystem*" />
   </ItemGroup>
+  
   <ItemGroup>
     <Compile Include="..\Common\ManagedCodeMarkers.vb">
       <Link>ManagedCodeMarkers.vb</Link>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/AdditionalFilesItemHandler.cs
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             if (!_paths.Contains(fullPath))
             {
                 logger.WriteLine("Adding additional file '{0}'", fullPath);
-                context.AddAdditionalFile(fullPath, isActiveContext);
+                context.AddAdditionalFile(fullPath, folderNames: [], isActiveContext);
                 bool added = _paths.Add(fullPath);
                 Assumes.True(added);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/CommandLineNotificationHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/CommandLineNotificationHandler.cs
@@ -18,18 +18,18 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
         public CommandLineNotificationHandler(UnconfiguredProject project)
         {
             // See FSharpCommandLineParserService.HandleCommandLineNotifications for an example of this export
-            CommandLineNotifications = new OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>>(projectCapabilityCheckProvider: project);
+            CommandLineNotifications = new OrderPrecedenceImportCollection<Action<string?, BuildOptions, BuildOptions>>(projectCapabilityCheckProvider: project);
         }
 
         /// <remarks>
         /// See <see cref="FSharpCommandLineParserService.HandleCommandLineNotifications"/> for an export.
         /// </remarks>
         [ImportMany]
-        public OrderPrecedenceImportCollection<Action<string, BuildOptions, BuildOptions>> CommandLineNotifications { get; }
+        public OrderPrecedenceImportCollection<Action<string?, BuildOptions, BuildOptions>> CommandLineNotifications { get; }
 
         public void Handle(IWorkspaceProjectContext context, IComparable version, BuildOptions added, BuildOptions removed, ContextState state, IManagedProjectDiagnosticOutputService logger)
         {
-            foreach (Lazy<Action<string, BuildOptions, BuildOptions>, IOrderPrecedenceMetadataView> value in CommandLineNotifications)
+            foreach (Lazy<Action<string?, BuildOptions, BuildOptions>, IOrderPrecedenceMetadataView> value in CommandLineNotifications)
             {
                 value.Value(context.BinOutputPath, added, removed);
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -525,16 +525,14 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
                     isActiveEditorContext: _activeEditorContextTracker.IsActiveEditorContext(ContextId),
                     isActiveConfiguration: IsPrimary);
 
-                Context.StartBatch();
-
                 try
                 {
+                    await using IAsyncDisposable _ = await Context.CreateBatchScopeAsync(cancellationToken);
+
                     applyFunc(update, contextState, cancellationToken);
                 }
                 finally
                 {
-                    await Context.EndBatchAsync();
-
                     UpdateProgressRegistration();
                 }
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -656,7 +656,7 @@
     <ItemGroup>
       <NpmContent Include="exports.json" />
       <!-- We have a runtime dependency on Microsoft.CodeAnalysis.dll in VS Code scenarios. -->
-      <NpmContent Include="$(PkgMicrosoft_CodeAnalysis_Common)\lib\net7.0\Microsoft.CodeAnalysis.dll" />
+      <NpmContent Include="$(PkgMicrosoft_CodeAnalysis_Common)\lib\net8.0\Microsoft.CodeAnalysis.dll" />
       <NpmContent Include="@(SatelliteDllsProjectOutputGroupOutput)">
         <PackagePath>%(SatelliteDllsProjectOutputGroupOutput.TargetPath)</PackagePath>
       </NpmContent>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectThreadingServiceFactory.cs
@@ -8,15 +8,5 @@ namespace Microsoft.VisualStudio.ProjectSystem
         {
             return new ProjectThreadingService(verifyOnUIThread);
         }
-
-        public static IProjectThreadingService ImplementVerifyOnUIThread(Action action)
-        {
-            var mock = new Mock<IProjectThreadingService>();
-
-            mock.Setup(s => s.VerifyOnUIThread())
-                .Callback(action);
-
-            return mock.Object;
-        }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -183,6 +183,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties
                     """[assembly: System.AssemblyDescriptionAttribute("MyDescription")]""")]
         public async Task SourceFileProperties_SetPropertyValueAsync(string code, string propertyName, string propertyValue, string expectedCode)
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             var provider = CreateProviderForSourceFileValidation(code, out Workspace workspace);
             var projectFilePath = workspace.CurrentSolution.Projects.First().FilePath;
             Assumes.NotNull(projectFilePath);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Utilities/SynchronizationContextUtil.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Utilities/SynchronizationContextUtil.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+namespace Microsoft.VisualStudio;
+
+internal static class SynchronizationContextUtil
+{
+    /// <summary>
+    /// Sets a <see langword="null"/> <see cref="SynchronizationContext"/>, and restores
+    /// whatever context was <see cref="SynchronizationContext.Current"/> when disposed.
+    /// </summary>
+    /// <remarks>
+    /// This method is intended for use in tests where we use JTF and test code that
+    /// wants to switch to the main thread. Some of our tests don't actually construct
+    /// JTF in a way that creates a main thread that can be switched to. For these cases,
+    /// whatever thread creates the <see cref="Threading.JoinableTaskContext"/> is considered
+    /// the main thread. In unit tests, it's likely this is a thread pool thread, and
+    /// attempting to switch to the main thread will land on another thread pool thread.
+    /// <see cref="Threading.JoinableTaskFactory.SwitchToMainThreadAsync(CancellationToken)"/>
+    /// attempts to validate the switch was successful, and throws when not. This causes test
+    /// failures where we don't have a main thread to switch to. A workaround for this is
+    /// to suppress the synchronization context, which disables the check and allows the test
+    /// to pass.
+    /// </remarks>
+    /// <returns>An object that restores the previous synchronization context when disposed.</returns>
+    public static IDisposable Suppress()
+    {
+        SynchronizationContext old = SynchronizationContext.Current;
+
+        SynchronizationContext.SetSynchronizationContext(null);
+
+        return new SuppressionReleaser(old);
+    }
+
+    private sealed class SuppressionReleaser(SynchronizationContext old) : IDisposable
+    {
+        private int _isDisposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _isDisposed, 1) is 0)
+            {
+                SynchronizationContext.SetSynchronizationContext(old);
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceProjectContextMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IWorkspaceProjectContextMock.cs
@@ -7,6 +7,13 @@ namespace Microsoft.VisualStudio.LanguageServices.ProjectSystem
         public IWorkspaceProjectContextMock()
         {
             SetupAllProperties();
+
+            Mock<IAsyncDisposable> batchScopeDisposable = new();
+
+            batchScopeDisposable.Setup(o => o.DisposeAsync());
+
+            Setup(o => o.CreateBatchScopeAsync(It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<IAsyncDisposable>(batchScopeDisposable.Object));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
@@ -17,11 +17,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 public class WorkspaceTests
 {
     private static BuildOptions EmptyBuildOptions { get; } = new BuildOptions(
-            sourceFiles: ImmutableArray<CommandLineSourceFile>.Empty,
-            additionalFiles: ImmutableArray<CommandLineSourceFile>.Empty,
-            metadataReferences: ImmutableArray<CommandLineReference>.Empty,
-            analyzerReferences: ImmutableArray<CommandLineAnalyzerReference>.Empty,
-            analyzerConfigFiles: ImmutableArray<string>.Empty);
+        sourceFiles: [],
+        additionalFiles: [],
+        metadataReferences: [],
+        analyzerReferences: [],
+        analyzerConfigFiles: []);
 
     [Fact]
     public async Task Dispose_DisposesChainedDisposables()
@@ -366,7 +366,7 @@ public class WorkspaceTests
             }
             """);
 
-        Mock<IWorkspaceProjectContext> workspaceProjectContext = new(MockBehavior.Loose);
+        Mock<IWorkspaceProjectContext> workspaceProjectContext = new IWorkspaceProjectContextMock();
         Mock<IWorkspaceUpdateHandler> updateHandler = new(MockBehavior.Strict);
         Mock<IProjectEvaluationHandler> projectEvaluationHandler = updateHandler.As<IProjectEvaluationHandler>();
 
@@ -426,7 +426,7 @@ public class WorkspaceTests
             }
             """);
 
-        Mock<IWorkspaceProjectContext> workspaceProjectContext = new(MockBehavior.Loose);
+        Mock<IWorkspaceProjectContext> workspaceProjectContext = new IWorkspaceProjectContextMock();
         Mock<IWorkspaceUpdateHandler> updateHandler = new(MockBehavior.Strict);
         Mock<IProjectEvaluationHandler> projectEvaluationHandler = updateHandler.As<IProjectEvaluationHandler>();
 
@@ -474,7 +474,7 @@ public class WorkspaceTests
             }
             """);
 
-        Mock<IWorkspaceProjectContext> workspaceProjectContext = new(MockBehavior.Loose);
+        Mock<IWorkspaceProjectContext> workspaceProjectContext = new IWorkspaceProjectContextMock();
         Mock<IWorkspaceUpdateHandler> updateHandler = new(MockBehavior.Strict);
         Mock<ISourceItemsHandler> sourceItemsHandler = updateHandler.As<ISourceItemsHandler>();
 
@@ -534,7 +534,7 @@ public class WorkspaceTests
               }
               """);
 
-        Mock<IWorkspaceProjectContext> workspaceProjectContext = new(MockBehavior.Loose);
+        Mock<IWorkspaceProjectContext> workspaceProjectContext = new IWorkspaceProjectContextMock();
         Mock<IWorkspaceUpdateHandler> updateHandler = new(MockBehavior.Strict);
         Mock<ICommandLineHandler> commandLineHandler = updateHandler.As<ICommandLineHandler>();
 
@@ -622,14 +622,14 @@ public class WorkspaceTests
     }
 
     [Fact]
-    public async Task Update_StartBatchThrows()
+    public async Task Update_CreateBatchScopeAsyncThrows()
     {
         Exception ex = new("Error starting batch");
 
         Mock<IWorkspaceProjectContext> workspaceProjectContext = new(MockBehavior.Strict);
 
-        // StartBatch throws
-        workspaceProjectContext.Setup(o => o.StartBatch()).Throws(ex);
+        // CreateBatchScopeAsync throws
+        workspaceProjectContext.Setup(o => o.CreateBatchScopeAsync(It.IsAny<CancellationToken>())).Throws(ex);
 
         // Expect disposal
         workspaceProjectContext.Setup(o => o.Dispose());
@@ -640,15 +640,17 @@ public class WorkspaceTests
     }
 
     [Fact]
-    public async Task Update_EndBatchAsyncThrows()
+    public async Task Update_BatchScopeDisposalThrows()
     {
         Exception ex = new("Error starting batch");
 
         Mock<IWorkspaceProjectContext> workspaceProjectContext = new(MockBehavior.Strict);
+        Mock<IAsyncDisposable> batchScopeDisposable = new();
 
-        // EndBatchAsync throws
-        workspaceProjectContext.Setup(o => o.StartBatch());
-        workspaceProjectContext.Setup(o => o.EndBatchAsync()).Throws(ex);
+        // DisposeAsync throws
+        batchScopeDisposable.Setup(o => o.DisposeAsync()).Throws(ex);
+
+        workspaceProjectContext.Setup(o => o.CreateBatchScopeAsync(It.IsAny<CancellationToken>())).Returns(new ValueTask<IAsyncDisposable>(batchScopeDisposable.Object));
 
         // Expect disposal
         workspaceProjectContext.Setup(o => o.Dispose());
@@ -817,7 +819,7 @@ public class WorkspaceTests
         activeWorkspaceProjectContextTracker ??= IActiveEditorContextTrackerFactory.Create();
         commandLineParserServices ??= new(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst) { commandLineParserService.Object };
         dataProgressTrackerService ??= IDataProgressTrackerServiceFactory.Create();
-        workspaceProjectContext ??= Mock.Of<IWorkspaceProjectContext>(MockBehavior.Loose);
+        workspaceProjectContext ??= new IWorkspaceProjectContextMock().Object;
         workspaceProjectContextFactory ??= IWorkspaceProjectContextFactoryFactory.ImplementCreateProjectContext(delegate { return workspaceProjectContext; });
         faultHandlerService ??= IProjectFaultHandlerServiceFactory.Create();
 #pragma warning disable VSSDK005

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/CSharp/RenamerTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         [InlineData("namespace n1 {class Foo{}} namespace n2 {class Foo{}}", "Foo.cs", "Bar.cs")]
         public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string sourceCode, string oldFilePath, string newFilePath)
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
@@ -42,6 +44,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         [InlineData("namespace n1 {class Foo{}} namespace n2 {class Foo{}}", "Foo.cs", "Bar.cs")]
         public async Task Rename_Symbol_ShouldNot_TriggerUserConfirmationAsync(string sourceCode, string oldFilePath, string newFilePath)
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new CSharpSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
@@ -72,7 +76,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
             var settingsManagerService = CreateSettingsManagerService(true);
 
-            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService).TimeoutAfter(TimeSpan.FromSeconds(1));
+            await RenameAsync(sourceCode, oldFilePath, newFilePath, userNotificationServices, roslynServices, vsOnlineServices, LanguageNames.CSharp, settingsManagerService).TimeoutAfter(TimeSpan.FromSeconds(30));
 
             Mock.Get(userNotificationServices).Verify(h => h.Confirm(It.IsAny<string>()), Times.Never);
             Mock.Get(roslynServices).Verify(h => h.ApplyChangesToSolution(It.IsAny<Workspace>(), It.IsAny<Solution>()), Times.Never);
@@ -116,8 +120,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.CSharp
         }
 
         [Fact]
-        public async Task Rename_Symbol_Should_ExitEarlyWhenFileDoesntChangeName()
+        public async Task Rename_Symbol_Should_ExitEarlyWhenFileDoesNotChangeName()
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             string sourceCode = "class Foo { }";
             string oldFilePath = "Foo.cs";
             string newFilePath = "FOO.cs";

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/RenamerTestsBase.cs
@@ -84,6 +84,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             string language, 
             IVsService<SVsSettingsPersistenceManager, ISettingsManager> settingsManagerService)
         {
+            // Configure mocks.
             var unconfiguredProject = UnconfiguredProjectFactory.Create(fullPath: $@"C:\project1.{ProjectFileExtension}");
             var projectServices = IUnconfiguredProjectVsServicesFactory.Implement(
                 threadingServiceCreator: () => IProjectThreadingServiceFactory.Create(),
@@ -92,36 +93,40 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename
             using var ws = new AdhocWorkspace();
             ws.AddSolution(InitializeWorkspace(ProjectId.CreateNewId(), oldFilePath, sourceCode, language));
 
-            var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement((string category, string page, string property, bool defaultValue) => { return true; });
-            var waitIndicator = (new Mock<IWaitIndicator>()).Object;
+            var environmentOptionsFactory = IEnvironmentOptionsFactory.Implement<bool>((_, _, _, _) => true);
+            var waitIndicator = Mock.Of<IWaitIndicator>();
             var projectAsynchronousTasksService = IProjectAsynchronousTasksServiceFactory.Create();
             var projectThreadingService = IProjectThreadingServiceFactory.Create();
-            var refactorNotifyService = (new Mock<IRefactorNotifyService>()).Object;
-            var extensibility = new Mock<IVsUIService<IVsExtensibility, IVsExtensibility3>>().Object;
-            var operationProgressMock = new Mock<IVsService<SVsOperationProgress, IVsOperationProgressStatusService>>().Object;
-            var context = new Mock<IProjectTreeActionHandlerContext>().Object;
+            var refactorNotifyService = Mock.Of<IRefactorNotifyService>();
+            var extensibility = Mock.Of<IVsUIService<IVsExtensibility, IVsExtensibility3>>();
+            var operationProgressMock = Mock.Of<IVsService<SVsOperationProgress, IVsOperationProgressStatusService>>();
+            var context = Mock.Of<IProjectTreeActionHandlerContext>();
 
             var mockNode = new Mock<IProjectTree>();
             mockNode.SetupGet(x => x.FilePath).Returns(oldFilePath);
             mockNode.SetupGet(x => x.IsFolder).Returns(false);
             var node = mockNode.Object;
 
-            var renamer = new TestRenamerProjectTreeActionHandler(unconfiguredProject,
-                                                              projectServices,
-                                                              new Lazy<Workspace>(() => ws),
-                                                              environmentOptionsFactory,
-                                                              userNotificationServices,
-                                                              roslynServices,
-                                                              waitIndicator,
-                                                              vsOnlineServices,
-                                                              projectAsynchronousTasksService,
-                                                              projectThreadingService,
-                                                              extensibility,
-                                                              operationProgressMock,
-                                                              settingsManagerService);
+            // Construct the renamer.
+            var renamer = new TestRenamerProjectTreeActionHandler(
+                unconfiguredProject,
+                projectServices,
+                new Lazy<Workspace>(() => ws),
+                environmentOptionsFactory,
+                userNotificationServices,
+                roslynServices,
+                waitIndicator,
+                vsOnlineServices,
+                projectAsynchronousTasksService,
+                projectThreadingService,
+                extensibility,
+                operationProgressMock,
+                settingsManagerService);
 
-            await renamer.RenameAsync(context, node, newFilePath)
-                         .TimeoutAfter(TimeSpan.FromSeconds(1));
+            // Perform the rename, with a timeout in case of hangs.
+            await renamer
+                .RenameAsync(context, node, newFilePath)
+                .TimeoutAfter(TimeSpan.FromSeconds(30));
         }
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rename/VisualBasic/RenamerTests.cs
@@ -91,6 +91,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
                     """)]
         public async Task Rename_Symbol_Should_Not_HappenAsync(string oldFilePath, string newFilePath, string sourceCode)
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
@@ -152,6 +154,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
             """)]
         public async Task Rename_Symbol_Should_TriggerUserConfirmationAsync(string oldFilePath, string newFilePath, string sourceCode)
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             var userNotificationServices = IUserNotificationServicesFactory.Create();
             var roslynServices = IRoslynServicesFactory.Implement(new VisualBasicSyntaxFactsService());
             var vsOnlineServices = IVsOnlineServicesFactory.Create(online: false);
@@ -208,8 +212,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename.VisualBasic
         }
 
         [Fact]
-        public async Task Rename_Symbol_Should_ExitEarlyWhenFileDoesntChangeName()
+        public async Task Rename_Symbol_Should_ExitEarlyWhenFileDoesNotChangeName()
         {
+            using var _ = SynchronizationContextUtil.Suppress();
+
             string sourceCode =
                 """
                 Class Foo


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1881089

Roslyn recently introduced async API for obtaining and releasing "batch" objects for applying updates in https://github.com/dotnet/roslyn/pull/72424.

This change increases the package versions, uses the newer API, fixes some obsolete usages, and gets things building by adding a few package references in order to break the tie on some assembly version conflicts during build.

---

This is another iteration of https://github.com/dotnet/project-system/pull/9455, which was reverted due to issues it created during signing. Unlike that prior PR, this does not remove `Microsoft.VisualStudio.Internal.MicroBuild.Swix`.

###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9471)