### PR TITLE
Avoid repeated switches to main thread to check if in command line mode

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -80,8 +80,6 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
         _isEnabled = new(
             async () =>
             {
-                await threadingService.JoinableTaskFactory.SwitchToMainThreadAsync();
-
                 // If VS is running in command line mode (e.g. "devenv.exe /build my.sln"),
                 // language services should not be enabled. The one exception to this is
                 // when we're populating a solution cache via "/populateSolutionCache".

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/VSShellServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Shell/VSShellServices.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.VS;
+using Microsoft.VisualStudio.ProjectSystem.VS.Interop;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
@@ -11,65 +12,54 @@ namespace Microsoft.VisualStudio.Shell;
 [AppliesTo(ProjectCapabilities.AlwaysApplicable)]
 internal class VSShellServices : IVsShellServices
 {
-
-    private readonly AsyncLazy<(bool IsCommandLineMode, bool IsPopulateSolutionCacheMode)> _initialization;
+    private static readonly object s_lockObject = new();
+    private static Task<bool>? s_isCommandLine;
+    private static Task<bool>? s_isPopulateCache;
 
     [ImportingConstructor]
     public VSShellServices(
-        IVsUIService<SVsShell, IVsShell> vsShellService,
-        IVsUIService<SVsAppCommandLine, IVsAppCommandLine> commandLineService,
-        JoinableTaskContext joinableTaskContext)
+        IVsService<IVsAppId> vsAppId,
+        IVsService<SVsAppCommandLine, IVsAppCommandLine> commandLine)
     {
-        _initialization = new(
-            async () =>
+        lock (s_lockObject)
+        {
+            s_isCommandLine ??= IsCommandLineModeAsync(vsAppId);
+            s_isPopulateCache ??= IsPopulateSolutionCacheModeAsync(commandLine);
+
+        }
+
+        static async Task<bool> IsCommandLineModeAsync(IVsService<IVsAppId> vsAppIdService)
+        {
+            IVsAppId? vsAppId = await vsAppIdService.GetValueOrNullAsync();
+            if (vsAppId is not null)
             {
-                // Initialisation must occur on the main thread.
-                await joinableTaskContext.Factory.SwitchToMainThreadAsync();
+                const int VSAPROPID_IsInCommandLineMode = (int)Microsoft.Internal.VisualStudio.AppId.Interop.__VSAPROPID10.VSAPROPID_IsInCommandLineMode;
+                return ErrorHandler.Succeeded(vsAppId.GetProperty(VSAPROPID_IsInCommandLineMode, out object o)) && o is bool isInCommandLineMode && isInCommandLineMode;
+            }
 
-                IVsShell? vsShell = vsShellService.Value;
-                IVsAppCommandLine? commandLine = commandLineService.Value;
+            return false;
+        }
 
-                bool isCommandLineMode = IsCommandLineMode();
+        static async Task<bool> IsPopulateSolutionCacheModeAsync(IVsService<SVsAppCommandLine, IVsAppCommandLine> commandLineService)
+        {
+            IVsAppCommandLine? commandLine = await commandLineService.GetValueOrNullAsync();
+            if (commandLine is null)
+                return false;
 
-                if (isCommandLineMode)
-                {
-                    return (IsCommandLineMode: true, IsPopulateSolutionCacheMode());
-                }
+            int hr = commandLine.GetOption("populateSolutionCache", out int populateSolutionCache, out string _);
 
-                return (false, false);
-
-                bool IsCommandLineMode()
-                {
-                    Assumes.Present(vsShell);
-
-                    int hr = vsShell.GetProperty((int)__VSSPROPID.VSSPROPID_IsInCommandLineMode, out object result);
-
-                    return ErrorHandler.Succeeded(hr)
-                        && result is bool isCommandLineMode
-                        && isCommandLineMode;
-                }
-
-                bool IsPopulateSolutionCacheMode()
-                {
-                    if (commandLine is null)
-                        return false;
-
-                    int hr = commandLine.GetOption("populateSolutionCache", out int populateSolutionCache, out string commandValue);
-
-                    return ErrorHandler.Succeeded(hr)
-                        && Convert.ToBoolean(populateSolutionCache);
-                }
-            },
-            joinableTaskContext.Factory);
+            return ErrorHandler.Succeeded(hr)
+                && Convert.ToBoolean(populateSolutionCache);
+        }
     }
 
     public async Task<bool> IsCommandLineModeAsync(CancellationToken cancellationToken)
     {
-        return (await _initialization.GetValueAsync(cancellationToken)).IsCommandLineMode;
+        return s_isCommandLine is not null && await s_isCommandLine;
     }
 
     public async Task<bool> IsPopulateSolutionCacheModeAsync(CancellationToken cancellationToken)
     {
-        return (await _initialization.GetValueAsync(cancellationToken)).IsPopulateSolutionCacheMode;
+        return s_isPopulateCache is not null && await s_isPopulateCache;
     }
 }


### PR DESCRIPTION
During solution load, there is a per project switch to the main thread to determine if the language service needs to be initialized. The APIs for this were switched to be safe to call from a background thread and we only need to check once since this can't change once the process is started.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9531)