### PR TITLE
Add `SdkAnalysisLevel` and `UsingMicrosoftNETSdk` to NuGet nominations

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -141,6 +141,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="UsingMicrosoftNETSdk"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="TargetFramework"
                   ReadOnly="True"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -137,6 +137,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="SdkAnalysisLevel"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="TargetFramework"
                   ReadOnly="True"
                   Visible="False" />


### PR DESCRIPTION
Add `SdkAnalysisLevel` and `UsingMicrosoftNETSdk` to the properties that are sent to NuGet during nomination, for restore.
Related PR : https://github.com/NuGet/NuGet.Client/pull/5833
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9482)