### PR TITLE
Specify preferred persistence GUID for project types

### DIFF
--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>17.11.207</CPSPackageVersion>
+    <CPSPackageVersion>17.12.21-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeRegistration.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ProjectTypeRegistration.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
     Capabilities = ProjectTypeCapabilities.VisualBasic,
     DisableAsynchronousProjectTreeLoad = true,
     PossibleProjectExtensions = "vbproj",
+    PreferredPersistProjectTypeGuid = ProjectType.LegacyVisualBasic,
     NewProjectRequireNewFolderVsTemplate = true,
     SupportsCodespaces = true,
     SupportsSolutionChangeWithoutReload = true)]
@@ -32,6 +33,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
     Capabilities = ProjectTypeCapabilities.FSharp,
     DisableAsynchronousProjectTreeLoad = true,
     PossibleProjectExtensions = "fsproj",
+    PreferredPersistProjectTypeGuid = ProjectType.LegacyFSharp,
     NewProjectRequireNewFolderVsTemplate = true,
     SupportsCodespaces = true,
     SupportsSolutionChangeWithoutReload = true)]
@@ -49,6 +51,7 @@ using Microsoft.VisualStudio.ProjectSystem.VS;
     Capabilities = ProjectTypeCapabilities.CSharp,
     DisableAsynchronousProjectTreeLoad = true,
     PossibleProjectExtensions = "csproj",
+    PreferredPersistProjectTypeGuid = ProjectType.LegacyCSharp,
     NewProjectRequireNewFolderVsTemplate = true,
     SupportsCodespaces = true,
     SupportsSolutionChangeWithoutReload = true)]


### PR DESCRIPTION
Fixes #1821

This change takes a new version of CPS, and populates a new property on the `ProjectTypeRegistrationAttribute` that specifies the preferred project type GUID for persistence.

This helps avoid an issue where occasionally VS would change the project type GUID in the solution file, as now the project can explicitly define when it wants to use a different project type GUID for persistence, as we do for managed C#/VB/F# projects.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9509)