### PR TITLE
Replace backward/forward slash in ProjectAndExecutableLaunchHandlerHelpers.GetOutputDirectoryAsync with system default

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ProjectAndExecutableLaunchHandlerHelpers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ProjectAndExecutableLaunchHandlerHelpers.cs
@@ -22,7 +22,9 @@ internal static class ProjectAndExecutableLaunchHandlerHelpers
 
         IProjectProperties properties = configuredProject.Services.ProjectPropertiesProvider.GetCommonProperties();
 
-        return await properties.GetEvaluatedPropertyValueAsync(ConfigurationGeneral.OutDirProperty);
+        var outDir = await properties.GetEvaluatedPropertyValueAsync(ConfigurationGeneral.OutDirProperty);
+
+        return ReplaceSlashWithSystemDefault(outDir);
     }
 
     /// <summary>
@@ -212,5 +214,10 @@ internal static class ProjectAndExecutableLaunchHandlerHelpers
         string runArguments = await properties.GetEvaluatedPropertyValueAsync("RunArguments");
 
         return (exeToRun, runArguments, runWorkingDirectory);
+    }
+
+    private static string ReplaceSlashWithSystemDefault(string path)
+    {
+        return path.Replace('/', Path.DirectorySeparatorChar).Replace('\\', Path.DirectorySeparatorChar);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ProjectAndExecutableLaunchHandlerHelpersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ProjectAndExecutableLaunchHandlerHelpersTests.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.IO;
 using Microsoft.VisualStudio.ProjectSystem.Utilities;
 
@@ -7,11 +8,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug;
 
 public class ProjectAndExecutableLaunchHandlerHelpersTests
 {
-    [Fact]
-    public async Task GetOutputDirectoryAsync_Returns_OutputDirectory_When_FullPath()
+    [Theory]
+    [InlineData("C:\\OutputDirectory", "/C:/OutputDirectory", "C:\\OutputDirectory")] // Windows
+    [InlineData("\\mnt\\OutputDirectory", "/mnt/OutputDirectory", "/mnt/OutputDirectory")] // Linux
+    [InlineData("\\mnt\\OutputDirectory", "/mnt/OutputDirectory", "/mnt\\OutputDirectory")] // mixed
+    public async Task GetOutputDirectoryAsync_Returns_OutputDirectory_When_FullPath(string expectedOutputDirectoryOnWindows, string expectedOutputDirectoryOnLinux, string actualOutputDirectory)
     {
-        // Arrange
-        var expectedOutputDirectory = @"C:\OutputDirectory";
+        var expectedOutputDirectory = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? expectedOutputDirectoryOnWindows : expectedOutputDirectoryOnLinux;
         var project = CreateConfiguredProject(new() { { "OutDir", expectedOutputDirectory } });
 
         // Act


### PR DESCRIPTION
fix #9584 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9585)