### PR TITLE
Fix showing empty target framework options in the Project Properties UI

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -53,7 +53,10 @@ internal sealed class SupportedTargetFrameworksEnumProvider(ConfiguredProject pr
                 ];
             }
 
-            return [];
+            // The user has not entered a value for the TargetFramework property. We've had a report of
+            // seeing this during a manual attempt to migrate a project from legacy CSPROJ to SDK-style.
+            // We should not show an empty list. Instead, assume the user wants to use .NETCoreApp.
+            return GetSupportedTargetFrameworksFromItems(SupportedNETCoreAppTargetFramework.SchemaName);
         }
 
         ICollection<IEnumValue> GetSupportedTargetFrameworksFromItems(string ruleName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
     [AppliesTo(ProjectCapability.DotNet)]
     internal class SupportedTargetFrameworksEnumProvider : SupportedValuesProvider
     {
-        protected override string[] RuleNames => new[] { SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName };
+        protected override string[] RuleNames => [SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName];
 
         [ImportingConstructor]
         public SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
@@ -47,17 +47,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
                 // We decided we will show it in the UI.
                 if (!Strings.IsNullOrEmpty(targetFramework))
                 {
-                    return new IEnumValue[]
-                    {
+                    return
+                    [
                         new PageEnumValue(new EnumValue
                         {
                             Name = targetFrameworkMoniker ?? targetFramework,
                             DisplayName = targetFrameworkIdentifier ?? targetFramework
                         })
-                    };
+                    ];
                 }
 
-                return Array.Empty<IEnumValue>();
+                return [];
             }
 
             ICollection<IEnumValue> GetSupportedTargetFrameworksFromItems(string ruleName)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -3,86 +3,85 @@
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
-namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
+namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks;
+
+/// <summary>
+///     Responsible for producing valid values for the TargetFramework property from evaluation.
+/// </summary>
+[ExportDynamicEnumValuesProvider("SupportedTargetFrameworksEnumProvider")]
+[AppliesTo(ProjectCapability.DotNet)]
+[method: ImportingConstructor]
+internal sealed class SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
+    : SupportedValuesProvider(project, subscriptionService)
 {
-    /// <summary>
-    ///     Responsible for producing valid values for the TargetFramework property from evaluation.
-    /// </summary>
-    [ExportDynamicEnumValuesProvider("SupportedTargetFrameworksEnumProvider")]
-    [AppliesTo(ProjectCapability.DotNet)]
-    [method: ImportingConstructor]
-    internal sealed class SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
-        : SupportedValuesProvider(project, subscriptionService)
+    protected override string[] RuleNames => [SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName];
+
+    protected override ICollection<IEnumValue> Transform(IProjectSubscriptionUpdate input)
     {
-        protected override string[] RuleNames => [SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName];
+        IProjectRuleSnapshot configurationGeneral = input.CurrentState[ConfigurationGeneral.SchemaName];
 
-        protected override ICollection<IEnumValue> Transform(IProjectSubscriptionUpdate input)
+        string? targetFrameworkIdentifier = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkIdentifierProperty);
+
+        if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetCoreApp))
         {
-            IProjectRuleSnapshot configurationGeneral = input.CurrentState[ConfigurationGeneral.SchemaName];
+            return GetSupportedTargetFrameworksFromItems(SupportedNETCoreAppTargetFramework.SchemaName);
+        }
+        else if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetFramework))
+        {
+            return GetSupportedTargetFrameworksFromItems(SupportedNETFrameworkTargetFramework.SchemaName);
+        }
+        else if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetStandard))
+        {
+            return GetSupportedTargetFrameworksFromItems(SupportedNETStandardTargetFramework.SchemaName);
+        }
+        else
+        {
+            string? targetFramework = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkProperty);
+            string? targetFrameworkMoniker = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkMonikerProperty);
 
-            string? targetFrameworkIdentifier = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkIdentifierProperty);
-
-            if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetCoreApp))
+            // This is the case where the TargetFrameworkProperty has a value we recognize but it's not in the supported lists the SDK sends us.
+            // We decided we will show it in the UI.
+            if (!Strings.IsNullOrEmpty(targetFramework))
             {
-                return GetSupportedTargetFrameworksFromItems(SupportedNETCoreAppTargetFramework.SchemaName);
-            }
-            else if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetFramework))
-            {
-                return GetSupportedTargetFrameworksFromItems(SupportedNETFrameworkTargetFramework.SchemaName);
-            }
-            else if (StringComparers.FrameworkIdentifiers.Equals(targetFrameworkIdentifier, TargetFrameworkIdentifiers.NetStandard))
-            {
-                return GetSupportedTargetFrameworksFromItems(SupportedNETStandardTargetFramework.SchemaName);
-            }
-            else
-            {
-                string? targetFramework = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkProperty);
-                string? targetFrameworkMoniker = configurationGeneral.Properties.GetStringProperty(ConfigurationGeneral.TargetFrameworkMonikerProperty);
-
-                // This is the case where the TargetFrameworkProperty has a value we recognize but it's not in the supported lists the SDK sends us.
-                // We decided we will show it in the UI.
-                if (!Strings.IsNullOrEmpty(targetFramework))
-                {
-                    return
-                    [
-                        new PageEnumValue(new EnumValue
-                        {
-                            Name = targetFrameworkMoniker ?? targetFramework,
-                            DisplayName = targetFrameworkIdentifier ?? targetFramework
-                        })
-                    ];
-                }
-
-                return [];
+                return
+                [
+                    new PageEnumValue(new EnumValue
+                    {
+                        Name = targetFrameworkMoniker ?? targetFramework,
+                        DisplayName = targetFrameworkIdentifier ?? targetFramework
+                    })
+                ];
             }
 
-            ICollection<IEnumValue> GetSupportedTargetFrameworksFromItems(string ruleName)
-            {
-                IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];
-
-                var list = new List<IEnumValue>(capacity: snapshot.Items.Count);
-
-                list.AddRange(snapshot.Items.Select(ToEnumValue));
-                list.Sort(SortValues); // TODO: This is a hotfix for item ordering. Remove this when completing: https://github.com/dotnet/project-system/issues/7025
-                return list;
-            }
+            return [];
         }
 
-        protected override IEnumValue ToEnumValue(KeyValuePair<string, IImmutableDictionary<string, string>> item)
+        ICollection<IEnumValue> GetSupportedTargetFrameworksFromItems(string ruleName)
         {
-            return new PageEnumValue(new EnumValue()
-            {
-                // Example: <SupportedTargetFramework  Include=".NETCoreApp,Version=v5.0"
-                //                                     DisplayName=".NET 5.0" />
+            IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];
 
-                Name = item.Key,
-                DisplayName = item.Value[SupportedTargetFramework.DisplayNameProperty],
-            });
+            var list = new List<IEnumValue>(capacity: snapshot.Items.Count);
+
+            list.AddRange(snapshot.Items.Select(ToEnumValue));
+            list.Sort(SortValues); // TODO: This is a hotfix for item ordering. Remove this when completing: https://github.com/dotnet/project-system/issues/7025
+            return list;
         }
+    }
 
-        protected override int SortValues(IEnumValue a, IEnumValue b)
+    protected override IEnumValue ToEnumValue(KeyValuePair<string, IImmutableDictionary<string, string>> item)
+    {
+        return new PageEnumValue(new EnumValue()
         {
-            return NaturalStringComparer.Instance.Compare(a.DisplayName, b.DisplayName);
-        }
+            // Example: <SupportedTargetFramework  Include=".NETCoreApp,Version=v5.0"
+            //                                     DisplayName=".NET 5.0" />
+
+            Name = item.Key,
+            DisplayName = item.Value[SupportedTargetFramework.DisplayNameProperty],
+        });
+    }
+
+    protected override int SortValues(IEnumValue a, IEnumValue b)
+    {
+        return NaturalStringComparer.Instance.Compare(a.DisplayName, b.DisplayName);
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -2,7 +2,6 @@
 
 using Microsoft.Build.Framework.XamlTypes;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using EnumCollection = System.Collections.Generic.ICollection<Microsoft.VisualStudio.ProjectSystem.Properties.IEnumValue>;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
 {
@@ -21,7 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
         {
         }
 
-        protected override EnumCollection Transform(IProjectSubscriptionUpdate input)
+        protected override ICollection<IEnumValue> Transform(IProjectSubscriptionUpdate input)
         {
             IProjectRuleSnapshot configurationGeneral = input.CurrentState[ConfigurationGeneral.SchemaName];
 
@@ -61,7 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
                 return Array.Empty<IEnumValue>();
             }
 
-            EnumCollection GetSupportedTargetFrameworksFromItems(string ruleName)
+            ICollection<IEnumValue> GetSupportedTargetFrameworksFromItems(string ruleName)
             {
                 IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
     [ExportDynamicEnumValuesProvider("SupportedTargetFrameworksEnumProvider")]
     [AppliesTo(ProjectCapability.DotNet)]
     [method: ImportingConstructor]
-    internal class SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
+    internal sealed class SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
         : SupportedValuesProvider(project, subscriptionService)
     {
         protected override string[] RuleNames => [SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName];

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -10,15 +10,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
     /// </summary>
     [ExportDynamicEnumValuesProvider("SupportedTargetFrameworksEnumProvider")]
     [AppliesTo(ProjectCapability.DotNet)]
-    internal class SupportedTargetFrameworksEnumProvider : SupportedValuesProvider
+    [method: ImportingConstructor]
+    internal class SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
+        : SupportedValuesProvider(project, subscriptionService)
     {
         protected override string[] RuleNames => [SupportedNETCoreAppTargetFramework.SchemaName, SupportedNETFrameworkTargetFramework.SchemaName, SupportedNETStandardTargetFramework.SchemaName, ConfigurationGeneral.SchemaName];
-
-        [ImportingConstructor]
-        public SupportedTargetFrameworksEnumProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService)
-            : base(project, subscriptionService)
-        {
-        }
 
         protected override ICollection<IEnumValue> Transform(IProjectSubscriptionUpdate input)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -60,8 +60,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Frameworks
             {
                 IProjectRuleSnapshot snapshot = input.CurrentState[ruleName];
 
-                int capacity = snapshot.Items.Count;
-                var list = new List<IEnumValue>(capacity);
+                var list = new List<IEnumValue>(capacity: snapshot.Items.Count);
 
                 list.AddRange(snapshot.Items.Select(ToEnumValue));
                 list.Sort(SortValues); // TODO: This is a hotfix for item ordering. Remove this when completing: https://github.com/dotnet/project-system/issues/7025


### PR DESCRIPTION
Fixes: https://developercommunity.visualstudio.com/t/Project-Properties-GUI-doesnt-show-avai/10770236

This change fixes the case where we show an empty list of target frameworks in the Project Properties UI.

![image](https://github.com/user-attachments/assets/25e0bad9-50f8-4f29-b7ac-6c581f49a5a4)

When there's no `<TargetFramework>` or `<TargetFrameworks>` properties, we now show the list of `.NETCoreApp` target frameworks.

This assumes the user is trying to manually migrate from legacy CSPROJ to SDK-style, and has not added the property to their project. This change allows them to do that.

The real change is in e73bb1923c04124f5dab4dbc5799d71ab2563934. Other changes modernize the code in this area and improve performance in a few cases. Probably best reviewed commit-by-commit, as each commit is small and clear.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9564)