### PR TITLE
Bump milestone tracking for merged PRs to 17.12

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -74,7 +74,7 @@ configuration:
           branch: main
       then:
       - addMilestone:
-          milestone: 17.11
+          milestone: 17.12
       description: Milestone tracking - main
       triggerOnOwnActions: true
 


### PR DESCRIPTION
`main` is now targeting 17.12. Update the config so that merged PRs are incorrectly assigned to the 17.11 milestone on GitHub.

This helps prevent confusion about what VS version a fix is in.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9512)