### PR TITLE
Allow re-entrancy in ProjectHotReloadSessionManager's semaphore

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -52,7 +52,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
             _semaphore = ReentrantSemaphore.Create(
                 initialCount: 1,
                 joinableTaskContext: project.Services.ThreadingPolicy.JoinableTaskContext.Context,
-                mode: ReentrantSemaphore.ReentrancyMode.NotAllowed);
+                mode: ReentrantSemaphore.ReentrancyMode.Freeform);
         }
 
         public async Task ActivateSessionAsync(int processId, bool runningUnderDebugger, string projectName)


### PR DESCRIPTION
Fixes [AB#2065632](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2065632)

After updating the VSSDK in #9460, we converted a bunch of usages of `AsyncSemaphore` to `ReentrantSemaphore`.

This has caused an issue in hot reload.

The new semaphore class has several modes. We change from disallowing re-entrancy, so allowing freeform re-entrancy.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9473)