### PR TITLE
Send telemetry when CodeModel is used

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Telemetry/TelemetryEventName.cs
@@ -70,5 +70,11 @@ namespace Microsoft.VisualStudio.Telemetry
         ///     Indicates that the NuGet restore detected a cycle.
         /// </summary>
         public const string NuGetRestoreCycleDetected = "vs/projectsystem/managed/nugetrestore/cycledetected";
+
+        /// <summary>
+        ///     Notifies that the legacy CodeModel was requested for a given project.
+        ///     Only fires once per unconfigured project.
+        /// </summary>
+        public const string CodeModelRequested = "vs/projectsystem/managed/codemodel/requested";
     }
 }


### PR DESCRIPTION
CodeModel is part of DTE and should not be being used in core VS scenarios. However extensions and some legacy components may still be hitting this code path.

We want to understand scenarios in which these code paths are used, and hope to use that information to improve startup performance when initializing language services.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9483)