### PR TITLE
Document where exported function is imported

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpCommandLineParserService.cs
@@ -73,17 +73,19 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.FSharp
             }
 
             return new FSharpBuildOptions(
-                    sourceFiles: sourceFiles.ToImmutableArray(),
-                    additionalFiles: ImmutableArray<CommandLineSourceFile>.Empty,
-                    metadataReferences: metadataReferences.ToImmutableArray(),
-                    analyzerReferences: ImmutableArray<CommandLineAnalyzerReference>.Empty,
-                    compileOptions: commandLineOptions.ToImmutableArray());
+                sourceFiles: sourceFiles.ToImmutableArray(),
+                additionalFiles: [],
+                metadataReferences: metadataReferences.ToImmutableArray(),
+                analyzerReferences: [],
+                compileOptions: commandLineOptions.ToImmutableArray());
         }
 
         [Export]
         [AppliesTo(ProjectCapability.FSharp)]
         public void HandleCommandLineNotifications(string binPath, BuildOptions added, BuildOptions removed)
         {
+            // NOTE this method is imported in CommandLineNotificationHandler as an Action<string?, BuildOptions, BuildOptions>
+
             if (added is FSharpBuildOptions fscAdded)
             {
                 foreach (Action<string, ImmutableArray<CommandLineSourceFile>, ImmutableArray<CommandLineReference>, ImmutableArray<string>> handler in _handlers)


### PR DESCRIPTION
Unlike exports of interfaces, it's harder to find the consumer of an exported function. This change adds a comment showing where to find this import.

Also, some minor formatting.

(Change made following a conversation with @0101.)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9535)