### PR TITLE
Remove an unnecessary allocation from RestoreBuilder.ToReferenceItems

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
@@ -50,14 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
 
             static ImmutableArray<ReferenceItem> ToReferenceItems(IImmutableDictionary<string, IImmutableDictionary<string, string>> items)
             {
-                return items.ToImmutableArray(static (key, value) => ToReferenceItem(key, value));
-
-                static ReferenceItem ToReferenceItem(string name, IImmutableDictionary<string, string> metadata)
-                {
-                    var properties = metadata.ToImmutableArray(static (key, value) => new ReferenceProperty(key, value));
-
-                    return new ReferenceItem(name, metadata);
-                }
+                return items.ToImmutableArray(static (name, metadata) => new ReferenceItem(name, metadata));
             }
         }
     }


### PR DESCRIPTION
The nested ToReferenceItem method was creating an ImmutableArray, but not using it. Went ahead and removed that line, and then since that method was only a single line, just pushed it's remaining contents to the caller.

There was a surprising amount of allocations going on in this line, which I happened to find while looking at the solution load section of a speedometer trace. Overall, this was about 0.3% of allocations in this profile.

*** relevant allocations from the speedometer profile addressed ***

![image](https://github.com/user-attachments/assets/978652f6-bcae-40f0-9b10-4e2984a25f3b)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9569)