### PR TITLE
Fix lingering analyzer node with warning

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependency.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependency.cs
@@ -106,23 +106,25 @@ internal sealed class MSBuildDependency : Dependency
         return this;
     }
 
-    internal MSBuildDependency With(bool isResolved, ProjectImageMoniker icon, ProjectTreeFlags flags, DiagnosticLevel diagnosticLevel)
+    internal MSBuildDependency With(bool isResolved, ProjectImageMoniker icon, ProjectTreeFlags flags, DiagnosticLevel diagnosticLevel, string caption, string? filePath)
     {
         if (isResolved != IsResolved ||
             diagnosticLevel != DiagnosticLevel ||
             icon != Icon ||
-            flags != Flags)
+            flags != Flags ||
+            caption != Caption ||
+            filePath != FilePath)
         {
             return new MSBuildDependency(
                 _factory,
                 Id,
-                Caption,
+                caption,
                 icon,
                 flags,
                 diagnosticLevel,
                 isResolved,
                 IsImplicit,
-                FilePath,
+                filePath,
                 BrowseObjectProperties);
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollection.cs
@@ -259,7 +259,7 @@ internal sealed class MSBuildDependencyCollection
 
                     if (id is not null && _dependencyById.TryGetValue(id, out MSBuildDependency? dependency))
                     {
-                        if (!_factory.ResolvedItemRequiresEvaluatedItem && !evaluationProjectChange.Before.Items.ContainsKey(id))
+                        if (!_factory.ResolvedItemRequiresEvaluatedItem && !evaluationProjectChange.After.Items.ContainsKey(id))
                         {
                             // The item is not present in evaluation, and this factory doesn't require an evaluated item.
                             // The removal of the build item means that the item must be removed altogether, as there's no

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
@@ -423,7 +423,8 @@ internal abstract class MSBuildDependencyFactoryBase : IMSBuildDependencyFactory
         DiagnosticLevel diagnosticLevel = dependency.DiagnosticLevel <= DiagnosticLevel.Warning ? DiagnosticLevel.Warning : dependency.DiagnosticLevel;
         ProjectTreeFlags flags = UpdateTreeFlags(dependency.Id, FlagCache.Get(isResolved: false, dependency.IsImplicit));
         ProjectImageMoniker icon = GetIcon(dependency.IsImplicit, diagnosticLevel);
-        updated = dependency.With(isResolved: false, icon: icon, flags: flags, diagnosticLevel: diagnosticLevel);
+        string caption = GetUnresolvedCaption(dependency.Id, dependency.BrowseObjectProperties);
+        updated = dependency.With(isResolved: false, icon: icon, flags: flags, diagnosticLevel: diagnosticLevel, caption: caption, filePath: dependency.Id);
         return !ReferenceEquals(dependency, updated);
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollectionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyCollectionTests.cs
@@ -31,7 +31,7 @@ public sealed class MSBuildDependencyCollectionTests
     }
 
     [Fact]
-    public void TryUpdate_DoesNothingWhenNoChanges()
+    public void TryUpdate_NoChanges_DoesNothing()
     {
         var factory = new Mock<MSBuildDependencyFactoryBase>(MockBehavior.Strict);
         factory.SetupGet(f => f.UnresolvedRuleName).Returns("UnresolvedRuleName");
@@ -48,7 +48,7 @@ public sealed class MSBuildDependencyCollectionTests
     }
 
     [Fact]
-    public void TryUpdate_AddsDependencyWhenIntroducedInEvaluation()
+    public void TryUpdate_Add_InEvaluationOnly_NoBuildData()
     {
         var collection = Create();
 
@@ -80,7 +80,9 @@ public sealed class MSBuildDependencyCollectionTests
 
         Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
         Assert.NotNull(dependencies);
+
         var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
+
         Assert.Equal("Item1", dependency.Id);
         Assert.Equal("UnresolvedCaption", dependency.Caption);
         Assert.Equal(DependencyTreeFlags.UnresolvedDependencyFlags + ProjectTreeFlags.Create("TestUnresolved"), dependency.Flags);
@@ -89,31 +91,26 @@ public sealed class MSBuildDependencyCollectionTests
         Assert.Equal("UnresolvedRuleName", dependency.SchemaName);
         Assert.Equal("SchemaItemType", dependency.SchemaItemType);
         Assert.False(dependency.UseResolvedReferenceRule);
-        Assert.Equal(new[] { new KeyValuePair<string, string>("A", "1") }, dependency.BrowseObjectProperties);
+        Assert.Equal([new("A", "1")], dependency.BrowseObjectProperties);
         Assert.Equal("Item1", dependency.FilePath);
         Assert.False(dependency.IsImplicit);
         Assert.Null(dependency.IsResolved);
     }
 
     [Fact]
-    public void TryUpdate_AddsResolvedDependencyWhenIntroducedInEvaluationAndBuild()
+    public void TryUpdate_Add_BuildOnly_AllowMissingEvaluation()
     {
-        var collection = Create();
+        var collection = Create(resolvedItemRequiresEvaluatedItem: false);
 
         IProjectChangeDescription evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
                 """
                 {
                     "Difference": {
-                        "AnyChanges": true,
-                        "AddedItems": [ "Item1" ]
+                        "AnyChanges": false
                     },
                     "After": {
                         "RuleName": "UnresolvedRuleName",
-                        "Items": {
-                            "Item1": {
-                                "A": "1"
-                            }
-                        }
+                        "Items": {}
                     }
                 }
                 """);
@@ -127,10 +124,7 @@ public sealed class MSBuildDependencyCollectionTests
                     "After": {
                         "RuleName": "ResolvedRuleName",
                         "Items": {
-                            "ResolvedItem1": {
-                                "OriginalItemSpec": "Item1",
-                                "A": "2"
-                            }
+                            "ResolvedItem1": {}
                         }
                     }
                 }
@@ -138,23 +132,27 @@ public sealed class MSBuildDependencyCollectionTests
 
         Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
         Assert.NotNull(dependencies);
-        var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
-        Assert.Equal("Item1", dependency.Id);
-        Assert.Equal("ResolvedCaption", dependency.Caption);
-        Assert.Equal(DependencyTreeFlags.ResolvedDependencyFlags + ProjectTreeFlags.Create("TestResolved"), dependency.Flags);
-        Assert.Equal(DiagnosticLevel.None, dependency.DiagnosticLevel);
-        Assert.Equal(_icon, dependency.Icon);
-        Assert.Equal("ResolvedRuleName", dependency.SchemaName);
-        Assert.Equal("SchemaItemType", dependency.SchemaItemType);
-        Assert.True(dependency.UseResolvedReferenceRule);
-        Assert.Equal(new[] { new KeyValuePair<string, string>("OriginalItemSpec", "Item1"), new KeyValuePair<string, string>("A", "2") }, dependency.BrowseObjectProperties);
-        Assert.Equal("ResolvedItem1", dependency.FilePath);
-        Assert.False(dependency.IsImplicit);
-        Assert.True(dependency.IsResolved);
+        Assert.Collection(
+            dependencies.Value.Cast<MSBuildDependency>(),
+            d =>
+            {
+                Assert.Equal("Item1", d.Id);
+                Assert.Equal("ResolvedCaption", d.Caption);
+                Assert.Equal(DependencyTreeFlags.ResolvedDependencyFlags + ProjectTreeFlags.Create("TestResolved"), d.Flags);
+                Assert.Equal(DiagnosticLevel.None, d.DiagnosticLevel);
+                Assert.Equal(_icon, d.Icon);
+                Assert.Equal("ResolvedRuleName", d.SchemaName);
+                Assert.Equal("SchemaItemType", d.SchemaItemType);
+                Assert.True(d.UseResolvedReferenceRule);
+                Assert.Empty(d.BrowseObjectProperties);
+                Assert.Equal("ResolvedItem1", d.FilePath);
+                Assert.False(d.IsImplicit);
+                Assert.True(d.IsResolved);
+            });
     }
 
     [Fact]
-    public void TryUpdate_AddsResolvedDependencyWhenIntroducedInEvaluationThenBuild()
+    public void TryUpdate_Add_BuildOnly_Ignored()
     {
         var collection = Create();
 
@@ -162,16 +160,11 @@ public sealed class MSBuildDependencyCollectionTests
                 """
                 {
                     "Difference": {
-                        "AnyChanges": true,
-                        "AddedItems": [ "Item1" ]
+                        "AnyChanges": false
                     },
                     "After": {
                         "RuleName": "UnresolvedRuleName",
-                        "Items": {
-                            "Item1": {
-                                "A": "1"
-                            }
-                        }
+                        "Items": {}
                     }
                 }
                 """);
@@ -179,43 +172,24 @@ public sealed class MSBuildDependencyCollectionTests
                 """
                 {
                     "Difference": {
-                        "AnyChanges": true,
+                        "AnyChanges": false,
                         "AddedItems": [ "ResolvedItem1" ]
                     },
                     "After": {
                         "RuleName": "ResolvedRuleName",
                         "Items": {
-                            "ResolvedItem1": {
-                                "OriginalItemSpec": "Item1",
-                                "A": "2"
-                            }
+                            "ResolvedItem1": {}
                         }
                     }
                 }
                 """);
 
-        // Evaluation only
-        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange: null, "FullPath", out ImmutableArray<IDependency>? dependencies));
-        // Evaluation and build (joint)
-        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out dependencies));
-        Assert.NotNull(dependencies);
-        var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
-        Assert.Equal("Item1", dependency.Id);
-        Assert.Equal("ResolvedCaption", dependency.Caption);
-        Assert.Equal(DependencyTreeFlags.ResolvedDependencyFlags + ProjectTreeFlags.Create("TestResolved"), dependency.Flags);
-        Assert.Equal(DiagnosticLevel.None, dependency.DiagnosticLevel);
-        Assert.Equal(_icon, dependency.Icon);
-        Assert.Equal("ResolvedRuleName", dependency.SchemaName);
-        Assert.Equal("SchemaItemType", dependency.SchemaItemType);
-        Assert.True(dependency.UseResolvedReferenceRule);
-        Assert.Equal(new[] { new KeyValuePair<string, string>("OriginalItemSpec", "Item1"), new KeyValuePair<string, string>("A", "2") }, dependency.BrowseObjectProperties);
-        Assert.Equal("ResolvedItem1", dependency.FilePath);
-        Assert.False(dependency.IsImplicit);
-        Assert.True(dependency.IsResolved);
+        Assert.False(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
+        Assert.Null(dependencies);
     }
 
     [Fact]
-    public void TryUpdate_AddsUnresolvedDependencyWhenIntroducedInEvaluationButNotBuild()
+    public void TryUpdate_Add_InEvaluationOnly_BuildDataPresent()
     {
         var collection = Create();
 
@@ -261,7 +235,368 @@ public sealed class MSBuildDependencyCollectionTests
         Assert.Equal("UnresolvedRuleName", dependency.SchemaName);
         Assert.Equal("SchemaItemType", dependency.SchemaItemType);
         Assert.False(dependency.UseResolvedReferenceRule);
-        Assert.Equal(new[] { new KeyValuePair<string, string>("A", "1") }, dependency.BrowseObjectProperties);
+        Assert.Equal([new("A", "1")], dependency.BrowseObjectProperties);
+        Assert.Equal("Item1", dependency.FilePath);
+        Assert.False(dependency.IsImplicit);
+        Assert.False(dependency.IsResolved);
+    }
+
+    [Fact]
+    public void TryUpdate_Add_EvaluationAndBuild_Simultaneous()
+    {
+        var collection = Create();
+
+        IProjectChangeDescription evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "Item1" ]
+                    },
+                    "After": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {
+                                "A": "1"
+                            }
+                        }
+                    }
+                }
+                """);
+        IProjectChangeDescription buildProjectChange = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "ResolvedItem1" ]
+                    },
+                    "After": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {
+                            "ResolvedItem1": {
+                                "OriginalItemSpec": "Item1",
+                                "A": "2"
+                            }
+                        }
+                    }
+                }
+                """);
+
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
+        Assert.NotNull(dependencies);
+        var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
+        Assert.Equal("Item1", dependency.Id);
+        Assert.Equal("ResolvedCaption", dependency.Caption);
+        Assert.Equal(DependencyTreeFlags.ResolvedDependencyFlags + ProjectTreeFlags.Create("TestResolved"), dependency.Flags);
+        Assert.Equal(DiagnosticLevel.None, dependency.DiagnosticLevel);
+        Assert.Equal(_icon, dependency.Icon);
+        Assert.Equal("ResolvedRuleName", dependency.SchemaName);
+        Assert.Equal("SchemaItemType", dependency.SchemaItemType);
+        Assert.True(dependency.UseResolvedReferenceRule);
+        Assert.Equal([new("OriginalItemSpec", "Item1"), new("A", "2")], dependency.BrowseObjectProperties);
+        Assert.Equal("ResolvedItem1", dependency.FilePath);
+        Assert.False(dependency.IsImplicit);
+        Assert.True(dependency.IsResolved);
+    }
+
+    [Fact]
+    public void TryUpdate_Add_EvaluationAndBuild_Sequential()
+    {
+        var collection = Create();
+
+        IProjectChangeDescription evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "Item1" ]
+                    },
+                    "After": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {
+                                "A": "1"
+                            }
+                        }
+                    }
+                }
+                """);
+        IProjectChangeDescription buildProjectChange = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "ResolvedItem1" ]
+                    },
+                    "After": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {
+                            "ResolvedItem1": {
+                                "OriginalItemSpec": "Item1",
+                                "A": "2"
+                            }
+                        }
+                    }
+                }
+                """);
+
+        // Evaluation only first
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange: null, "FullPath", out _));
+
+        // Evaluation and build (joint)
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
+
+        Assert.NotNull(dependencies);
+
+        var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
+
+        Assert.Equal("Item1", dependency.Id);
+        Assert.Equal("ResolvedCaption", dependency.Caption);
+        Assert.Equal(DependencyTreeFlags.ResolvedDependencyFlags + ProjectTreeFlags.Create("TestResolved"), dependency.Flags);
+        Assert.Equal(DiagnosticLevel.None, dependency.DiagnosticLevel);
+        Assert.Equal(_icon, dependency.Icon);
+        Assert.Equal("ResolvedRuleName", dependency.SchemaName);
+        Assert.Equal("SchemaItemType", dependency.SchemaItemType);
+        Assert.True(dependency.UseResolvedReferenceRule);
+        Assert.Equal([new("OriginalItemSpec", "Item1"), new("A", "2")], dependency.BrowseObjectProperties);
+        Assert.Equal("ResolvedItem1", dependency.FilePath);
+        Assert.False(dependency.IsImplicit);
+        Assert.True(dependency.IsResolved);
+    }
+
+    // TODO duplicate test with resolvedItemRequiresEvaluatedItem set to false
+    [Fact]
+    public void TryUpdate_RemovedFromBuildData()
+    {
+        var collection = Create();
+
+        // Set up initial state with a resolved dependency.
+
+        IProjectChangeDescription evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "Item1", "Item2" ]
+                    },
+                    "After": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {},
+                            "Item2": {}
+                        }
+                    }
+                }
+                """);
+        IProjectChangeDescription buildProjectChange = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "ResolvedItem1", "ResolvedItem2" ]
+                    },
+                    "After": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {
+                            "ResolvedItem1": {},
+                            "ResolvedItem2": {}
+                        }
+                    }
+                }
+                """);
+
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
+
+        Assert.NotNull(dependencies);
+
+        Assert.Collection(
+            dependencies.Value.Cast<MSBuildDependency>(),
+            d =>
+            {
+                Assert.Equal("Item1", d.Id);
+                Assert.True(d.IsResolved);
+            },
+            d =>
+            {
+                Assert.Equal("Item2", d.Id);
+                Assert.True(d.IsResolved);
+            });
+
+        // Remove both from build, and Item2 from evaluation.
+
+        evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "RemovedItems": [ "Item2" ]
+                    },
+                    "Before": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {},
+                            "Item2": {}
+                        }
+                    },
+                    "After": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {}
+                        }
+                    }
+                }
+                """);
+        buildProjectChange = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "RemovedItems": [ "ResolvedItem1", "ResolvedItem2" ]
+                    },
+                    "Before": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {
+                            "ResolvedItem1": {},
+                            "ResolvedItem2": {}
+                        }
+                    },
+                    "After": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {}
+                    }
+                }
+                """);
+
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out dependencies));
+
+        Assert.NotNull(dependencies);
+
+        // Item1 remains, unresolved. Item2 has been removed.
+
+        var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
+
+        Assert.Equal("Item1", dependency.Id);
+        Assert.Equal("UnresolvedCaption", dependency.Caption);
+        Assert.Equal(DependencyTreeFlags.UnresolvedDependencyFlags + ProjectTreeFlags.Create("TestUnresolved"), dependency.Flags);
+        Assert.Equal(DiagnosticLevel.Warning, dependency.DiagnosticLevel);
+        Assert.Equal(_iconWarning, dependency.Icon);
+        Assert.Equal("UnresolvedRuleName", dependency.SchemaName);
+        Assert.Equal("SchemaItemType", dependency.SchemaItemType);
+        Assert.False(dependency.UseResolvedReferenceRule);
+        Assert.Equal("Item1", dependency.FilePath);
+        Assert.False(dependency.IsImplicit);
+        Assert.False(dependency.IsResolved);
+    }
+
+    [Fact]
+    public void TryUpdate_RemovedFromBuildData_AllowMissingEvaluation()
+    {
+        var collection = Create(resolvedItemRequiresEvaluatedItem: false);
+
+        // Set up initial state with a resolved dependency.
+
+        IProjectChangeDescription evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "Item1" ]
+                    },
+                    "After": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {}
+                        }
+                    }
+                }
+                """);
+        IProjectChangeDescription buildProjectChange = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "AddedItems": [ "ResolvedItem1", "ResolvedItem2" ]
+                    },
+                    "After": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {
+                            "ResolvedItem1": {},
+                            "ResolvedItem2": {}
+                        }
+                    }
+                }
+                """);
+
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out ImmutableArray<IDependency>? dependencies));
+
+        Assert.NotNull(dependencies);
+
+        Assert.Collection(
+            dependencies.Value.Cast<MSBuildDependency>(),
+            d =>
+            {
+                Assert.Equal("Item1", d.Id);
+                Assert.True(d.IsResolved);
+            },
+            d =>
+            {
+                Assert.Equal("Item2", d.Id);
+                Assert.True(d.IsResolved);
+            });
+
+        // Remove both from build, and Item2 from evaluation.
+
+        evaluationProjectChanged = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": false,
+                    },
+                    "After": {
+                        "RuleName": "UnresolvedRuleName",
+                        "Items": {
+                            "Item1": {}
+                        }
+                    }
+                }
+                """);
+        buildProjectChange = IProjectChangeDescriptionFactory.FromJson(
+                """
+                {
+                    "Difference": {
+                        "AnyChanges": true,
+                        "RemovedItems": [ "ResolvedItem1", "ResolvedItem2" ]
+                    },
+                    "Before": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {
+                            "ResolvedItem1": {},
+                            "ResolvedItem2": {}
+                        }
+                    },
+                    "After": {
+                        "RuleName": "ResolvedRuleName",
+                        "Items": {}
+                    }
+                }
+                """);
+
+        Assert.True(collection.TryUpdate(evaluationProjectChanged, buildProjectChange, "FullPath", out dependencies));
+
+        Assert.NotNull(dependencies);
+
+        // Item1 remains, unresolved. Item2 has been removed.
+
+        var dependency = Assert.IsType<MSBuildDependency>(Assert.Single<IDependency>(dependencies));
+
+        Assert.Equal("Item1", dependency.Id);
+        Assert.Equal("UnresolvedCaption", dependency.Caption);
+        Assert.Equal(DependencyTreeFlags.UnresolvedDependencyFlags + ProjectTreeFlags.Create("TestUnresolved"), dependency.Flags);
+        Assert.Equal(DiagnosticLevel.Warning, dependency.DiagnosticLevel);
+        Assert.Equal(_iconWarning, dependency.Icon);
+        Assert.Equal("UnresolvedRuleName", dependency.SchemaName);
+        Assert.Equal("SchemaItemType", dependency.SchemaItemType);
+        Assert.False(dependency.UseResolvedReferenceRule);
         Assert.Equal("Item1", dependency.FilePath);
         Assert.False(dependency.IsImplicit);
         Assert.False(dependency.IsResolved);
@@ -365,7 +700,7 @@ public sealed class MSBuildDependencyCollectionTests
         Assert.Null(dependencies);
     }
 
-    private MSBuildDependencyCollection Create()
+    private MSBuildDependencyCollection Create(bool resolvedItemRequiresEvaluatedItem = true)
     {
         var factory = new Mock<MSBuildDependencyFactoryBase>(MockBehavior.Strict);
 
@@ -374,13 +709,17 @@ public sealed class MSBuildDependencyCollectionTests
         factory.SetupGet(f => f.SchemaItemType).Returns("SchemaItemType");
         factory.SetupGet(f => f.DependencyGroupType).Returns(_dependencyGroupType);
         factory.SetupGet(f => f.Icon).Returns(_icon);
+        factory.SetupGet(f => f.ResolvedItemRequiresEvaluatedItem).Returns(resolvedItemRequiresEvaluatedItem);
         factory.SetupGet(f => f.IconImplicit).Returns(_iconImplicit);
         factory.SetupGet(f => f.IconWarning).Returns(_iconWarning);
         factory.SetupGet(f => f.IconError).Returns(_iconError);
         factory.SetupGet(f => f.FlagCache).Returns(new MSBuildDependencyFactoryBase.DependencyFlagCache(ProjectTreeFlags.Create("TestResolved"), ProjectTreeFlags.Create("TestUnresolved")));
         factory.Setup(f => f.GetOriginalItemSpec("ResolvedItem1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("Item1");
+        factory.Setup(f => f.GetOriginalItemSpec("ResolvedItem2", It.IsAny<ImmutableDictionary<string, string>>())).Returns("Item2");
         factory.Setup(f => f.GetUnresolvedCaption("Item1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("UnresolvedCaption");
+        factory.Setup(f => f.GetUnresolvedCaption("Item2", It.IsAny<ImmutableDictionary<string, string>>())).Returns("UnresolvedCaption");
         factory.Setup(f => f.GetResolvedCaption("ResolvedItem1", "Item1", It.IsAny<ImmutableDictionary<string, string>>())).Returns("ResolvedCaption");
+        factory.Setup(f => f.GetResolvedCaption("ResolvedItem2", "Item2", It.IsAny<ImmutableDictionary<string, string>>())).Returns("ResolvedCaption");
         factory.Setup(f => f.UpdateTreeFlags(It.IsAny<string>(), It.IsAny<ProjectTreeFlags>())).Returns((string id, ProjectTreeFlags f) => f);
         factory.Setup(f => f.GetDiagnosticLevel(It.IsAny<bool?>(), It.IsAny<bool>(), It.IsAny<ImmutableDictionary<string, string>>(), It.IsAny<DiagnosticLevel>())).CallBase();
 


### PR DESCRIPTION
Fixes #9230

Generally, we require MSBuild-based dependencies to exist in evaluation before they're shown in the tree. Items that exist only in build data are not displayed.

Analyzers opt out of this default behaviour by setting `ResolvedItemRequiresEvaluatedItem` to false. Analyzer references can be added to the project within MSBuild targets and will appear as resolved in the tree.

When such an item is removed from build data, we only removed from the tree when no evaluation data was present.

There was a bug in this code. It was checking for an evaluated item in the previous data, where it should have been checking in the current data. It's a simple fix.

Added more test cases. Made a function change as part of that testing to restore caption and file path on a dependency that becomes unresolved, so that they look identical to how they appear on solution load (when there's no memory of a previously resolved state).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9537)