### PR TITLE
Test that StringComparers and StringComparisons are kept in sync

### DIFF
--- a/docs/build-acceleration.md
+++ b/docs/build-acceleration.md
@@ -169,7 +169,7 @@ Looking through the build output with the following points in mind:
 
 ## Reference Assemblies
 
-A reference assembly is a DLLs that models the public API of a project, without any actual implementation.
+A reference assembly is a DLL that models the public API of a project, without any actual implementation.
 
 During build, reference assembly timestamps are only updated when their project's public API changes. Incremental build systems use file system timestamps for many of their optimisations. If project changes are internal-only (e.g. method bodies, private members added/removed, documentation changed) then the timestamp is not changed. Knowing the time at which a public API was last changed allows skipping some compilation.
 
@@ -184,7 +184,7 @@ In our example, `A` only need to recompile if it has its own changes, or if `B`'
 
 Production of a reference assembly is controlled by the `ProduceReferenceAssembly` MSBuild property, and the feature is part of MSBuild directly. This means it works well outside of VS, in case you also do CLI builds. Note that most CI builds are non-incremental (they happen on fresh clones), so this property has no impact there.
 
-When `ProduceReferenceAssembly` was introduced in .NET 5, it was only enabled by default for .NET 5 and later. We investigated changing the default for earlier frameworks too, but this caused issues in a very small number of highly customised builds and we take backwards compatability very seriously. That said, it's generally desirable to configure projects to produce reference assemblies, regardless of whether you use Build Acceleration or not.
+When `ProduceReferenceAssembly` was introduced in .NET 5, it was only enabled by default for .NET 5 and later. We investigated changing the default for earlier frameworks too, but this caused issues in a very small number of highly customised builds and we take backwards compatibility very seriously. That said, it's generally desirable to configure projects to produce reference assemblies, regardless of whether you use Build Acceleration or not.
 
 For more information, see [Reference Assemblies](https://learn.microsoft.com/dotnet/standard/assembly/reference-assemblies) on Microsoft Learn.
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringComparers.cs
@@ -55,6 +55,7 @@ namespace Microsoft.VisualStudio
         public static StringComparison PropertyLiteralValues => StringComparison.OrdinalIgnoreCase;
         public static StringComparison PropertyValues => StringComparison.Ordinal;
         public static StringComparison RuleNames => StringComparison.OrdinalIgnoreCase;
+        public static StringComparison CategoryNames => StringComparison.OrdinalIgnoreCase;
         public static StringComparison ConfigurationDimensionNames => StringComparison.Ordinal;
         public static StringComparison ConfigurationDimensionValues => StringComparison.Ordinal;
         public static StringComparison DependencyIds => StringComparison.OrdinalIgnoreCase;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/StringComparisonTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/StringComparisonTests.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Globalization;
 using System.Reflection;
 
 namespace Microsoft.VisualStudio;
@@ -14,89 +15,123 @@ public sealed class StringComparersTests
         var comparers = typeof(StringComparers).GetProperties(flags).OrderBy(c => c.Name, StringComparer.Ordinal).ToList();
         var comparisons = typeof(StringComparisons).GetProperties(flags).OrderBy(c => c.Name, StringComparer.Ordinal).ToList();
 
-        var comparerNames = comparers.Select(c => c.Name).ToList();
-        var comparisonNames = comparisons.Select(c => c.Name).ToList();
+        var currentCulture = CultureInfo.CurrentCulture;
+        var currentUICulture = CultureInfo.CurrentUICulture;
+        var defaultThreadCurrentCulture = CultureInfo.DefaultThreadCurrentCulture;
+        var defaultThreadCurrentUICulture = CultureInfo.DefaultThreadCurrentUICulture;
 
-        // Check that all comparers have a matching comparison.
-        // Include details about which ones are missing in the test failure message to make fixing easier.
-        var extraComparers = comparerNames.Except(comparisonNames, StringComparer.Ordinal).ToList();
-        var extraComparisons = comparisonNames.Except(comparerNames, StringComparer.Ordinal).ToList();
-
-        if (extraComparers.Count + extraComparisons.Count != 0)
+        try
         {
-            Assert.Fail($"""
+            // Temporarily set the culture to en-AU to ensure consistent results.
+            // This prevents test failures when the current culture is the invariant culture.
+            CultureInfo.CurrentCulture = new CultureInfo("en-AU");
+            CultureInfo.CurrentUICulture = new CultureInfo("en-AU");
+            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-AU");
+            CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-AU");
+
+            ValidateSets();
+
+            ValidateValues();
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = currentCulture;
+            CultureInfo.CurrentUICulture = currentUICulture;
+            CultureInfo.DefaultThreadCurrentCulture = defaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = defaultThreadCurrentUICulture;
+        }
+
+        void ValidateSets()
+        {
+            var comparerNames = comparers.Select(c => c.Name).ToList();
+            var comparisonNames = comparisons.Select(c => c.Name).ToList();
+
+            // Check that all comparers have a matching comparison.
+            // Include details about which ones are missing in the test failure message to make fixing easier.
+            var extraComparers = comparerNames.Except(comparisonNames, StringComparer.Ordinal).ToList();
+            var extraComparisons = comparisonNames.Except(comparerNames, StringComparer.Ordinal).ToList();
+
+            if (extraComparers.Count + extraComparisons.Count != 0)
+            {
+                Assert.Fail($"""
                 Mismatched {nameof(StringComparers)} and {nameof(StringComparisons)}:
                 - Comparers without matching comparisons: {string.Join(", ", extraComparers)}
                 - Comparisons without matching comparers: {string.Join(", ", extraComparisons)}
                 """);
+            }
         }
 
-        var comparerValues = comparers.Select(c => (c.Name, Value: (StringComparer)c.GetValue(null)!)).ToList();
-        var comparisonValues = comparisons.Select(c => (c.Name, Value: (StringComparison)c.GetValue(null)!)).ToList();
-
-        // Check that all comparer values match the corresponding comparison values.
-        foreach (var (comparer, comparison) in comparerValues.Zip(comparisonValues, (a, b) => (a, b)))
+        void ValidateValues()
         {
-            Assert.Equal(comparer.Name, comparison.Name, StringComparer.Ordinal);
+            var comparerValues = comparers.Select(c => (c.Name, Value: (StringComparer)c.GetValue(null)!)).ToList();
+            var comparisonValues = comparisons.Select(c => (c.Name, Value: (StringComparison)c.GetValue(null)!)).ToList();
 
-            var comparerKind = GetComparerKind(comparer.Value);
-            var comparisonKind = GetComparisonKind(comparison.Value);
-
-            if (!string.Equals(comparerKind, comparisonKind, StringComparison.Ordinal))
+            // Check that all comparer values match the corresponding comparison values.
+            foreach (var (comparer, comparison) in comparerValues.Zip(comparisonValues, (a, b) => (a, b)))
             {
-                Assert.Fail($"""
+                Assert.Equal(comparer.Name, comparison.Name, StringComparer.Ordinal);
+
+                var comparerKind = GetComparerKind(comparer.Value);
+                var comparisonKind = GetComparisonKind(comparison.Value);
+
+                if (!string.Equals(comparerKind, comparisonKind, StringComparison.Ordinal))
+                {
+                    Assert.Fail($"""
                     Mismatched comparisons:
                     - {nameof(StringComparers)}.{comparer.Name} = {comparerKind}
                     - {nameof(StringComparisons)}.{comparer.Name} = {comparisonKind}
                     """);
-            }
-        }
-
-        static string GetComparerKind(StringComparer comparer)
-        {
-            foreach (var (c, name) in Comparers())
-            {
-                if (Equals(c, comparer))
-                {
-                    return name;
                 }
             }
 
-            Assert.Fail("Unknown comparer: " + comparer);
-            return null!; // Unreachable
+            return;
 
-            static IEnumerable<(StringComparer, string)> Comparers()
+            static string GetComparerKind(StringComparer comparer)
             {
-                yield return (StringComparer.Ordinal, nameof(StringComparer.Ordinal));
-                yield return (StringComparer.OrdinalIgnoreCase, nameof(StringComparer.OrdinalIgnoreCase));
-                yield return (StringComparer.CurrentCulture, nameof(StringComparer.CurrentCulture));
-                yield return (StringComparer.CurrentCultureIgnoreCase, nameof(StringComparer.CurrentCultureIgnoreCase));
-                yield return (StringComparer.InvariantCulture, nameof(StringComparer.InvariantCulture));
-                yield return (StringComparer.InvariantCultureIgnoreCase, nameof(StringComparer.InvariantCultureIgnoreCase));
-            }
-        }
-
-        static string GetComparisonKind(StringComparison comparison)
-        {
-            foreach (var (c, name) in Comparisons())
-            {
-                if (c == comparison)
+                foreach (var (c, name) in Comparers())
                 {
-                    return name;
+                    if (Equals(c, comparer))
+                    {
+                        return name;
+                    }
+                }
+
+                Assert.Fail("Unknown comparer: " + comparer);
+                return null!; // Unreachable
+
+                static IEnumerable<(StringComparer, string)> Comparers()
+                {
+                    yield return (StringComparer.Ordinal, nameof(StringComparer.Ordinal));
+                    yield return (StringComparer.OrdinalIgnoreCase, nameof(StringComparer.OrdinalIgnoreCase));
+                    yield return (StringComparer.CurrentCulture, nameof(StringComparer.CurrentCulture));
+                    yield return (StringComparer.CurrentCultureIgnoreCase, nameof(StringComparer.CurrentCultureIgnoreCase));
+                    yield return (StringComparer.InvariantCulture, nameof(StringComparer.InvariantCulture));
+                    yield return (StringComparer.InvariantCultureIgnoreCase, nameof(StringComparer.InvariantCultureIgnoreCase));
                 }
             }
 
-            Assert.Fail("Unknown comparison: " + comparison);
-            return null!; // Unreachable
-
-            static IEnumerable<(StringComparison, string)> Comparisons()
+            static string GetComparisonKind(StringComparison comparison)
             {
-                yield return (StringComparison.Ordinal, nameof(StringComparison.Ordinal));
-                yield return (StringComparison.OrdinalIgnoreCase, nameof(StringComparison.OrdinalIgnoreCase));
-                yield return (StringComparison.CurrentCulture, nameof(StringComparison.CurrentCulture));
-                yield return (StringComparison.CurrentCultureIgnoreCase, nameof(StringComparison.CurrentCultureIgnoreCase));
-                yield return (StringComparison.InvariantCulture, nameof(StringComparison.InvariantCulture));
-                yield return (StringComparison.InvariantCultureIgnoreCase, nameof(StringComparison.InvariantCultureIgnoreCase));
+                foreach (var (c, name) in Comparisons())
+                {
+                    if (c == comparison)
+                    {
+                        return name;
+                    }
+                }
+
+                Assert.Fail("Unknown comparison: " + comparison);
+                return null!; // Unreachable
+
+                static IEnumerable<(StringComparison, string)> Comparisons()
+                {
+                    yield return (StringComparison.Ordinal, nameof(StringComparison.Ordinal));
+                    yield return (StringComparison.OrdinalIgnoreCase, nameof(StringComparison.OrdinalIgnoreCase));
+                    yield return (StringComparison.CurrentCulture, nameof(StringComparison.CurrentCulture));
+                    yield return (StringComparison.CurrentCultureIgnoreCase, nameof(StringComparison.CurrentCultureIgnoreCase));
+                    yield return (StringComparison.InvariantCulture, nameof(StringComparison.InvariantCulture));
+                    yield return (StringComparison.InvariantCultureIgnoreCase, nameof(StringComparison.InvariantCultureIgnoreCase));
+                }
             }
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/StringComparisonTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/StringComparisonTests.cs
@@ -1,0 +1,103 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Reflection;
+
+namespace Microsoft.VisualStudio;
+
+public sealed class StringComparersTests
+{
+    [Fact]
+    public void StringComparersAndStringComparisonsMatch()
+    {
+        var flags = BindingFlags.Public | BindingFlags.Static;
+
+        var comparers = typeof(StringComparers).GetProperties(flags).OrderBy(c => c.Name, StringComparer.Ordinal).ToList();
+        var comparisons = typeof(StringComparisons).GetProperties(flags).OrderBy(c => c.Name, StringComparer.Ordinal).ToList();
+
+        var comparerNames = comparers.Select(c => c.Name).ToList();
+        var comparisonNames = comparisons.Select(c => c.Name).ToList();
+
+        // Check that all comparers have a matching comparison.
+        // Include details about which ones are missing in the test failure message to make fixing easier.
+        var extraComparers = comparerNames.Except(comparisonNames, StringComparer.Ordinal).ToList();
+        var extraComparisons = comparisonNames.Except(comparerNames, StringComparer.Ordinal).ToList();
+
+        if (extraComparers.Count + extraComparisons.Count != 0)
+        {
+            Assert.Fail($"""
+                Mismatched {nameof(StringComparers)} and {nameof(StringComparisons)}:
+                - Comparers without matching comparisons: {string.Join(", ", extraComparers)}
+                - Comparisons without matching comparers: {string.Join(", ", extraComparisons)}
+                """);
+        }
+
+        var comparerValues = comparers.Select(c => (c.Name, Value: (StringComparer)c.GetValue(null)!)).ToList();
+        var comparisonValues = comparisons.Select(c => (c.Name, Value: (StringComparison)c.GetValue(null)!)).ToList();
+
+        // Check that all comparer values match the corresponding comparison values.
+        foreach (var (comparer, comparison) in comparerValues.Zip(comparisonValues, (a, b) => (a, b)))
+        {
+            Assert.Equal(comparer.Name, comparison.Name, StringComparer.Ordinal);
+
+            var comparerKind = GetComparerKind(comparer.Value);
+            var comparisonKind = GetComparisonKind(comparison.Value);
+
+            if (!string.Equals(comparerKind, comparisonKind, StringComparison.Ordinal))
+            {
+                Assert.Fail($"""
+                    Mismatched comparisons:
+                    - {nameof(StringComparers)}.{comparer.Name} = {comparerKind}
+                    - {nameof(StringComparisons)}.{comparer.Name} = {comparisonKind}
+                    """);
+            }
+        }
+
+        static string GetComparerKind(StringComparer comparer)
+        {
+            foreach (var (c, name) in Comparers())
+            {
+                if (Equals(c, comparer))
+                {
+                    return name;
+                }
+            }
+
+            Assert.Fail("Unknown comparer: " + comparer);
+            return null!; // Unreachable
+
+            static IEnumerable<(StringComparer, string)> Comparers()
+            {
+                yield return (StringComparer.Ordinal, nameof(StringComparer.Ordinal));
+                yield return (StringComparer.OrdinalIgnoreCase, nameof(StringComparer.OrdinalIgnoreCase));
+                yield return (StringComparer.CurrentCulture, nameof(StringComparer.CurrentCulture));
+                yield return (StringComparer.CurrentCultureIgnoreCase, nameof(StringComparer.CurrentCultureIgnoreCase));
+                yield return (StringComparer.InvariantCulture, nameof(StringComparer.InvariantCulture));
+                yield return (StringComparer.InvariantCultureIgnoreCase, nameof(StringComparer.InvariantCultureIgnoreCase));
+            }
+        }
+
+        static string GetComparisonKind(StringComparison comparison)
+        {
+            foreach (var (c, name) in Comparisons())
+            {
+                if (c == comparison)
+                {
+                    return name;
+                }
+            }
+
+            Assert.Fail("Unknown comparison: " + comparison);
+            return null!; // Unreachable
+
+            static IEnumerable<(StringComparison, string)> Comparisons()
+            {
+                yield return (StringComparison.Ordinal, nameof(StringComparison.Ordinal));
+                yield return (StringComparison.OrdinalIgnoreCase, nameof(StringComparison.OrdinalIgnoreCase));
+                yield return (StringComparison.CurrentCulture, nameof(StringComparison.CurrentCulture));
+                yield return (StringComparison.CurrentCultureIgnoreCase, nameof(StringComparison.CurrentCultureIgnoreCase));
+                yield return (StringComparison.InvariantCulture, nameof(StringComparison.InvariantCulture));
+                yield return (StringComparison.InvariantCultureIgnoreCase, nameof(StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
+    }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/StringComparisonTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/StringComparisonTests.cs
@@ -54,10 +54,10 @@ public sealed class StringComparersTests
             if (extraComparers.Count + extraComparisons.Count != 0)
             {
                 Assert.Fail($"""
-                Mismatched {nameof(StringComparers)} and {nameof(StringComparisons)}:
-                - Comparers without matching comparisons: {string.Join(", ", extraComparers)}
-                - Comparisons without matching comparers: {string.Join(", ", extraComparisons)}
-                """);
+                    Mismatched {nameof(StringComparers)} and {nameof(StringComparisons)}:
+                    - Comparers without matching comparisons: {string.Join(", ", extraComparers)}
+                    - Comparisons without matching comparers: {string.Join(", ", extraComparisons)}
+                    """);
             }
         }
 
@@ -77,10 +77,10 @@ public sealed class StringComparersTests
                 if (!string.Equals(comparerKind, comparisonKind, StringComparison.Ordinal))
                 {
                     Assert.Fail($"""
-                    Mismatched comparisons:
-                    - {nameof(StringComparers)}.{comparer.Name} = {comparerKind}
-                    - {nameof(StringComparisons)}.{comparer.Name} = {comparisonKind}
-                    """);
+                        Mismatched comparisons:
+                        - {nameof(StringComparers)}.{comparer.Name} = {comparerKind}
+                        - {nameof(StringComparisons)}.{comparer.Name} = {comparisonKind}
+                        """);
                 }
             }
 
@@ -97,7 +97,7 @@ public sealed class StringComparersTests
                 }
 
                 Assert.Fail("Unknown comparer: " + comparer);
-                return null!; // Unreachable
+                throw Assumes.NotReachable();
 
                 static IEnumerable<(StringComparer, string)> Comparers()
                 {
@@ -121,7 +121,7 @@ public sealed class StringComparersTests
                 }
 
                 Assert.Fail("Unknown comparison: " + comparison);
-                return null!; // Unreachable
+                throw Assumes.NotReachable();
 
                 static IEnumerable<(StringComparison, string)> Comparisons()
                 {


### PR DESCRIPTION
These two utility classes should have the same members, with equivalent values. This change adds missing properties to both classes, and adds a test to ensure that they're kept in sync in future.

(I made a similar test for Aspire so copied it here.)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9527)