### PR TITLE
Reorder DTB documentation sections

### DIFF
--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -98,23 +98,6 @@ The following are symptoms of a design-time build that is taking too long:
 
 You can force Visual Studio to show the results of a design-time build using the following instructions:
 
-#### Visual Studio 2015 or below
-
-1. Delete the `.vs` directory that sits alongside the solution that is experiencing the problem
-2. Start a _Developer Command Prompt for VS2015_
-3. At the prompt, run `SET TRACEDESIGNTIME=true`
-4. At the prompt, run `devenv`
-5. Open the solution
-6. Under `%TEMP%`, look for `[RANDOMGUID].designtime.log` files, these will contain the results of the design-time build. If running Visual Studio 2015 Update 2 or higher, the name of the project and design-time target that is being called will also be included in the file name.
-
-#### Visual Studio 2017 or later
-
-1. Install the [Project System Tools](https://github.com/dotnet/project-system-tools#project-system-tools) extension
-2. In Visual Studio, choose the `View > Other Windows > Build Logging` menu item.
-3. Click on the "play" button.
-
-This will cause design-time builds to show up in the build logging tool window. If you have the [MSBuild Structured Log Viewer](https://msbuildlog.com) installed, you can double-click on a log to view it in the viewer, otherwise you can right-click and choose `Save As...` to save the log in the new [binary log format](https://github.com/Microsoft/msbuild/wiki/Binary-Log).
-
 #### Visual Studio 2022 or later
 
 You may use the [Project System Tools](https://github.com/dotnet/project-system-tools#project-system-tools) extension mentioned immediately above, however that extension does not capture all available information. To capture all build information:
@@ -127,7 +110,7 @@ You may use the [Project System Tools](https://github.com/dotnet/project-system-
    ```
    You can use whatever path you like for `MSBUILDDEBUGPATH`, but it must be writeable by the current user.
 1. Type `devenv` to start Visual Studio with this configuration.
-1. Open the `MSBUILDDEBUGPATH` path in Windows Explorer to see the captured `.binlog` and other diagnostic files. You can open them using the [MSBuild Structured Log Viewer](https://msbuildlog.com)
+1. Open the `MSBUILDDEBUGPATH` path in Windows Explorer to see the captured `.binlog` and other diagnostic files. You can open them using the [MSBuild Structured Log Viewer](https://msbuildlog.com).
 
 ⚠️ While this environment variable is set, all builds will be logged. It's possible for the number of output logs to be very high.
 
@@ -135,6 +118,23 @@ For more information, see:
 
 - [Providing MSBuild Binary Logs for investigation](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Providing-Binary-Logs.md)
 - [Further MSBuild documentation on binlogs](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs).
+
+#### Visual Studio 2017
+
+1. Install the [Project System Tools](https://github.com/dotnet/project-system-tools#project-system-tools) extension.
+2. In Visual Studio, choose the `View > Other Windows > Build Logging` menu item.
+3. Click on the "play" button.
+
+This will cause design-time builds to show up in the build logging tool window. If you have the [MSBuild Structured Log Viewer](https://msbuildlog.com) installed, you can double-click on a log to view it in the viewer, otherwise you can right-click and choose `Save As...` to save the log in the new [binary log format](https://github.com/Microsoft/msbuild/wiki/Binary-Log).
+
+#### Visual Studio 2015 or below
+
+1. Delete the `.vs` directory that sits alongside the solution that is experiencing the problem.
+2. Start a _Developer Command Prompt for VS2015_.
+3. At the prompt, run `SET TRACEDESIGNTIME=true`
+4. At the prompt, run `devenv`
+5. Open the solution.
+6. Under `%TEMP%`, look for `[RANDOMGUID].designtime.log` files, these will contain the results of the design-time build. If running Visual Studio 2015 Update 2 or higher, the name of the project and design-time target that is being called will also be included in the file name.
 
 ### Diagnosing failing or slow design-time builds
 


### PR DESCRIPTION
This puts the VS2022 instructions at the top, increasing the chance that users following these instructions produce high-fidelity binlogs.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9528)