### PR TITLE
Add setup component ID for .NET 9

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Setup/SetupComponentReferenceData.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Setup/SetupComponentReferenceData.cs
@@ -38,7 +38,8 @@ internal static class SetupComponentReferenceData
         .Add("v5.0", "Microsoft.NetCore.Component.Runtime.5.0")
         .Add("v6.0", "Microsoft.NetCore.Component.Runtime.6.0")
         .Add("v7.0", "Microsoft.NetCore.Component.Runtime.7.0")
-        .Add("v8.0", "Microsoft.NetCore.Component.Runtime.8.0");
+        .Add("v8.0", "Microsoft.NetCore.Component.Runtime.8.0")
+        .Add("v9.0", "Microsoft.NetCore.Component.Runtime.9.0");
 
     /// <summary>
     /// Attempts to map a .NET Core <c>TargetFrameworkVersion</c> to the corresponding VS Setup component ID for that version's runtime.


### PR DESCRIPTION
Extends our hard-coded mapping from `TargetFrameworkVersion` to Visual Studio setup component ID so that targeting .NET 9 will prompt to install the relevant runtime via IPA (in-product acquisition).

The component is defined in https://dev.azure.com/devdiv/DevDiv/_git/VS?path=%2Fsrc%2FSetupPackages%2FGroup%2FComponent%2FDotNetCoreRuntime.9.0%2Fcomponent.swr (MS internal)

#8186 is tracking the removal of this hard-coded data, which requires work from the SDK (tracked in https://github.com/dotnet/sdk/issues/25575).
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9549)