### PR TITLE
Make build property CompilerGeneratedFilesOutputPath accessible to Roslyn project

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -35,6 +35,10 @@
   <StringProperty Name="TargetRefPath"
                   ReadOnly="True"
                   Visible="False" />
+  
+  <StringProperty Name="CompilerGeneratedFilesOutputPath"
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="MaxSupportedLangVersion"
                   ReadOnly="True"


### PR DESCRIPTION
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9544)

The property determines the full paths of source-generated files which needs to be tracked by Roslyn project to support EnC.