### PR TITLE
Specify warning levels for F# projects

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/BuildPropertyPage.FSharp.xaml
@@ -75,6 +75,37 @@
     <EnumValue Name="embedded" DisplayName="Embedded in DLL/EXE, portable across platforms" />
   </EnumProperty>
 
+  <!--
+    From: https://learn.microsoft.com/en-us/dotnet/fsharp/language-reference/compiler-options
+    
+  	"warn:warning-level" Sets a warning level (0 to 5). The default level is 3. Each warning is given a level based on its severity. Level 5 gives more, but less severe, warnings than level 1.
+  -->
+  <EnumProperty Name="WarningLevel"
+                DisplayName="Warning level"
+                Description="Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels."
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2146798"
+                Category="ErrorsAndWarnings">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="EditabilityCondition">
+        <NameValuePair.Value>
+          (has-evaluated-value "Build" "WarningLevelOverridden" false)
+        </NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="0"
+               DisplayName="0 - Fewest warnings, including most severe issues" />
+    <EnumValue Name="1"
+               DisplayName="1" />
+    <EnumValue Name="2"
+               DisplayName="2" />
+    <EnumValue Name="3"
+               DisplayName="3 - Default warning level" />
+    <EnumValue Name="4"
+               DisplayName="4" />
+    <EnumValue Name="5"
+               DisplayName="5 - Most warnings, including less severe issues" />
+  </EnumProperty>
+
   <StringProperty Name="LangVersion" Visible="False" />
 
   <BoolProperty Name="CheckForOverflowUnderflow" Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.cs.xlf
@@ -67,6 +67,16 @@
         <target state="translated">typ ladění</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Vložené v knihovně DLL/EXE, přenosné mezi platformami</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">Soubor PDB, přenosný napříč platformami</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.de.xlf
@@ -67,6 +67,16 @@
         <target state="translated">Debugtyp</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Eingebettet in DLL/EXE, plattformübergreifend portierbar</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">PDB-Datei, plattformübergreifend portierbar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.es.xlf
@@ -67,6 +67,16 @@
         <target state="translated">tipo de depuración</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Incrustado en DLL/EXE, portable en distintas plataformas</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">Archivo PDB, portable en distintas plataformas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.fr.xlf
@@ -67,6 +67,16 @@
         <target state="translated">type de débogage</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Incorporé dans DLL/EXE, portable sur toutes les plateformes</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">Fichier PDB, portable sur toutes les plateformes</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.it.xlf
@@ -67,6 +67,16 @@
         <target state="translated">tipo di debug</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Incorporato in DLL/EXE, portabile tra piattaforme</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">File PDB, portabile tra piattaforme</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ja.xlf
@@ -67,6 +67,16 @@
         <target state="translated">デバッグの種類</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">DLL/EXE に組み込まれ、プラットフォーム間で移植可能</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">プラットフォーム間で移植可能な PDB ファイル</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ko.xlf
@@ -67,6 +67,16 @@
         <target state="translated">디버그 형식</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">DLL/EXE에 포함됨, 플랫폼 간에 이동 가능</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">PDB 파일, 플랫폼 간에 이동 가능</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pl.xlf
@@ -67,6 +67,16 @@
         <target state="translated">typ debugowania</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Osadzone w bibliotece DLL/EXE, przenośne na różne platformy</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">Plik PDB, przenośny na różnych platformach</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.pt-BR.xlf
@@ -67,6 +67,16 @@
         <target state="translated">tipo de depuração</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Incorporado em DLL/EXE, portável entre plataformas</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">Arquivo PDB, portável entre plataformas</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.ru.xlf
@@ -67,6 +67,16 @@
         <target state="translated">тип отладки</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">Внедрено в DLL/EXE, переносимость между платформами</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">PDB-файл, переносимый между платформами</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.tr.xlf
@@ -67,6 +67,16 @@
         <target state="translated">hata ayıklama türü</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">DLL/EXE içine gömülü, platformlar arasında taşınabilir</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">PDB dosyası, platformlar arasında taşınabilir</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hans.xlf
@@ -67,6 +67,16 @@
         <target state="translated">调试类型</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">嵌入到 DLL/EXE 中，可跨平台移植</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">PDB 文件，可跨平台移植</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/BuildPropertyPage.FSharp.xaml.zh-Hant.xlf
@@ -67,6 +67,16 @@
         <target state="translated">偵錯類型</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|Description">
+        <source>Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</source>
+        <target state="new">Specifies the level to display for compiler warnings. Higher levels produce more warnings, and include all warnings from lower levels.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|WarningLevel|DisplayName">
+        <source>Warning level</source>
+        <target state="new">Warning level</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|DebugType.embedded|DisplayName">
         <source>Embedded in DLL/EXE, portable across platforms</source>
         <target state="translated">內嵌在 DLL/EXE 中，可跨平台攜帶</target>
@@ -85,6 +95,36 @@
       <trans-unit id="EnumValue|DebugType.portable|DisplayName">
         <source>PDB file, portable across platforms</source>
         <target state="translated">PDB 檔案，可跨平台攜帶</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.0|DisplayName">
+        <source>0 - Fewest warnings, including most severe issues</source>
+        <target state="new">0 - Fewest warnings, including most severe issues</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.1|DisplayName">
+        <source>1</source>
+        <target state="new">1</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.2|DisplayName">
+        <source>2</source>
+        <target state="new">2</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.3|DisplayName">
+        <source>3 - Default warning level</source>
+        <target state="new">3 - Default warning level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.4|DisplayName">
+        <source>4</source>
+        <target state="new">4</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|WarningLevel.5|DisplayName">
+        <source>5 - Most warnings, including less severe issues</source>
+        <target state="new">5 - Most warnings, including less severe issues</target>
         <note />
       </trans-unit>
       <trans-unit id="StringProperty|OtherFlags|Description">


### PR DESCRIPTION
Fixes #9469
Fixes https://github.com/dotnet/fsharp/issues/13714

F# projects don't use the same warning levels as C#/VB projects.

Previously, the same set of levels were used on all project types. This change adds an explicit set for F#.

![image](https://github.com/user-attachments/assets/78af3f9c-b354-4b80-b9e8-be86079e7c3e)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9511)