### PR TITLE
Fix exception due to duplicate keys

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DesignTimeBuilds/DesignTimeBuildLoggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DesignTimeBuilds/DesignTimeBuildLoggerProvider.cs
@@ -146,6 +146,7 @@ internal sealed class DesignTimeBuildLoggerProvider(ITelemetryService telemetryS
                 object[][] targetDurations = _targetRecordById.Values
                     .Where(static record => record.Elapsed > new TimeSpan(ticks: 5 * TimeSpan.TicksPerMillisecond))
                     .OrderByDescending(record => record.Elapsed)
+                    .Take(10)
                     .Select(record => new object[] { GetHashedTargetName(record), record.Elapsed.Milliseconds })
                     .ToArray();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DesignTimeBuilds/DesignTimeBuildLoggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DesignTimeBuilds/DesignTimeBuildLoggerProvider.cs
@@ -142,16 +142,18 @@ internal sealed class DesignTimeBuildLoggerProvider(ITelemetryService telemetryS
             void SendTelemetry()
             {
                 // Filter out very fast targets (to reduce the cost of ordering) then take the top ten by elapsed time.
-                var durationByTarget = _targetRecordById.Values
+                // Note that targets can run multiple times, so the same target may appear more than once in the results.
+                object[][] targetDurations = _targetRecordById.Values
                     .Where(static record => record.Elapsed > new TimeSpan(ticks: 5 * TimeSpan.TicksPerMillisecond))
                     .OrderByDescending(record => record.Elapsed)
-                    .ToDictionary(GetHashedTargetName, record => record.Elapsed.Milliseconds, StringComparers.TargetNames);
+                    .Select(record => new object[] { GetHashedTargetName(record), record.Elapsed.Milliseconds })
+                    .ToArray();
 
                 telemetryService.PostProperties(
                     TelemetryEventName.DesignTimeBuildComplete,
                     [
                         (TelemetryPropertyName.DesignTimeBuildComplete.Succeeded, _succeeded),
-                        (TelemetryPropertyName.DesignTimeBuildComplete.Targets, new ComplexPropertyValue(durationByTarget)),
+                        (TelemetryPropertyName.DesignTimeBuildComplete.Targets, new ComplexPropertyValue(targetDurations)),
                         (TelemetryPropertyName.DesignTimeBuildComplete.ErrorCount, _errorCount),
                         (TelemetryPropertyName.DesignTimeBuildComplete.ErrorTargets, _errorTargets),
                     ]);
@@ -179,11 +181,11 @@ internal sealed class DesignTimeBuildLoggerProvider(ITelemetryService telemetryS
         /// <remarks>
         /// If the target is shipped by Microsoft (or the user is internal), the target's name is returned unchanged.
         /// </remarks>
-        private string GetHashedTargetName(TargetRecord target)
+        private string GetHashedTargetName(TargetRecord record)
         {
             return ImmutableInterlocked.GetOrAdd(
                 ref s_hashByTargetName,
-                (target.TargetName, target.IsMicrosoft),
+                (record.TargetName, record.IsMicrosoft),
                 GetHashedTargetName,
                 telemetryService);
 


### PR DESCRIPTION
During DTBs, a target may run more than once. A previous change used the target name as a key in a dictionary, however in some cases this would throw and exception due to having duplicate dictionary keys.

This changes the form of the data to an array of arrays. It's potentially harder to write Kusto queries against, but preserves all the information within the data and avoids the exception.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9596)