### PR TITLE
Revert "Make build property CompilerGeneratedFilesOutputPath accessible to Roslyn project"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -35,10 +35,6 @@
   <StringProperty Name="TargetRefPath"
                   ReadOnly="True"
                   Visible="False" />
-  
-  <StringProperty Name="CompilerGeneratedFilesOutputPath"
-                  ReadOnly="True"
-                  Visible="False" />
 
   <StringProperty Name="MaxSupportedLangVersion"
                   ReadOnly="True"


### PR DESCRIPTION
Reverts dotnet/project-system#9544

This change was triggering a failure in Roslyn around use of `EmitCompilerGeneratedFiles`, leading to project faults resembling:

```
System.ArgumentException: Absolute path expected
Parameter name: path
  at Microsoft.CodeAnalysis.CompilationOutputInfo.WithGeneratedFilesOutputDirectory(String path)
  at Microsoft.CodeAnalysis.Workspaces.ProjectSystem.ProjectSystemProject.<>c__DisplayClass69_0.<set_GeneratedFilesOutputDirectory>b__0(Solution s)
...
```

At the start of October, Roslyn started requiring an absolute path here:

https://github.com/dotnet/roslyn/pull/75311/files#diff-8440787c9215f81fa8cabe9072d5ab0598251313a4480cfca075041ceed8a5bbR41-R44

But by default, the SDK provides a relative path (and indeed all online examples show relative paths here). Only once we inserted #9544 

@tmat has a PR open in Roslyn to fix this: https://github.com/dotnet/roslyn/pull/75674/files

Once the Roslyn side is fixed, we can reinstate this change.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9579)