### PR TITLE
Revert "Revert "Make build property CompilerGeneratedFilesOutputPath accessible to Roslyn project""

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/LanguageService.xaml
@@ -35,6 +35,10 @@
   <StringProperty Name="TargetRefPath"
                   ReadOnly="True"
                   Visible="False" />
+  
+  <StringProperty Name="CompilerGeneratedFilesOutputPath"
+                  ReadOnly="True"
+                  Visible="False" />
 
   <StringProperty Name="MaxSupportedLangVersion"
                   ReadOnly="True"


### PR DESCRIPTION
Following the fix in https://github.com/dotnet/roslyn/pull/75674, we can revisit this change.

This PR reverts dotnet/project-system#9579, reinstating #9544.


 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9581)