### PR TITLE
Improve ordering in target framework dropdown

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Frameworks/SupportedTargetFrameworksEnumProvider.cs
@@ -85,6 +85,29 @@ internal sealed class SupportedTargetFrameworksEnumProvider(ConfiguredProject pr
 
     protected override int SortValues(IEnumValue a, IEnumValue b)
     {
-        return NaturalStringComparer.Instance.Compare(a.DisplayName, b.DisplayName);
+        // Order by family first, then by version (descending).
+        int comparison = GetFamilyRank(a.DisplayName) - GetFamilyRank(b.DisplayName);
+
+        if (comparison is not 0)
+        {
+            // Ranks differ.
+            return comparison;
+        }
+
+        // Same rank. Large numbers first.
+        return NaturalStringComparer.Instance.Compare(a.DisplayName, b.DisplayName) * -1;
+
+        static int GetFamilyRank(string displayName)
+        {
+            if (displayName.StartsWith(".NET Core ", StringComparison.OrdinalIgnoreCase))
+                return 1;
+            if (displayName.StartsWith(".NET Standard ", StringComparison.OrdinalIgnoreCase))
+                return 2;
+            if (displayName.StartsWith(".NET Framework ", StringComparison.OrdinalIgnoreCase))
+                return 3;
+            if (displayName.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase))
+                return 0;
+            return 4;
+        }
     }
 }


### PR DESCRIPTION
Small tweak following #9564.

Previously the ordering was "natural" ascending. This created a block with ".NET 5+" items at the top, and ".NET Core" items below, however the newest .NET item (e.g. ".NET 9") would be in the middle of the list.

The change here adds sorting by group, then by version, and makes that version ordering descending. This means that the latest and greatest version is always at the top of the list.

## Before

![image](https://github.com/user-attachments/assets/9b7337f5-f471-42c3-93d4-cb3995eb3f73)

## After

![image](https://github.com/user-attachments/assets/cd132c60-1db6-4d9b-8a7c-d3a9fc2c7db3)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9566)