### PR TITLE
Remove some unused locals

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -386,6 +386,7 @@ dotnet_diagnostic.IDE0030WithoutSuggestion.severity = error
 dotnet_diagnostic.IDE0031.severity = warning      # Use null propagation (nullable)
 dotnet_diagnostic.IDE0051.severity = warning      # Private member unused
 dotnet_diagnostic.IDE0052.severity = warning      # Remove unread private members
+dotnet_diagnostic.IDE0059.severity = error        # Unnecessary assignment
 dotnet_diagnostic.IDE0079.severity = warning      # Unused suppresion
 dotnet_diagnostic.IDE0083.severity = warning      # Use pattern matching
 dotnet_diagnostic.IDE0084.severity = warning      # Use IsNot

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/References/AbstractReferenceHandler.cs
@@ -67,7 +67,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.References
 
         private static async Task<bool> GetAttributeTreatAsUsedAsync(IProjectProperties metadata)
         {
-            var propertyNames = await metadata.GetPropertyNamesAsync();
             string? value = await metadata.GetEvaluatedPropertyValueAsync(ProjectReference.TreatAsUsedProperty);
 
             return value is not null && PropertySerializer.SimpleTypes.ToValue<bool>(value);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckStatePersistence.cs
@@ -178,7 +178,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
                     guidProject: Guid.Empty,
                     fVersionSpecific: true,
                     fEnsureCreated: true,
-                    out bool isTemporary,
+                    out _, // isTemporary
                     out string workingFolderPath);
 
                 return Path.Combine(workingFolderPath, ProjectItemCacheFileName);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/PackageRestoreCycleDetectorTests.cs
@@ -40,8 +40,6 @@ public sealed class PackageRestoreCycleDetectorTests
     {
         var project = UnconfiguredProjectFactory.CreateWithActiveConfiguredProjectProvider(IProjectThreadingServiceFactory.Create());
 
-        var projectSystemOptions = new Mock<IProjectSystemOptions>();
-
         var telemetryService = new Mock<ITelemetryService>();
         var nonModelNotificationService = new Mock<INonModalNotificationService>();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/MiscellaneousRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/MiscellaneousRuleTests.cs
@@ -271,7 +271,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Rules
             foreach (var rule in GetAllRules())
             {
                 string ruleName = (string)rule[0];
-                string fullPath = (string)rule[1];
 
                 if (s_embeddedRuleNames.Contains(ruleName))
                 {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -679,7 +679,6 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate
 
             var t0 = DateTime.UtcNow.AddMinutes(-3); // t0 Input file timestamp
             var t1 = DateTime.UtcNow.AddMinutes(-2); // t1 Rebuild (sets output file timestamp)
-            var t2 = DateTime.UtcNow.AddMinutes(-1); // t2 Check up-to-date (true)
 
             _fileSystem.AddFile(_inputPath, t0);
 


### PR DESCRIPTION
Following a recent PR that improved performance by removing the initialization of a value assigned to an unused variable, I wanted to enable more analyzers to prevent this in future.

Unfortunately there's not an analyzer that'll catch all instances of this. Within VS we have `IDE0059` already, and this PR turns it into an error (rather than a hint) but it won't catch everything.

The things it did flag are fixed here.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9573)