### PR TITLE
Fail FUTDC when output ref assembly missing

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -222,6 +222,23 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                 }
             }
 
+            // If the project produces a reference assembly, validate that it's present on disk.
+            string? referenceAssemblyPath = state.ProjectCopyData.TargetRefPath;
+
+            if (state.ProjectCopyData.ProduceReferenceAssembly && referenceAssemblyPath is not null)
+            {
+                log.Verbose(nameof(VSResources.FUTD_CheckingProducedReferenceAssemblyExists_1), referenceAssemblyPath);
+                DateTime? referenceAssemblyTime = timestampCache.GetTimestampUtc(referenceAssemblyPath);
+
+                if (referenceAssemblyTime is null)
+                {
+                    return log.Fail("OutputReferenceAssemblyNotFound", nameof(VSResources.FUTD_OutputReferenceAssemblyNotFound_1), referenceAssemblyPath);
+                }
+                
+                using Log.Scope _ = log.IndentScope();
+                log.Verbose(nameof(VSResources.FUTD_ReferenceAssemblyTimeAndPath_2), referenceAssemblyPath, referenceAssemblyTime);
+            }
+
             // Validation passed
             return true;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/ICopyItemAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/ICopyItemAggregator.cs
@@ -70,12 +70,14 @@ internal record struct CopyItemsResult(
 /// </summary>
 /// <param name="ProjectFullPath">The full path to the project file (e.g. the <c>.csproj</c> file).</param>
 /// <param name="TargetPath">The full path to the target file (e.g. a <c>.dll</c> file), which should be unique to the configuration.</param>
+/// <param name="TargetRefPath">The full path to the target reference assembly file (e.g. a <c>.dll</c> file), which should be unique to the configuration. <see langword="null"/> if the project doesn't produce a reference assembly.</param>
 /// <param name="ProduceReferenceAssembly">Whether this project produces a reference assembly or not, determined by the <c>ProduceReferenceAssembly</c> MSBuild property.</param>
 /// <param name="CopyItems">The set of items the project provider to the output directory of itself and other projects.</param>
 /// <param name="ReferencedProjectTargetPaths">The target paths resolved from this project's references to other projects.</param>
 internal record struct ProjectCopyData(
     string? ProjectFullPath,
     string TargetPath,
+    string? TargetRefPath,
     bool ProduceReferenceAssembly,
     ImmutableArray<CopyItem> CopyItems,
     ImmutableArray<string> ReferencedProjectTargetPaths)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -245,7 +245,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
             CopyReferenceInputs = ImmutableArray<string>.Empty;
             PresentBuildAccelerationIncompatiblePackages = ImmutableArray<string>.Empty;
             LastItemChanges = ImmutableArray<(bool IsAdd, string ItemType, string)>.Empty;
-            ProjectCopyData = new(null, "", false, ImmutableArray<CopyItem>.Empty, ImmutableArray<string>.Empty);
+            ProjectCopyData = new(null, "", null, false, ImmutableArray<CopyItem>.Empty, ImmutableArray<string>.Empty);
         }
 
         private UpToDateCheckImplicitConfiguredInput(
@@ -694,7 +694,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
                         bool produceReferenceAssembly = change3.After.Properties.GetBoolProperty(ConfigurationGeneral.ProduceReferenceAssemblyProperty) ?? false;
 
-                        return new ProjectCopyData(msBuildProjectFullPath, targetPath, produceReferenceAssembly, copyItems, referenceItems);
+                        change3.After.Properties.TryGetStringProperty(ConfigurationGeneral.TargetRefPathProperty, out string? targetRefPath);
+
+                        return new ProjectCopyData(msBuildProjectFullPath, targetPath, targetRefPath, produceReferenceAssembly, copyItems, referenceItems);
                     }
                 }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.Designer.cs
@@ -484,6 +484,15 @@ namespace Microsoft.VisualStudio {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Checking for existence of expected output reference assembly:.
+        /// </summary>
+        internal static string FUTD_CheckingProducedReferenceAssemblyExists_1 {
+            get {
+                return ResourceManager.GetString("FUTD_CheckingProducedReferenceAssemblyExists_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Comparing timestamps of copy marker inputs and output:.
         /// </summary>
         internal static string FUTD_ComparingCopyMarkerTimestamps {
@@ -759,6 +768,24 @@ namespace Microsoft.VisualStudio {
         internal static string FUTD_OutputDoesNotExist_1 {
             get {
                 return ResourceManager.GetString("FUTD_OutputDoesNotExist_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output reference assembly &apos;{0}&apos; not found, not up-to-date..
+        /// </summary>
+        internal static string FUTD_OutputReferenceAssemblyNotFound_1 {
+            get {
+                return ResourceManager.GetString("FUTD_OutputReferenceAssemblyNotFound_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Output reference assembly &apos;{0}&apos; found, with timestamp {1}..
+        /// </summary>
+        internal static string FUTD_ReferenceAssemblyTimeAndPath_2 {
+            get {
+                return ResourceManager.GetString("FUTD_ReferenceAssemblyTimeAndPath_2", resourceCulture);
             }
         }
         

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/VSResources.resx
@@ -324,6 +324,17 @@ In order to debug this project, add an executable project to this solution which
   <data name="FUTD_ComparingCopyMarkerTimestamps" xml:space="preserve">
     <value>Comparing timestamps of copy marker inputs and output:</value>
   </data>
+  <data name="FUTD_CheckingProducedReferenceAssemblyExists_1" xml:space="preserve">
+    <value>Checking for existence of expected output reference assembly:</value>
+  </data>
+  <data name="FUTD_OutputReferenceAssemblyNotFound_1" xml:space="preserve">
+    <value>Output reference assembly '{0}' not found, not up-to-date.</value>
+    <comment>{0} is an absolute file path.</comment>
+  </data>
+  <data name="FUTD_ReferenceAssemblyTimeAndPath_2" xml:space="preserve">
+    <value>Output reference assembly '{0}' found, with timestamp {1}.</value>
+    <comment>{0} is an absolute file path. {1} is a datetime.</comment>
+  </data>
   <data name="FUTD_SetOfItemsChangedMoreRecentlyThanOutput_2" xml:space="preserve">
     <value>The set of project items was changed more recently ({0}) than the last successful build start time ({1}), not up-to-date.</value>
     <comment>{0} and {1} are datetimes.</comment>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.cs.xlf
@@ -30,6 +30,21 @@
         <target state="translated">Akcelerace kompilování není pro tento projekt k dispozici, protože kopíruje duplicitní soubory do výstupního adresáře: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Název sestavení architektury</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.de.xlf
@@ -30,6 +30,21 @@
         <target state="translated">Für dieses Projekt ist keine Buildbeschleunigung verfügbar, da doppelte Dateien in das Ausgabeverzeichnis kopiert werden: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Der Name der Frameworkassembly.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.es.xlf
@@ -30,6 +30,21 @@
         <target state="translated">La aceleración de compilación no está disponible para este proyecto porque copia archivos duplicados en el directorio de salida: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nombre del ensamblado del marco.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.fr.xlf
@@ -30,6 +30,21 @@
         <target state="translated">L’accélération de build n’est pas disponible pour ce projet, car il copie les fichiers dupliqués dans le répertoire de sortie : {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nom de l'assembly de framework.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.it.xlf
@@ -30,6 +30,21 @@
         <target state="translated">L'accelerazione di compilazione non è disponibile per questo progetto poiché copia i file duplicati nella directory di output: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nome dell'assembly del framework.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ja.xlf
@@ -30,6 +30,21 @@
         <target state="translated">ビルド アクセラレータは重複するファイルを出力ディレクトリにコピーするため、このプロジェクトではビルド アクセラレータを使用できません: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">フレームワーク アセンブリの名前です。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ko.xlf
@@ -30,6 +30,21 @@
         <target state="translated">이 프로젝트는 출력 디렉터리에 중복 파일을 복사하므로 빌드 가속을 사용할 수 없습니다.{0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">프레임워크 어셈블리의 이름입니다.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pl.xlf
@@ -30,6 +30,21 @@
         <target state="translated">Przyspieszanie kompilacji nie jest dostępne dla tego projektu, ponieważ kopiuje zduplikowane pliki do katalogu wyjściowego: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Nazwa zestawu struktury.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.pt-BR.xlf
@@ -30,6 +30,21 @@
         <target state="translated">A aceleração de compilação não está disponível para esse projeto porque copia arquivos duplicados para o diretório de saída: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">O nome do assembly de estrutura.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.ru.xlf
@@ -30,6 +30,21 @@
         <target state="translated">Ускорение сборки недоступно для этого проекта, так как оно копирует повторяющиеся файлы в выходной каталог: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Имя сборки платформы.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.tr.xlf
@@ -30,6 +30,21 @@
         <target state="translated">Yinelenen dosyaları {0} çıkış dizinine kopyaladığından derleme hızlandırma özelliği bu proje için kullanılamıyor</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">Çerçeve bütünleştirilmiş kodunun adı.</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hans.xlf
@@ -30,6 +30,21 @@
         <target state="translated">生成加速对此项目不可用，因为它将重复文件复制到输出目录: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">框架程序集的名称。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/VSResources.zh-Hant.xlf
@@ -30,6 +30,21 @@
         <target state="translated">此專案無法使用建置加速，因為它會將重複的檔案複製到輸出目錄: {0}</target>
         <note>{0} is a list of one or more relative file paths.</note>
       </trans-unit>
+      <trans-unit id="FUTD_CheckingProducedReferenceAssemblyExists_1">
+        <source>Checking for existence of expected output reference assembly:</source>
+        <target state="new">Checking for existence of expected output reference assembly:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="FUTD_OutputReferenceAssemblyNotFound_1">
+        <source>Output reference assembly '{0}' not found, not up-to-date.</source>
+        <target state="new">Output reference assembly '{0}' not found, not up-to-date.</target>
+        <note>{0} is an absolute file path.</note>
+      </trans-unit>
+      <trans-unit id="FUTD_ReferenceAssemblyTimeAndPath_2">
+        <source>Output reference assembly '{0}' found, with timestamp {1}.</source>
+        <target state="new">Output reference assembly '{0}' found, with timestamp {1}.</target>
+        <note>{0} is an absolute file path. {1} is a datetime.</note>
+      </trans-unit>
       <trans-unit id="FrameworkAssemblyAssemblyNameDescription">
         <source>The name of the framework assembly.</source>
         <target state="translated">架構組件的名稱。</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ConfigurationGeneral.xaml
@@ -314,6 +314,9 @@
   <StringProperty Name="TargetPath"
                   Visible="False" />
 
+  <StringProperty Name="TargetRefPath"
+                  Visible="False" />
+
   <StringProperty Name="TargetPlatformIdentifier"
                   Visible="False" />
 


### PR DESCRIPTION
Fixes #9557

A project's reference assembly output has historically been ignored by its FUTDC. The file cannot be treated as a standard output, as it is not always changed in response to input changes. Treating it as a regular output would therefore lead to overbuild.

This change adds explicit handling for the file, so that if it is removed from disk then the FUTDC consider the project out-of-date, and a build is scheduled.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9558)