### PR TITLE
Removes files that do not need code signing checked 

### DIFF
--- a/eng/pipelines/templates/analyze-compliance.yml
+++ b/eng/pipelines/templates/analyze-compliance.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
   # Most SDL tasks are run through the 1ES official pipeline template: https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/overview
-  # However, we still must run CodeSign and APIScan ourselves
+  # However, we still must run APIScan ourselves
 
   ###################################################################################################################################################################
   # RUN ANALYSIS
@@ -18,33 +18,6 @@ steps:
   - script:
     displayName: === Run Analysis ===
     condition: false
-
-  # Verify the loose DLLs are signed appropriately.
-  # Note: This task takes ~3 minutes only because it is the first Guardian task in this job. So, it installs the Guardian components so the other tasks don't have to.
-  # YAML reference: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/code-signing-validation-build-task#v1-preview
-  - task: CodeSign@1
-    displayName: Verify Signed DLLs
-    inputs:
-      Path: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/bin/Dlls/
-      # Glob Format: https://dev.azure.com/securitytools/SecurityIntegration/_wiki/wikis/Guardian/1378/Glob-Format
-      Targets: '**/Microsoft.VisualStudio.AppDesigner*.dll;**/Microsoft.VisualStudio.Editors*.dll;**/Microsoft.VisualStudio.ProjectSystem.Managed*.dll'
-    condition: succeededOrFailed()
-
-  # Verifies the packages (and files within) are signed appropriately.
-  - task: MicroBuildCodesignVerify@3
-    displayName: Verify Signed Packages
-    inputs:
-      TargetFolders: |
-        $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/packages
-        $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/VSSetup/Insertion
-      # Filters out certain files (usually by extension) for Authenticode certificate verification.
-      # File Format:
-      #   Wildcards (* and ?) can be used and paths are relative to the TargetFolders locations.
-      #   Format is one entry per line followed by a comma and then a comment as to why the entry is approved.
-      ApprovalListPathForCerts: $(Build.SourcesDirectory)/eng/pipelines/configuration/AuthenticodeSigningFilter.txt
-      # The bootstrapper folder is placed inside the VSSetup/Insertion folder. We don't want to verify the VS bootstrapper for signing.
-      ExcludeFolders: bootstrapper
-    condition: succeededOrFailed()
 
   # Scan for the use of undocumented APIs.
   # YAML reference: https://eng.ms/docs/security-compliance-identity-and-management-scim/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/apiscan-build-task#v2

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -262,8 +262,12 @@ jobs:
         !obj\**
         !bin\UnitTests\**
         !bin\IntegrationTests\**
+        !bin\Dlls\net472\ProjectSystemSetup.dll
+        !bin\Dlls\net472\VisualStudioEditorsSetup.dll
         !bin\Dlls\net472\Setup.dll
         !SymStore\**    
+        !VSSetup\Insertion\bootstrapper\**\vs_enterprise.exe
+        
     
     # Authenticate with a service connection to be able to publish packages to external (different DevOps organization) NuGet feeds.
   # See: https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -26,12 +26,12 @@ jobs:
         zipSources: false
       sbom:
         enabled: true
-    outputParentDirectory: $(Build.SourcesDirectory)/artifacts
+    outputParentDirectory: $(Build.SourcesDirectory)/artifacts/output
     outputs:
       # Publish artifacts
       - output: pipelineArtifact
         displayName: Publish Build Artifacts
-        targetPath: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)
+        targetPath: $(Build.SourcesDirectory)/artifacts/output
         artifactName: $(Build.BuildNumber)
         condition: succeededOrFailed()
       - output: pipelineArtifact
@@ -41,13 +41,13 @@ jobs:
         condition: succeededOrFailed()
       - output: pipelineArtifact
         displayName: Publish Loc Artifacts
-        targetPath: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/bin/Dlls/
+        targetPath: $(Build.SourcesDirectory)/artifacts/output/bin/Dlls/
         artifactName: Loc
         condition: succeededOrFailed()
     
       # Publish VS drop
       - output: microBuildVstsDrop
-        dropFolder: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)/VSSetup/Insertion
+        dropFolder: $(Build.SourcesDirectory)/artifacts/output/VSSetup/Insertion
         # TODO: Consider using $(GitBuildVersion) instead of $(Build.BuildNumber) as it better correlates the build of the code to the VS insertion.
         # Meaning, instead of VS Insertion -> Pipeline BuildNumber -> Code BuildVersion, it would just be VS Insertion -> Code BuildVersion.
         # If this is updated, VstsDropNames set in build-official-release.yml would also need to be updated.
@@ -250,8 +250,22 @@ jobs:
   - powershell: Copy-Item -Path '$(Build.SourcesDirectory)/eng/pipelines/configuration/staging.artifactignore' -Destination '$(Build.StagingDirectory)/.artifactignore'
     displayName: Copy Staging Artifact Filter
     condition: succeededOrFailed()
-
-  # Authenticate with a service connection to be able to publish packages to external (different DevOps organization) NuGet feeds.
+    
+    # This output folder is used for 1ES code signing validation
+  - task: CopyFiles@2
+    displayName: Copy necessary files to output folder
+    inputs:
+      SourceFolder: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)
+      TargetFolder: $(Build.SourcesDirectory)/artifacts/output
+      Contents: |
+        *\**
+        !obj\**
+        !bin\UnitTests\**
+        !bin\IntegrationTests\**
+        !bin\Dlls\net472\Setup.dll
+        !SymStore\**    
+    
+    # Authenticate with a service connection to be able to publish packages to external (different DevOps organization) NuGet feeds.
   # See: https://docs.microsoft.com/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops
   # This connecction is used in the templateContext nuget outputs.
   - task: NuGetAuthenticate@1

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -263,6 +263,7 @@ jobs:
         !bin\UnitTests\**
         !bin\IntegrationTests\**
         !bin\Dlls\net472\ProjectSystemSetup.dll
+        !bin\Dlls\net472\ProjectSystem.dll
         !bin\Dlls\net472\VisualStudioEditorsSetup.dll
         !bin\Dlls\net472\Setup.dll
         !SymStore\**    


### PR DESCRIPTION
Unit test, integration test, and setup dlls all fall under this banner, as well as the vs bootstrapper and a file produced under the SymStore directory path.

successful build: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9655384&view=logs&j=3de96e8d-b8d1-5108-47b8-f6a54739db67&t=ae45fcc0-4c88-53b1-520c-1a3469c00c6b