### PR TITLE
Add Project Properties UI for NuGet Audit settings

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -15,6 +15,10 @@
     <Category Name="Resources"
               DisplayName="Resources"
               Description="Resource settings for the application." />
+
+    <Category Name="Dependencies"
+              DisplayName="Dependencies"
+              Description="Dependency management settings for the application." />
   </Rule.Categories>
 
   <Rule.DataSource>
@@ -288,4 +292,45 @@
                DisplayName="Resource file" />
   </EnumProperty>
 
+  <!-- TODO convert to fwlink -->
+  <BoolProperty Name="NuGetAudit"
+                DisplayName="Audit NuGet dependencies"
+                Description="Audit package dependencies for security vulnerabilities."
+                HelpUrl="https://learn.microsoft.com/nuget/concepts/auditing-packages"
+                Category="Dependencies" />
+
+  <EnumProperty Name="NuGetAuditMode"
+                DisplayName="Audit Mode"
+                Description="Specifies which packages to include in the audit."
+                Category="Dependencies">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Application" "NuGetAudit" true)</NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="direct"
+               DisplayName="Direct dependencies" />
+    <EnumValue Name="all"
+               DisplayName="All dependencies (direct and transitive)" />
+  </EnumProperty>
+
+  <EnumProperty Name="NuGetAuditLevel"
+                DisplayName="Audit Severity Level"
+                Description="The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.."
+                Category="Dependencies">
+    <EnumProperty.Metadata>
+      <NameValuePair Name="VisibilityCondition">
+        <NameValuePair.Value>(has-evaluated-value "Application" "NuGetAudit" true)</NameValuePair.Value>
+      </NameValuePair>
+    </EnumProperty.Metadata>
+    <EnumValue Name="low"
+               DisplayName="Low" />
+    <EnumValue Name="moderate"
+               DisplayName="Moderate" />
+    <EnumValue Name="high"
+               DisplayName="High" />
+    <EnumValue Name="critical"
+               DisplayName="Critical" />
+  </EnumProperty>
+  
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -323,13 +323,13 @@
       </NameValuePair>
     </EnumProperty.Metadata>
     <EnumValue Name="low"
-               DisplayName="Low" />
+               DisplayName="Low and above (all levels)" />
     <EnumValue Name="moderate"
-               DisplayName="Moderate" />
+               DisplayName="Moderate and above" />
     <EnumValue Name="high"
-               DisplayName="High" />
+               DisplayName="High and above" />
     <EnumValue Name="critical"
-               DisplayName="Critical" />
+               DisplayName="Critical only" />
   </EnumProperty>
   
 </Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -292,11 +292,10 @@
                DisplayName="Resource file" />
   </EnumProperty>
 
-  <!-- TODO convert to fwlink -->
   <BoolProperty Name="NuGetAudit"
                 DisplayName="Audit NuGet dependencies"
                 Description="Audit package dependencies for security vulnerabilities."
-                HelpUrl="https://learn.microsoft.com/nuget/concepts/auditing-packages"
+                HelpUrl="https://go.microsoft.com/fwlink/?linkid=2288404"
                 Category="Dependencies" />
 
   <EnumProperty Name="NuGetAuditMode"
@@ -316,7 +315,7 @@
 
   <EnumProperty Name="NuGetAuditLevel"
                 DisplayName="Audit Severity Level"
-                Description="The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.."
+                Description="The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported."
                 Category="Dependencies">
     <EnumProperty.Metadata>
       <NameValuePair Name="VisibilityCondition">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Automaticky generovat přesměrování vazeb</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Povolí pro tento projekt WPF.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">platforma</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Určuje typ aplikace, která se má sestavit.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Prostředky</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Bindungsumleitungen automatisch generieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Hiermit wird WPF für dieses Projekt aktiviert.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">Plattform</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Hiermit wird der Typ der zu erstellenden Anwendung angegeben.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Ressourcen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Generación automática de redirecciones de enlace</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Habilite WPF para este proyecto.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">plataforma</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Especifica el tipo de aplicación para compilar.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Recursos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Générer automatiquement les redirections de liaison</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Activez WPF pour ce projet.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">plateforme</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Spécifie le type d'application à générer.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Ressources</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Genera automaticamente reindirizzamenti di binding</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Abilita WPF per questo progetto.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">piattaforma</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Specifica il tipo di applicazione da compilare.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Risorse</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -12,6 +12,16 @@
         <target state="translated">バインド リダイレクトの自動生成</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">このプロジェクトで WPF を有効にします。</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows フォーム</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">プラットフォーム</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">ビルドするアプリケーションの種類を指定します。</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">リソース</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -12,6 +12,16 @@
         <target state="translated">바인딩 리디렉션 자동 생성</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">이 프로젝트에 WPF를 사용하도록 설정합니다.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">플랫폼</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">빌드할 애플리케이션의 유형을 지정합니다.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">리소스</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Automatycznie generowane przekierowania powiązań</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Włącz funkcję WPF dla tego projektu.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">platforma</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Określa typ aplikacji do skompilowania.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Zasoby</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Gerar automaticamente redirecionamentos de associação</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Habilita o WPF para este projeto.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">plataforma</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Especifica o tipo de aplicativo a ser compilado.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Recursos</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Автоматически создавать перенаправления привязок</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Включите WPF для этого проекта.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">платформа</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Указывает тип собираемого приложения.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Ресурсы</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -12,6 +12,16 @@
         <target state="translated">Otomatik olarak, bağlama yeniden yönlendirmeleri oluşturma</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">Bu proje için WPF'yi etkinleştirin.</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">platform</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">Derlenecek uygulamanın türünü belirtir.</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">Kaynaklar</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -12,6 +12,16 @@
         <target state="translated">自动生成绑定重定向</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">为该项目启用 WPF。</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows 窗体</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">平台</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">指定要生成的应用程序的类型。</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">资源</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -12,6 +12,16 @@
         <target state="translated">自動產生繫結重新導向</target>
         <note />
       </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|Description">
+        <source>Audit package dependencies for security vulnerabilities.</source>
+        <target state="new">Audit package dependencies for security vulnerabilities.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="BoolProperty|NuGetAudit|DisplayName">
+        <source>Audit NuGet dependencies</source>
+        <target state="new">Audit NuGet dependencies</target>
+        <note />
+      </trans-unit>
       <trans-unit id="BoolProperty|UseWPF|Description">
         <source>Enable WPF for this project.</source>
         <target state="translated">為此專案啟用 WPF。</target>
@@ -30,6 +40,16 @@
       <trans-unit id="BoolProperty|UseWindowsForms|DisplayName">
         <source>Windows Forms</source>
         <target state="translated">Windows Forms</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|Description">
+        <source>Dependency management settings for the application.</source>
+        <target state="new">Dependency management settings for the application.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Category|Dependencies|DisplayName">
+        <source>Dependencies</source>
+        <target state="new">Dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="Category|General|Description">
@@ -122,6 +142,26 @@
         <target state="translated">平台</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
+        <source>Audit Severity Level</source>
+        <target state="new">Audit Severity Level</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|Description">
+        <source>Specifies which packages to include in the audit.</source>
+        <target state="new">Specifies which packages to include in the audit.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumProperty|NuGetAuditMode|DisplayName">
+        <source>Audit Mode</source>
+        <target state="new">Audit Mode</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumProperty|OutputType|Description">
         <source>Specifies the type of application to build.</source>
         <target state="translated">指定要建置的應用程式類型。</target>
@@ -140,6 +180,36 @@
       <trans-unit id="EnumProperty|ResourceSpecificationKind|DisplayName">
         <source>Resources</source>
         <target state="translated">資源</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
+        <source>Critical</source>
+        <target state="new">Critical</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
+        <source>High</source>
+        <target state="new">High</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
+        <source>Low</source>
+        <target state="new">Low</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
+        <source>Moderate</source>
+        <target state="new">Moderate</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">
+        <source>All dependencies (direct and transitive)</source>
+        <target state="new">All dependencies (direct and transitive)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="EnumValue|NuGetAuditMode.direct|DisplayName">
+        <source>Direct dependencies</source>
+        <target state="new">Direct dependencies</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|OutputType.Exe|DisplayName">

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -143,8 +143,8 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|Description">
-        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</source>
-        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported..</target>
+        <source>The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</source>
+        <target state="new">The minimum vulnerability severity level to report when a package has a known vulnerability. Known vulnerabilities with a lower severity level will not be reported.</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumProperty|NuGetAuditLevel|DisplayName">
@@ -183,23 +183,23 @@
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.critical|DisplayName">
-        <source>Critical</source>
-        <target state="new">Critical</target>
+        <source>Critical only</source>
+        <target state="new">Critical only</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.high|DisplayName">
-        <source>High</source>
-        <target state="new">High</target>
+        <source>High and above</source>
+        <target state="new">High and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.low|DisplayName">
-        <source>Low</source>
-        <target state="new">Low</target>
+        <source>Low and above (all levels)</source>
+        <target state="new">Low and above (all levels)</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditLevel.moderate|DisplayName">
-        <source>Moderate</source>
-        <target state="new">Moderate</target>
+        <source>Moderate and above</source>
+        <target state="new">Moderate and above</target>
         <note />
       </trans-unit>
       <trans-unit id="EnumValue|NuGetAuditMode.all|DisplayName">


### PR DESCRIPTION
Fixes #9246

Adds definitions for three properties that control how NuGet Audit is presented to the user, allowing them to configure the feature to their liking.

![image](https://github.com/user-attachments/assets/6acdac40-4557-44a5-984a-82d50b90784f)
