### PR TITLE
Changing active configuration should not trigger restore cycle detection

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/IPackageRestoreCycleDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/IPackageRestoreCycleDetector.cs
@@ -30,9 +30,11 @@ internal interface IPackageRestoreCycleDetector
     /// The implementation may take some action internally, such as alerting the user and/or sending telemetry.
     /// The caller is expected to use a return value of <see langword="true"/> to halt further restores from
     /// occurring and consuming resources indefinitely.
+    /// This method uses the active project configuration so that cycle state can be reset when it changes.
     /// </remarks>
     /// <param name="hash">The most recent restore hash value, computed from all inputs to the restore operation.</param>
+    /// <param name="activeProjectConfiguration">The active project configuration.</param>
     /// <param name="cancellationToken">A token that can signal a loss of interest in the result.</param>
     /// <returns><see langword="true"/> if a cycle is detected, otherwise <see langword="false"/>.</returns>
-    Task<bool> IsCycleDetectedAsync(Hash hash, CancellationToken cancellationToken);
+    Task<bool> IsCycleDetectedAsync(Hash hash, ProjectConfiguration activeProjectConfiguration, CancellationToken cancellationToken);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreCycleDetector.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreCycleDetector.cs
@@ -140,10 +140,13 @@ internal sealed class PackageRestoreCycleDetector(
 
         void Reset()
         {
-            _stopwatch.Reset();
-            _counter = 0;
-            _values.Clear();
-            _lookupTable.Clear();
+            lock (_lock)
+            {
+                _stopwatch.Reset();
+                _counter = 0;
+                _values.Clear();
+                _lookupTable.Clear();
+            }
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
@@ -126,7 +126,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             // them to actually contains changes, only nominate if there are any.
             Hash hash = RestoreHasher.CalculateHash(restoreInfo);
 
-            if (await _cycleDetector.IsCycleDetectedAsync(hash, token))
+            if (await _cycleDetector.IsCycleDetectedAsync(hash, value.ActiveConfiguration, token))
             {
                 _lastHash = hash;
                 return false;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -9,24 +9,17 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
 {
     [Export(typeof(IPackageRestoreUnconfiguredInputDataSource))]
     [AppliesTo(ProjectCapability.PackageReferences)]
-    internal class PackageRestoreUnconfiguredInputDataSource : ChainedProjectValueDataSourceBase<PackageRestoreUnconfiguredInput>, IPackageRestoreUnconfiguredInputDataSource
+    [method: ImportingConstructor]
+    internal class PackageRestoreUnconfiguredInputDataSource(
+        UnconfiguredProject project,
+        IActiveConfiguredProjectProvider activeConfiguredProjectProvider,
+        IActiveConfigurationGroupService activeConfigurationGroupService)
+        : ChainedProjectValueDataSourceBase<PackageRestoreUnconfiguredInput>(
+            project,
+            synchronousDisposal: false,
+            registerDataSource: false),
+        IPackageRestoreUnconfiguredInputDataSource
     {
-        private readonly UnconfiguredProject _project;
-        private readonly IActiveConfigurationGroupService _activeConfigurationGroupService;
-
-        [ImportingConstructor]
-        public PackageRestoreUnconfiguredInputDataSource(UnconfiguredProject project, IActiveConfigurationGroupService activeConfigurationGroupService)
-            : base(project, synchronousDisposal: false, registerDataSource: false)
-        {
-            _project = project;
-            _activeConfigurationGroupService = activeConfigurationGroupService;
-        }
-
-        protected override UnconfiguredProject ContainingProject
-        {
-            get { return _project; }
-        }
-
         protected override IDisposable LinkExternalInput(ITargetBlock<RestoreInfo> targetBlock)
         {
             // At a high-level, we want to combine all implicitly active configurations (ie the active config of each TFM) restore data
@@ -34,51 +27,65 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             // made to a configuration, such as adding a PackageReference, we should react to it and push a new version of our output. If the 
             // active configuration changes, we should react to it, and publish data from the new set of implicitly active configurations.
 
+            // Merge across configurations
             var joinBlock = new ConfiguredProjectDataSourceJoinBlock<PackageRestoreConfiguredInput>(
                 project => project.Services.ExportProvider.GetExportedValueOrDefault<IPackageRestoreConfiguredInputDataSource>(),
                 JoinableFactory,
-                _project);
+                ContainingProject!);
 
             // Transform all restore data -> combined restore data
-            DisposableValue<ISourceBlock<RestoreInfo>> mergeBlock = joinBlock.TransformWithNoDelta(update => update.Derive(MergeRestoreInputs));
+            IPropagatorBlock<IProjectVersionedValue<(IReadOnlyList<PackageRestoreConfiguredInput>, ConfiguredProject)>, RestoreInfo> transformBlock =
+                DataflowBlockSlim.CreateTransformBlock<IProjectVersionedValue<(IReadOnlyList<PackageRestoreConfiguredInput>, ConfiguredProject)>, RestoreInfo>(
+                    transformFunction: update => update.Derive(MergeRestoreInputs));
 
-            JoinUpstreamDataSources(_activeConfigurationGroupService.ActiveConfiguredProjectGroupSource);
+            // Sync link in the active configuration
+            IDisposable syncLink = ProjectDataSources.SyncLinkTo(
+                joinBlock.SyncLinkOptions(),
+                activeConfiguredProjectProvider.SourceBlock.SyncLinkOptions(),
+                target: transformBlock,
+                linkOptions: DataflowOption.PropagateCompletion);
+
+            JoinUpstreamDataSources(activeConfigurationGroupService.ActiveConfiguredProjectGroupSource, activeConfiguredProjectProvider);
 
             // Set the link up so that we publish changes to target block
-            mergeBlock.Value.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
+            transformBlock.LinkTo(targetBlock, DataflowOption.PropagateCompletion);
 
             return new DisposableBag
             {
                 joinBlock,
+                syncLink,
 
                 // Link the active configured projects to our join block
-                _activeConfigurationGroupService.ActiveConfiguredProjectGroupSource.SourceBlock.LinkTo(joinBlock, DataflowOption.PropagateCompletion),
+                activeConfigurationGroupService.ActiveConfiguredProjectGroupSource.SourceBlock.LinkTo(joinBlock, DataflowOption.PropagateCompletion),
             };
         }
 
-        private PackageRestoreUnconfiguredInput MergeRestoreInputs(IReadOnlyCollection<PackageRestoreConfiguredInput> inputs)
+        private PackageRestoreUnconfiguredInput MergeRestoreInputs((IReadOnlyList<PackageRestoreConfiguredInput> Inputs, ConfiguredProject ActiveConfiguredProject) data)
         {
+            (IReadOnlyList<PackageRestoreConfiguredInput> inputs, ConfiguredProject activeConfiguredProject) = data;
+
             // If there are no updates, we have no active configurations
             ProjectRestoreInfo? restoreInfo = null;
-            if (inputs.Count != 0)
+
+            if (inputs.Count is not 0)
             {
                 // We need to combine the snapshots from each implicitly active configuration (ie per TFM), 
                 // resolving any conflicts, which we'll report to the user.
-                string msbuildProjectExtensionsPath = ResolveMSBuildProjectExtensionsPathConflicts(inputs);
+                string msBuildProjectExtensionsPath = ResolveMSBuildProjectExtensionsPathConflicts(inputs);
                 string originalTargetFrameworks = ResolveOriginalTargetFrameworksConflicts(inputs);
                 string projectAssetsFilePath = ResolveProjectAssetsFilePathConflicts(inputs);
                 ImmutableArray<ReferenceItem> toolReferences = ResolveToolReferenceConflicts(inputs);
                 ImmutableArray<TargetFrameworkInfo> targetFrameworks = GetAllTargetFrameworks(inputs);
 
                 restoreInfo = new ProjectRestoreInfo(
-                    msbuildProjectExtensionsPath,
+                    msBuildProjectExtensionsPath,
                     projectAssetsFilePath,
                     originalTargetFrameworks,
                     targetFrameworks,
                     toolReferences);
             }
 
-            return new PackageRestoreUnconfiguredInput(restoreInfo, inputs);
+            return new PackageRestoreUnconfiguredInput(restoreInfo, inputs, activeConfiguredProject.ProjectConfiguration);
         }
 
         private string ResolveProjectAssetsFilePathConflicts(IReadOnlyCollection<PackageRestoreConfiguredInput> updates)
@@ -209,7 +216,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
                 ReportDataSourceUserFault(
                   ex,
                   ProjectFaultSeverity.LimitedFunctionality,
-                  ContainingProject);
+                  ContainingProject!);
             }
         }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreUnconfiguredInputDataSource.cs
@@ -110,7 +110,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             // Every config should had same value
             bool hasConflicts = updates.Select(u => propertyGetter(u.RestoreInfo))
                                        .Distinct(StringComparers.PropertyNames)
-                                       .Count() > 1;
+                                       .Skip(1)
+                                       .Any();
 
             if (hasConflicts)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/PackageRestoreUnconfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/PackageRestoreUnconfiguredInput.cs
@@ -5,23 +5,25 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
     /// <summary>
     ///     Represents restore input data for an <see cref="UnconfiguredProject"/>.
     /// </summary>
-    internal class PackageRestoreUnconfiguredInput
+    internal sealed class PackageRestoreUnconfiguredInput(
+        ProjectRestoreInfo? restoreInfo,
+        IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs,
+        ProjectConfiguration activeConfiguration)
     {
-        public PackageRestoreUnconfiguredInput(ProjectRestoreInfo? restoreInfo, IReadOnlyCollection<PackageRestoreConfiguredInput> configuredInputs)
-        {
-            RestoreInfo = restoreInfo;
-            ConfiguredInputs = configuredInputs;
-        }
-
         /// <summary>
         ///     Gets the restore information produced in this input. Can be <see langword="null"/> if
         ///     the project has no active configurations.
         /// </summary>
-        public ProjectRestoreInfo? RestoreInfo { get; }
+        public ProjectRestoreInfo? RestoreInfo { get; } = restoreInfo;
 
         /// <summary>
         ///     Gets the <see cref="PackageRestoreConfiguredInput"/> instances that contributed to <see cref="RestoreInfo"/>.
         /// </summary>
-        public IReadOnlyCollection<PackageRestoreConfiguredInput> ConfiguredInputs { get; }
+        public IReadOnlyCollection<PackageRestoreConfiguredInput> ConfiguredInputs { get; } = configuredInputs;
+
+        /// <summary>
+        ///     Gets the active configuration.
+        /// </summary>
+        public ProjectConfiguration ActiveConfiguration { get; } = activeConfiguration;
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
@@ -53,7 +53,7 @@ public sealed class PackageRestoreCycleDetectorTests
         }
     }
 
-    private static Hash CreateHash(byte b) => new(new[] { b });
+    private static Hash CreateHash(byte b) => new([b]);
 
     private static PackageRestoreCycleDetector CreateInstance()
     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
@@ -59,8 +59,6 @@ public sealed class PackageRestoreCycleDetectorTests
     {
         var project = UnconfiguredProjectFactory.CreateWithActiveConfiguredProjectProvider(IProjectThreadingServiceFactory.Create());
 
-        var projectSystemOptions = new Mock<IProjectSystemOptions>();
-
         var telemetryService = new Mock<ITelemetryService>();
         var nonModelNotificationService = new Mock<INonModalNotificationService>();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreDataSourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreDataSourceTests.cs
@@ -36,8 +36,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             var instance = CreateInitializedInstance(nugetRestoreService: nugetRestoreService);
 
             var restoreInfo = ProjectRestoreInfoFactory.Create(msbuildProjectExtensionsPath: @"C:\Alpha\Beta");
-            var ConfigureInputs = PackageRestoreConfiguredInputFactory.Create(restoreInfo);
-            var value = IProjectVersionedValueFactory.Create(new PackageRestoreUnconfiguredInput(restoreInfo, ConfigureInputs!));
+            var configuredInputs = PackageRestoreConfiguredInputFactory.Create(restoreInfo);
+            var activeConfiguration = ProjectConfigurationFactory.Create("Debug|AnyCPU");
+
+            var value = IProjectVersionedValueFactory.Create(new PackageRestoreUnconfiguredInput(restoreInfo, configuredInputs, activeConfiguration));
 
             await instance.RestoreAsync(value);
 
@@ -52,8 +54,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             var nugetRestoreService = INuGetRestoreServiceFactory.ImplementNominateProjectAsync((restoreInfo, versionInfo, cancellationToken) => { callCount++; });
 
             var instance = CreateInitializedInstance(nugetRestoreService: nugetRestoreService);
+            var activeConfiguration = ProjectConfigurationFactory.Create("Debug|AnyCPU");
 
-            var value = IProjectVersionedValueFactory.Create(new PackageRestoreUnconfiguredInput(null, new PackageRestoreConfiguredInput[0]));
+            var value = IProjectVersionedValueFactory.Create(new PackageRestoreUnconfiguredInput(null, [], activeConfiguration));
 
             await instance.RestoreAsync(value);
 
@@ -69,7 +72,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             var instance = CreateInitializedInstance(nugetRestoreService: nugetRestoreService);
 
             var restoreInfo = ProjectRestoreInfoFactory.Create();
-            var value = IProjectVersionedValueFactory.Create(new PackageRestoreUnconfiguredInput(restoreInfo, new PackageRestoreConfiguredInput[0]));
+            var activeConfiguration = ProjectConfigurationFactory.Create("Debug|AnyCPU");
+
+            var value = IProjectVersionedValueFactory.Create(new PackageRestoreUnconfiguredInput(restoreInfo, [], activeConfiguration));
 
             await instance.RestoreAsync(value);
 
@@ -101,7 +106,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             nuGetRestoreService ??= INuGetRestoreServiceFactory.Create();
 
             var cycleDetector = new Mock<IPackageRestoreCycleDetector>();
-            cycleDetector.Setup(o => o.IsCycleDetectedAsync(It.IsAny<Hash>(), It.IsAny<CancellationToken>())).ReturnsAsync(isCycleDetected);
+            cycleDetector.Setup(o => o.IsCycleDetectedAsync(It.IsAny<Hash>(), It.IsAny<ProjectConfiguration>(), It.IsAny<CancellationToken>())).ReturnsAsync(isCycleDetected);
 
             return new PackageRestoreDataSourceMocked(
                 project,


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1951646

We have a feature that attempts to detect patterns in NuGet restore data, flagging these as a runaway restore cycle, stopping the cyclic behaviour, and alerting the user.

Test teams found a scenario where continuously changing active configuration (i.e. toggling between Debug and Release several times) would trigger the cycle detection logic incorrectly. This was causing failures in automated test runs.

This only happens when restore data differs between configurations. A new console app with some simple packages added does not trigger this. The .NET Project System repo would, however.

This commit fixes the issue by including the active project configuration in the dataflow data, such that the cycle detector resets its state whenever the active configuration changes.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9567)