### PR TITLE
Improve docs around design-time builds

### DIFF
--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -11,36 +11,6 @@ Design-time builds are special builds that are launched by the project system to
 
 For performance reasons, and unlike normal builds which call the _Build_ target, design-time builds call a limited set of targets. This can lead to custom builds that succeed during a normal build, but end up failing during a design-time build, typically due to custom targets with under-specified dependencies.
 
-## Targets that run during design-time builds
-
-The following design-time targets are called, including any dependencies, during design-time builds in the C#/VB project systems. Other project systems, such as C++ or JavaScript will call different targets. 
-
-Design-Time Target                             | Defined by | Description
------------------------------------------------|------------|------------------
-BuiltProjectOutputGroup                        | MSBuild    | 
-CollectAnalyzersDesignTime                     | DNPS       | Returns `Analyzer` items.
-CollectCentralPackageVersions                  | NuGet      | Returns `PackageVersion` items.
-CollectCopyToOutputDirectoryItemDesignTime     | DNPS       | Identifies items the project contributes to the output directory during build. Supports the Fast Up-to-date Check and Build Acceleration.
-CollectFrameworkReferences                     | NuGet      | Returns non-transitive `FrameworkReference` items. Supports package restore.
-CollectNuGetAuditSuppressions                  | NuGet      | Returns `NuGetAuditSuppress` items. Supports package restore.
-CollectPackageDownloads                        | NuGet      | Returns `PackageDownload` items. Supports package restore.
-CollectPackageReferences                       | NuGet      | Returns `PackageReference` items. Supports package restore.
-CollectResolvedCompilationReferencesDesignTime | DNPS       |
-CollectResolvedSDKReferencesDesignTime         | SDK        |
-CollectSuggestedVisualStudioComponentIds       | DNPS       | Supports in-product acquisition (IPA).
-CollectUpToDateCheckBuiltDesignTime            | DNPS       | Supports the Fast Up-to-date Check.
-CollectUpToDateCheckInputDesignTime            | DNPS       | Supports the Fast Up-to-date Check.
-CollectUpToDateCheckOutputDesignTime           | DNPS       | Supports the Fast Up-to-date Check.
-CompileDesignTime                              | MSBuild    | Passes command-line arguments, `<Compile>` items and `<Analyzer>` items to the compiler in normal builds, or to the language service in design-time builds.
-GenerateSupportedTargetFrameworkAlias          | SDK        | Returns `SupportedTargetFrameworkAlias` items. Supports the Project Properties UI.
-ResolveAssemblyReferencesDesignTime            | MSBuild    | Resolves `Reference` items to their paths. Supports the Dependencies Node.
-ResolveComReferencesDesignTime                 | MSBuild    | Resolves `COMReference` items to their primary interop assemblies (PIA) paths. Supports the Dependencies Node.
-ResolveFrameworkReferencesDesignTime           | MSBuild    | Resolves `FrameworkReference` items to their paths. Supports the Dependencies Node.
-ResolvePackageDependenciesDesignTime           | MSBuild    | Resolves `PackageReference` items to their paths. Supports the Dependencies Node.
-ResolveProjectReferencesDesignTime2            | DNPS       | Resolves `ProjectReference` items to their output paths. Overrides `ResolveProjectReferencesDesignTime` from MSBuild's common targets. Supports the Dependencies Node.
-
-Where DNPS is the .NET Project System (this repository).
-
 ## Designing targets for use in design-time builds
 
 Targets that dynamically change references, source files or compilation options _must_ run during design-time builds to avoid unexpected behavior in Visual Studio. In contrast, if a target does not contribute these items, then it should actively avoid running in these builds to ensure design-time builds are as fast as possible. Whether a target is run in design-time builds is based on whether a target's `BeforeTargets` and `AfterTargets` attributes specifies a direct or indirect dependency of any of the above  targets. See [Diagnosing design-time builds](#diagnosing-design-time-builds) to see logs that help you figure out if your target is being run or not.
@@ -184,3 +154,33 @@ Task Performance Summary:
         1 ms  AssignProjectConfiguration                 1 calls
         2 ms  Delete                                     3 calls
 ``` 
+
+## Targets that run during design-time builds
+
+The following design-time targets are called, including any dependencies, during design-time builds in the C#/VB project systems. Other project systems, such as C++ or JavaScript will call different targets. 
+
+Design-Time Target                             | Defined by | Description
+-----------------------------------------------|------------|------------------
+BuiltProjectOutputGroup                        | MSBuild    | 
+CollectAnalyzersDesignTime                     | DNPS       | Returns `Analyzer` items.
+CollectCentralPackageVersions                  | NuGet      | Returns `PackageVersion` items.
+CollectCopyToOutputDirectoryItemDesignTime     | DNPS       | Identifies items the project contributes to the output directory during build. Supports the Fast Up-to-date Check and Build Acceleration.
+CollectFrameworkReferences                     | NuGet      | Returns non-transitive `FrameworkReference` items. Supports package restore.
+CollectNuGetAuditSuppressions                  | NuGet      | Returns `NuGetAuditSuppress` items. Supports package restore.
+CollectPackageDownloads                        | NuGet      | Returns `PackageDownload` items. Supports package restore.
+CollectPackageReferences                       | NuGet      | Returns `PackageReference` items. Supports package restore.
+CollectResolvedCompilationReferencesDesignTime | DNPS       |
+CollectResolvedSDKReferencesDesignTime         | SDK        |
+CollectSuggestedVisualStudioComponentIds       | DNPS       | Supports in-product acquisition (IPA).
+CollectUpToDateCheckBuiltDesignTime            | DNPS       | Supports the Fast Up-to-date Check.
+CollectUpToDateCheckInputDesignTime            | DNPS       | Supports the Fast Up-to-date Check.
+CollectUpToDateCheckOutputDesignTime           | DNPS       | Supports the Fast Up-to-date Check.
+CompileDesignTime                              | MSBuild    | Passes command-line arguments, `<Compile>` items and `<Analyzer>` items to the compiler in normal builds, or to the language service in design-time builds.
+GenerateSupportedTargetFrameworkAlias          | SDK        | Returns `SupportedTargetFrameworkAlias` items. Supports the Project Properties UI.
+ResolveAssemblyReferencesDesignTime            | MSBuild    | Resolves `Reference` items to their paths. Supports the Dependencies Node.
+ResolveComReferencesDesignTime                 | MSBuild    | Resolves `COMReference` items to their primary interop assemblies (PIA) paths. Supports the Dependencies Node.
+ResolveFrameworkReferencesDesignTime           | MSBuild    | Resolves `FrameworkReference` items to their paths. Supports the Dependencies Node.
+ResolvePackageDependenciesDesignTime           | MSBuild    | Resolves `PackageReference` items to their paths. Supports the Dependencies Node.
+ResolveProjectReferencesDesignTime2            | DNPS       | Resolves `ProjectReference` items to their output paths. Overrides `ResolveProjectReferencesDesignTime` from MSBuild's common targets. Supports the Dependencies Node.
+
+Where DNPS is the .NET Project System (this repository).

--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -1,7 +1,5 @@
 # Design-time builds
 
-## What is a design-time build
-
 Visual Studio needs various information about your projects, including source files, references and options. In .NET, much of this data is defined in MSBuild `<Project>` files, such as `MyProject.csproj`. Visual Studio uses the MSBuild engine to obtain data about a project via a so-called _design-time build_ (DTB).
 
 DTBs differ from normal builds in a few key ways:
@@ -11,7 +9,7 @@ DTBs differ from normal builds in a few key ways:
 - No compilation occurs, and outputs aren't modified.
 - Additional MSBuild targets are invoked to obtain various data.
 
-## What features do design-time builds support
+## Features that design-time builds support
 
 Data obtained from DTBs drive many IDE features, including:
 
@@ -19,11 +17,11 @@ Data obtained from DTBs drive many IDE features, including:
 
 - **NuGet** needs information in order to restore packages used by the project. Without this, types from NuGet packages are unavailable in the IDE and code that uses them will show errors. Packages can also contribute their own targets to DTBs to extend IDE behavior.
 
-- **Dependencies tree** shows the project's declared dependencies, and the DTB attempts to resolve them. Any failures are shown as warnings in the tree.
+- **Dependencies tree** shows the project's declared dependencies, and the DTB attempts to resolve them. Any items that couldn't be resolved during the DTB are shown as warnings in the tree.
 
 And many others.
 
-## When do design-time builds occur
+## Design-time builds triggers
 
 Design-time builds occur during project load, and in response to project changes. For example, changing the project's target framework, or adding a NuGet package, are both operations that modify the project (e.g. `.csproj`) file. Those changes trigger a design-time builds, which are scheduled behind the scenes.
 
@@ -39,7 +37,7 @@ Changing `Directory.*.props` and `Directory.*.targets` files will trigger DTBs i
 
 The easiest way to manually trigger a DTB is to make a white-space change in the project file and save it. This can be helpful when capturing DTB logs (discussed below in [Diagnosing design-time builds](#Diagnosing-design-time-builds)).
 
-## What can go wrong
+## Problems with design-time builds
 
 DTBs run in the IDE (i.e. at design time). A problematic DTB will manifest its problems in the IDE experience.
 

--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -1,38 +1,171 @@
 # Design-time builds
 
-- [What is a design-time build?](#what-is-a-design-time-build)
-- [Targets that run during design-time builds](#targets-that-run-during-design-time-builds)
-- [Designing targets for use in design-time builds](#designing-targets-for-use-in-design-time-builds)
-- [Diagnosing design-time builds](#diagnosing-design-time-builds)
+## What is a design-time build
 
-## What is a design-time build?
+Visual Studio needs various information about your projects, including source files, references and options. In .NET, much of this data is defined in MSBuild `<Project>` files, such as `MyProject.csproj`. Visual Studio uses the MSBuild engine to obtain data about a project via a so-called _design-time build_ (DTB).
 
-Design-time builds are special builds that are launched by the project system to gather just enough information to populate the language service and other project services, such as the Dependencies node.  Design-time builds are not directly user-initiated, but may be indirectly launched in response to a user action such as changing the project file, build options, adding/removing source files and references, or switching configurations.
+DTBs differ from normal builds in a few key ways:
 
-For performance reasons, and unlike normal builds which call the _Build_ target, design-time builds call a limited set of targets. This can lead to custom builds that succeed during a normal build, but end up failing during a design-time build, typically due to custom targets with under-specified dependencies.
+- They are scheduled automatically by VS, such as during project load or when a project file changes.
+- They run behind-the-scenes, without showing output in the IDE (generally).
+- No compilation occurs, and outputs aren't modified.
+- Additional MSBuild targets are invoked to obtain various data.
+
+## What features do design-time builds support
+
+Data obtained from DTBs drive many IDE features, including:
+
+- **Language services** need to know things like `<LangVersion>`, source files, references, etc. This information drives syntax highlighting, IntelliSense, error highlighting, analyzers, etc.
+
+- **NuGet** needs information in order to restore packages used by the project. Without this, types from NuGet packages are unavailable in the IDE and code that uses them will show errors. Packages can also contribute their own targets to DTBs to extend IDE behavior.
+
+- **Dependencies tree** shows the project's declared dependencies, and the DTB attempts to resolve them. Any failures are shown as warnings in the tree.
+
+And many others.
+
+## When do design-time builds occur
+
+Design-time builds occur during project load, and in response to project changes. For example, changing the project's target framework, or adding a NuGet package, are both operations that modify the project (e.g. `.csproj`) file. Those changes trigger a design-time builds, which are scheduled behind the scenes.
+
+Visual Studio caches data from these builds to disk in the `.vs` folder. During project load, if the cache is up to date, then the DTB is skipped and the cached data used instead.
+
+If a project multi-targets (e.g. `<TargetFrameworks>net9.0;net48</TargetFrameworks>`) then a separate DTB is scheduled for each target framework. Data will differ between targets, so each needs its own DTB.
+
+DTBs take the IDE's active configuration (e.g. _Debug_ or _Release_) into account. Changing the active configuration triggers a DTB.
+
+When switching branches, DTBs only run if projects are modified.
+
+Changing `Directory.*.props` and `Directory.*.targets` files will trigger DTBs in all nested projects.
+
+The easiest way to manually trigger a DTB is to make a white-space change in the project file and save it. This can be helpful when capturing DTB logs (discussed below in [Diagnosing design-time builds](#Diagnosing-design-time-builds)).
+
+## What can go wrong
+
+DTBs run in the IDE (i.e. at design time). A problematic DTB will manifest its problems in the IDE experience.
+
+For example, a slow DTB will increase the time taken to load the project, and can hog resources when making various changes in the IDE.
+
+DTBs can also report errors and fail. In Visual Studio, failing design-time builds display an info bar with text:
+
+> An error occurred during a design-time build. Some features may not work correctly. See the Error List for details.
+
+When a DTB fails, any number of VS features might fail to work. Some examples:
+
+- IntelliSense shows incomplete and/or incorrect results.
+- Code is not highlighted in the editor, or is highlighted incorrectly.
+- Opening source files in the editor shows them in the `Miscellaneous Files` project.
+- Builds succeed while outdated build failure messages are in the Error List.
+
+## Diagnosing design-time builds
+
+The error list will show any error messages from the DTB, however investigating errors and performance issues usually requires a build log.
+
+### Capturing binlogs
+
+To capture binary build logs (binlogs):
+
+1. Open a _Developer Command Prompt_ for the version of Visual Studio you want to use.
+1. Enable MSBuild logging via environment variable:
+   ```
+   set MSBUILDDEBUGENGINE=1
+   ```
+1. Decide where you want logs to be written:
+   - By default, logs are written to a `MSBuild_Logs` subdirectory (beneath the current working directory).
+   - To specify a directory to write logs, set the `MSBUILDDEBUGPATH` environment variable to an absolute directory path. It must be writeable by the current user.
+      ```
+      set MSBUILDDEBUGPATH=c:\some\path
+      ```
+1. Run `devenv.exe` to start Visual Studio.
+1. Make a white-space change in the project you're investigating to trigger a DTB.
+1. Open the directory from step 3 in Windows Explorer to see the captured `.binlog` and other diagnostic files.
+1. Open the most recent `*DesignTimeBatchBuild*.binlog` file in the [MSBuild Structured Log Viewer](https://msbuildlog.com).
+
+> [!NOTE]
+> While this environment variable is set, all builds will be logged. You must manually remove these log files when they're no longer needed. It is recommended to only set this enviroment for short periods, as needed.
+
+For more information, see:
+
+- [Binary log format](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Binary-Log.md)
+- [MSBuild Structured Log Viewer](https://msbuildlog.com)
+- [Providing MSBuild binary logs for investigation](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Providing-Binary-Logs.md)
+- [Further MSBuild documentation on binlogs](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs).
+
+<details>
+<summary>Instructions for versions before Visual Studio 2022</summary>
+
+Support for `MSBUILDDEBUGENGINE` was added in MSBuild 17.0, which shipped with VS 17.0 (the first release of VS2022). Different approaches are needed for earlier versions of Visual Studio.
+
+#### Visual Studio 2017
+
+1. Install the [Project System Tools](https://github.com/dotnet/project-system-tools#project-system-tools) extension.
+2. In Visual Studio, choose the `View > Other Windows > Build Logging` menu item.
+3. Click on the "play" button.
+
+This will cause design-time builds to show up in the build logging tool window. If you have the [MSBuild Structured Log Viewer](https://msbuildlog.com) installed, you can double-click on a log to view it in the viewer, otherwise you can right-click and choose `Save As...` to save a binary log.
+
+Note that logs produced via this mechanism have lower verbosity than those captured by `MSBUILDDEBUGENGINE`
+
+#### Visual Studio 2015 or below
+
+1. Delete the `.vs` directory that sits alongside the solution that is experiencing the problem.
+2. Start a _Developer Command Prompt for VS2015_.
+3. At the prompt, run `set TRACEDESIGNTIME=true`
+4. At the prompt, run `devenv`
+5. Open the solution.
+6. Under `%TEMP%`, look for `[RANDOMGUID].designtime.log` files, these will contain the results of the design-time build. If running Visual Studio 2015 Update 2 or higher, the name of the project and design-time target that is being called will also be included in the file name.
+
+</details>
+
+### Diagnosing failing design-time builds
+
+When opening a `.binlog` in the [MSBuild Structured Log Viewer](https://msbuildlog.com), any error is immediately highlighted. If the cause of the error is not obvious, follow execution and data backwards until a cause is found. This will likely require at least a basic knowledge of MSBuild's evaluation and execution model.
+
+### Diagnosing failing design-time builds
+
+The [MSBuild Structured Log Viewer](https://msbuildlog.com) supports design-time build performance investigations.
+
+Under a project's node, a _Top 10 most expensive tasks_ node lists the project's longest-running tasks and which targets invoked them.
+
+There are also the _Timeline_ and _Tracing_ views that show execution duration in different forms.
 
 ## Designing targets for use in design-time builds
 
-Targets that dynamically change references, source files or compilation options _must_ run during design-time builds to avoid unexpected behavior in Visual Studio. In contrast, if a target does not contribute these items, then it should actively avoid running in these builds to ensure design-time builds are as fast as possible. Whether a target is run in design-time builds is based on whether a target's `BeforeTargets` and `AfterTargets` attributes specifies a direct or indirect dependency of any of the above  targets. See [Diagnosing design-time builds](#diagnosing-design-time-builds) to see logs that help you figure out if your target is being run or not.
+Targets that dynamically change references, source files or compilation options _must_ run during both normal _and_ design-time builds to avoid unexpected behavior in Visual Studio.
 
-### Running in a design-time build
+Equally, if a target does not contribute these items, then it should actively avoid running in these builds to ensure design-time builds are as fast as possible.
 
-If you've determined that your target needs to run in a design-time build, using the above table set `BeforeTargets` to the normal target equivalent of what you are contributing to the build. For example, if a target changes `<Reference>` items, then it should indicate that it runs _before_ `ResolveAssemblyReferences` target:
+### Adding items during design-time builds
+
+MSBuild targets that run during DTBs can add items to the project. To do so, the target must run before the corresponding design-time target, per the following table:
+
+Design-Time Target                            | Normal Target                      | Description
+----------------------------------------------|------------------------------------|------------------
+ResolveAssemblyReferencesDesignTime           | ResolveAssemblyReferences          | Resolves `<Reference>` items to their paths.
+ResolveProjectReferencesDesignTime            | ResolveProjectReferences           | Resolves `<ProjectReference>` items to their output paths.
+ResolveComReferencesDesignTime                | ResolveComReferences               | Resolves `<COMReference>` items to their primary interop assemblies (PIA) paths.
+ResolveFrameworkReferencesDesignTime          | ResolveFrameworkReferences         | Resolves `<FrameworkReference>` items to their paths.
+ResolvePackageDependenciesDesignTime          | ResolvePackageDependencies         | Resolves `<PackageReference>` items to their paths.
+CompileDesignTime (new project system)/Compile| Compile                            | Passes command-line arguments, `<Compile>` items and `<Analyzer>` items to the compiler in normal builds, or to the language service in design-time builds.
+
+If you've determined that your target needs to run in a design-time build, refer to the above table and set `BeforeTargets` to the normal target equivalent of what you are contributing to the build. For example, if a target changes `<Reference>` items, then it should indicate that it runs _before_ `ResolveAssemblyReferences` target:
 
 ```xml
 <Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">
     ...
 </Target>
 ```
-The `AddAdditionalReferences` target will run in both normal builds _and_ design-time builds, leading to consistent results between them.
+
+This new `AddAdditionalReferences` target will run in both normal builds _and_ design-time builds, leading to consistent results between them.
+
+Note that dependencies added during DTBs will not be displayed in the the projects Dependencies tree in Solution Explorer. For an item to be shown as a dependency, it must be present during MSBuild evaluation.
 
 ### Determining whether a target is running in a design-time build
 
-Checking if a target is running in a design-time build can be used to avoid expensive calculations or work that is only needed for a normal build, helping to keep the IDE responsive.
+In rare cases, you may wish to stop a target from running during design-time builds. Perhaps the target performs expensive calculations that aren't required for Visual Studio. Skipping such targets helps keep the IDE responsive.
 
-Different project systems use different properties to distinguish between design-time builds and normal builds. For example, the .NET Project System in this repo builds on top of the Common Project System (CPS) components, and CPS-based project systems set the `DesignTimeBuild` property. However, non-SDK-style C# and VB projects generally use what we call the "legacy" project system, and it uses the `BuildingProject` property.
+Different project systems use different properties to distinguish between design-time builds and normal builds. For example, the .NET Project System in this repo builds on top of the Common Project System (CPS), which sets the `DesignTimeBuild` property. Older, non-SDK-style C# and VB projects (from the .NET Framework era) use the `BuildingProject` property.
 
-As such, you should make use of both the `DesignTimeBuild` and `BuildingProject` properties to determine whether a target is running in a design-time build or a normal build: 
+As such, you should make use of both the `DesignTimeBuild` and `BuildingProject` properties to determine whether a target is running in a design-time build or a normal build. Extending our earlier example:
 
 ```xml
 <Target Name="AddAdditionalReferences" BeforeTargets="ResolveAssemblyReferences">
@@ -43,117 +176,12 @@ As such, you should make use of both the `DesignTimeBuild` and `BuildingProject`
 </Target>
 ```
 
-__NOTE:__ The `DesignTimeBuild` property is typically empty (`''`) in normal builds, so avoid comparisons to `'false'`.
+> [!IMPORTANT]
+> The `DesignTimeBuild` property is typically empty (`''`) in normal builds, so avoid comparisons to `'false'`.
  
 ### Specifying explicit dependencies
 
-If your target has dependencies on properties, items or files produced during the build, it must have a `DependsOnTargets` attribute that accurately indicates the set of targets that produce those assets. An under-specified `DependsOnTargets` will lead to unexpected behavior, such as targets that fail on the first design-time build or fail during every design-time build.
-
-## Diagnosing design-time builds
-
-### Signs that a design-time build is failing or taking too long
-
-While the results of design-time builds are not directly visible by default, the following symptoms are good indicators that one is failing for a given project:
-
-- Source files in a project are marked as coming from the `Miscellaneous Files` project when opened in the editor
-- IntelliSense shows incomplete and/or incorrect results
-- A normal build succeeds inside and outside of Visual Studio, yet the Error List continues to show build errors
-
-The following are symptoms of a design-time build that is taking too long:
-
-- Project modifications, such as renaming, adding or deleting files, take a long time
-- Switching build configurations, for example from Debug to Release, takes a long time
-
-### Getting Visual Studio to output the results of a design-time build
-
-You can force Visual Studio to show the results of a design-time build using the following instructions:
-
-#### Visual Studio 2022 or later
-
-You may use the [Project System Tools](https://github.com/dotnet/project-system-tools#project-system-tools) extension mentioned immediately above, however that extension does not capture all available information. To capture all build information:
-
-1. Open a _Developer Command Prompt_ for the version of Visual Studio you want to use.
-1. Set two environment variables as follows:
-   ```
-   set MSBuildDebugEngine=1
-   set MSBUILDDEBUGPATH=c:\some\path
-   ```
-   You can use whatever path you like for `MSBUILDDEBUGPATH`, but it must be writeable by the current user.
-1. Type `devenv` to start Visual Studio with this configuration.
-1. Open the `MSBUILDDEBUGPATH` path in Windows Explorer to see the captured `.binlog` and other diagnostic files. You can open them using the [MSBuild Structured Log Viewer](https://msbuildlog.com).
-
-⚠️ While this environment variable is set, all builds will be logged. It's possible for the number of output logs to be very high.
-
-For more information, see:
-
-- [Providing MSBuild Binary Logs for investigation](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Providing-Binary-Logs.md)
-- [Further MSBuild documentation on binlogs](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md#logs).
-
-#### Visual Studio 2017
-
-1. Install the [Project System Tools](https://github.com/dotnet/project-system-tools#project-system-tools) extension.
-2. In Visual Studio, choose the `View > Other Windows > Build Logging` menu item.
-3. Click on the "play" button.
-
-This will cause design-time builds to show up in the build logging tool window. If you have the [MSBuild Structured Log Viewer](https://msbuildlog.com) installed, you can double-click on a log to view it in the viewer, otherwise you can right-click and choose `Save As...` to save the log in the new [binary log format](https://github.com/Microsoft/msbuild/wiki/Binary-Log).
-
-#### Visual Studio 2015 or below
-
-1. Delete the `.vs` directory that sits alongside the solution that is experiencing the problem.
-2. Start a _Developer Command Prompt for VS2015_.
-3. At the prompt, run `SET TRACEDESIGNTIME=true`
-4. At the prompt, run `devenv`
-5. Open the solution.
-6. Under `%TEMP%`, look for `[RANDOMGUID].designtime.log` files, these will contain the results of the design-time build. If running Visual Studio 2015 Update 2 or higher, the name of the project and design-time target that is being called will also be included in the file name.
-
-### Diagnosing failing or slow design-time builds
-
-After following the above instructions, open the resulting build log file or Output window (for the new project system).
-
-#### Failing design-time build
-
-For a failing build, look for errors at the end of the log:
-
-```
-Build FAILED.
-
-c:\Projects\MyProject\MyProject.csproj(17,5): error : An error occurred!
-    0 Warning(s)
-    1 Error(s)
-```
-
-These errors indicate that a target failed, typically this is due to targets that have not correctly specified their dependencies.
-
-#### Slow design-time build
-
-For a slow design-time, look for the target performance summary at end of the log which can indicate long running tasks and targets:
-
-```
-Target Performance Summary:
-        0 ms  AfterClean                                 1 calls
-        0 ms  Clean                                      1 calls
-        0 ms  CleanReferencedProjects                    1 calls
-        0 ms  CleanPublishFolder                         1 calls
-        0 ms  BeforeRebuild                              1 calls
-        0 ms  BeforeClean                                1 calls
-        0 ms  BeforeBuild                                1 calls
-        0 ms  _SplitProjectReferencesByFileExistence     1 calls
-        1 ms  CleanXsdCodeGen                            1 calls
-        2 ms  AssignProjectConfiguration                 1 calls
-        7 ms  CoreClean                                  1 calls
-       10 ms  _CheckForInvalidConfigurationAndPlatform   1 calls
-
-Task Performance Summary:
-        0 ms  RemoveDuplicates                           1 calls
-        0 ms  Error                                      1 calls
-        1 ms  MakeDir                                    1 calls
-        1 ms  Message                                    2 calls
-        1 ms  ReadLinesFromFile                          1 calls
-        1 ms  WriteLinesToFile                           1 calls
-        1 ms  FindUnderPath                              2 calls
-        1 ms  AssignProjectConfiguration                 1 calls
-        2 ms  Delete                                     3 calls
-``` 
+If your target has dependencies on properties, items or files produced during the build, it must have a `DependsOnTargets` attribute that accurately indicates the set of targets that produce those assets. An under-specified `DependsOnTargets` will lead to unexpected behavior, including incomplete data and DTB failures.
 
 ## Targets that run during design-time builds
 


### PR DESCRIPTION
This PR updates `docs/design-time-builds.md` as it was missing some details, and had some outdated information. The content was rewritten in a few places to be clearer and provide more context.

Docs in the `/docs` folder are aimed at users of the project system. This PR moves the most relevant customer-facing content to the front of the doc, particularly now we are surfacing DTB errors more prominently in VS.

This change adds the verbatim info bar text to the doc, so that searches can find it more easily.

The instructions for capturing binlogs were refined to be more targeted and succinct. Instructions for earlier versions of VS were collapsed in a summary/details region.

Outdated instructions for performance analysis have been rewritten to reference features in the structured log viewer.

More explanation is given about what DTBs are used for, and what conditions trigger them.

Newer GitHub markdown features were used.

A previous edit (ace1a0e17311a880826489830d31cc3fc3ecdafa) made a section on authoring DTB targets confusing, by modifying a table that it referenced so a referenced column no longer existed. The old table has been copied into that section to avoid confusion and improve clarity.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9594)