### PR TITLE
Update CPS to version 11.17.207

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,17 +33,17 @@
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.Vsman"                       Version="2.0.115" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core"                              Version="1.0.0" />
     <PackageVersion Include="Nerdbank.GitVersioning"                                                 Version="3.6.79-alpha" />
-    <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.11.72" />
+    <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.11.74" />
     <PackageVersion Include="System.IO.Pipelines"                                                    Version="8.0.0" />
-    <PackageVersion Include="StreamJsonRpc"                                                          Version="2.18.53" />
+    <PackageVersion Include="StreamJsonRpc"                                                          Version="2.19.23" />
 
     <!-- VS SDK -->
     <!-- https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk -->
     <PackageVersion Include="EnvDTE"                                                                 Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.11.38822-preview.1" />
-    <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.5.37" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.6.13" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.11.111-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.10.39" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.11.9" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="17.0.0-preview-2-31223-026" />
     <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.0.0-preview-2-31223-026" />
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="8.0.50728" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.11.3-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.11.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.2.2146" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.11.38822-preview.1" />
@@ -62,9 +62,9 @@
     <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.11.38822-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.11.8" />
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.11.38822-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.11.6-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.11.6-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.11.38822-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.11.20" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.11.20" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.11.39607" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.11.0-preview-1-34901-010" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.11.54-preview1" />

--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>17.8.53-pre</CPSPackageVersion>
+    <CPSPackageVersion>17.11.207</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -59,11 +59,6 @@
     <!-- Package for creating an NPM package during build. -->
     <!-- See: https://dev.azure.com/devdiv/DevDiv/_git/vs-green?path=/components&anchor=packaging-components -->
     <PackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.NpmPack" PrivateAssets="all" />
-
-    <!-- Force a particular version of this package to resolve a Component Governance issue. -->
-    <!-- ExcludeAssets="all" is specified because we don't actually want to _use_ the package. -->
-    <!-- TODO: This can be removed when CPS and/or MSBuild no longer depend (directly or transitively) on the bad version. -->
-    <PackageReference Include="System.Security.Cryptography.Pkcs" VersionOverride="7.0.2" ExcludeAssets="all" />
   </ItemGroup>
 
   <!-- Dependencies -->

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Snapshot;
 using Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies;
 using Microsoft.VisualStudio.Imaging.Interop;
 using Microsoft.VisualStudio;
-using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Subscriptions;
 
 namespace Microsoft.VisualStudio.ProjectSystem.Tree.Dependencies.Legacy;


### PR DESCRIPTION
Insertions from dotnet/project-system into dotnet-project-system-vscode automatically update the CPS version of that repo to match the version used in this repo. I need a newer version in dotnet-project-system-vscode for some feature work, so to avoid problems I'm updating it here as well.

This also allows us to remove a `PackageReference` that was needed just to resolve a Component Governance issue. The change also removes an unnecessary "using" that the build started to warn about.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9488)