### PR TITLE
Drop dataflow package version to 8.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -68,7 +68,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.13.0-preview-1-35408-014" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.13.17-preview1-ga15b669c04" />
-    <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="9.0.0-rc.2.24473.5" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="8.0.0" />
     <PackageVersion Include="System.Formats.Asn1"                                                    Version="8.0.1" />
     <PackageVersion Include="Microsoft.VSDesigner"                                                   Version="17.13.38055-preview.1" />
     <PackageVersion Include="VsWebSite.Interop"                                                      Version="17.13.38055-preview.1" />


### PR DESCRIPTION
The 9.0.0-rc.2.24473.5 version is causing issues in CI due to package downgrades being reported as errors. Building locally suggests that 8.0.0 is fine for our solution, so this drops the version.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9576)