### PR TITLE
Add CollectNuGetAuditSupressions target

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -421,6 +421,12 @@
        sent to NuGet to be restored.-->
   <Target Name="CollectPackageReferences" Returns="@(PackageReference)" />
 
+  <!-- This target is used to collect the NuGet audit supression items. It is defined by the .NET SDK starting in version 8.0.400, but we need this no-op
+       implementation when using older SDKs that don't have it; otherwise our design-time builds will fail. The NuGet.targets file in the SDK is imported
+       _after_ this file, and will override this implementation with the real one (when present).
+       This can (and should) be removed when we no longer need to support SDKs older than 8.0.400. -->
+  <Target Name="CollectNuGetAuditSuppressions" Returns="@(NuGetAuditSuppress)" />
+  
   <!-- This target is used to collect the SuggestedWorkload items in the project.-->
   <Target Name="CollectSuggestedWorkloads"
           Returns="@(SuggestedWorkload)"


### PR DESCRIPTION
Related to PR #9470.

After PR #9470, VS and C# Dev Kit will attempt to collect NuGet audit suppression items via the `CollectNuGetAuditSuppressions` target. However, this target new to the 8.0.400 version of the .NET SDK. If a project is using an older version of the SDK our design-time build will now fail with complaints that the target doesn't exist.

To work around this, here we update Microsoft.Managed.DesignTime.targets to include a no-op version of the target. This file ships with VS and the C# Dev Kit, not the SDK, and so we can guarantee that the target will always be present when we need it. The real definition in the SDK is in NuGet.targets; this file is imported _after_ Microsoft.Managed.DesignTime.targets and so the real definition, when it exists, will automatically replace the no-op definition.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9486)