### PR TITLE
Make PropPageDesignerView update font on WM_SETTINGCHANGE

### DIFF
--- a/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
+++ b/src/Microsoft.VisualStudio.AppDesigner/PropPageDesigner/PropPageDesignerView.vb
@@ -536,6 +536,11 @@ Namespace Microsoft.VisualStudio.Editors.PropPageDesigner
             Select Case msg
                 Case Win32Constant.WM_PALETTECHANGED, Win32Constant.WM_SYSCOLORCHANGE, Win32Constant.WM_THEMECHANGED
                     OnThemeChanged()
+                Case Win32Constant.WM_SETTINGCHANGE
+                    Dim newFont As Font = ShellUtil.FontChangeMonitor.GetDialogFont(Me)
+                    If Not newFont.Equals(Font) Then
+                        Font = newFont
+                    End If
             End Select
         End Sub
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2060273

The two combo boxes at the top of property pages - Configuration and Platform - do not respond to system-wide font changes. I am adding screenshots taken after increasing the text size via Accessibility -> Text size Windows setting.

**Before:**
![image](https://github.com/dotnet/project-system/assets/12206368/eed6f1c4-423c-41f3-953b-45583fcb4fb7)

**After:**
![image](https://github.com/dotnet/project-system/assets/12206368/9cf76e64-082a-4b7d-9caf-b15576a8aca8)

The fix implements the logic already in place for other controls.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9472)