### PR TITLE
Small fixes

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Packaging/ManagedProjectSystemPackage.cs
@@ -13,12 +13,12 @@ namespace Microsoft.VisualStudio.Packaging
     [PackageRegistration(AllowsBackgroundLoading = true, RegisterUsing = RegistrationMethod.Assembly, UseManagedResourcesOnly = true)]
     [ProvideProjectFactory(typeof(XprojProjectFactory), null, "#27", "xproj", "xproj", null)]
     [ProvideAutoLoad(ActivationContextGuid, PackageAutoLoadFlags.BackgroundLoad)]
-    [ProvideUIContextRule(ActivationContextGuid,
+    [ProvideUIContextRule(
+        contextGuid: ActivationContextGuid,
         name: "Load Managed Project Package",
         expression: "dotnetcore",
-        termNames: new[] { "dotnetcore" },
-        termValues: new[] { "SolutionHasProjectCapability:.NET & CPS" }
-        )]
+        termNames: ["dotnetcore"],
+        termValues: ["SolutionHasProjectCapability:.NET & CPS"])]
     [ProvideMenuResource("Menus.ctmenu", 5)]
     internal sealed class ManagedProjectSystemPackage : AsyncPackage
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSession.cs
@@ -3,7 +3,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
-using static Microsoft.VisualStudio.ProjectSystem.VS.HotReload.ProjectHotReloadSessionManager;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.VS.Build;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyAttachedCollectionSourceProvider.cs
@@ -17,13 +17,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
     [VisualStudio.Utilities.Order(Before = HierarchyItemsProviderNames.Contains)]
     internal sealed class FrameworkReferenceAssemblyAttachedCollectionSourceProvider : DependenciesAttachedCollectionSourceProviderBase
     {
-        private readonly IRelationProvider _relationProvider;
-
         [ImportingConstructor]
-        public FrameworkReferenceAssemblyAttachedCollectionSourceProvider(IRelationProvider relationProvider)
+        public FrameworkReferenceAssemblyAttachedCollectionSourceProvider()
             : base(Flags.FrameworkDependency)
         {
-            _relationProvider = relationProvider;
         }
 
         protected override bool TryCreateCollectionSource(
@@ -48,7 +45,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Tree.Dependencies.AttachedColl
 
                     var framework = new FrameworkReferenceIdentity(path, profile, name);
                     var item = new FrameworkReferenceItem(framework);
-                    if (AggregateContainsRelationCollection.TryCreate(item, _relationProvider, out AggregateContainsRelationCollection? collection))
+                    if (AggregateContainsRelationCollection.TryCreate(item, relationProvider, out AggregateContainsRelationCollection? collection))
                     {
                         containsCollectionSource = new AggregateRelationCollectionSource(hierarchyItem, collection);
                         return true;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -50,8 +50,6 @@
   <ItemGroup>
     <!-- Needed to break assembly conflict on StreamJsonRpc between microsoft.visualstudio.projectsystem.query and microsoft.visualstudio.languageservices -->
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
-    <!-- Pin MessagePack to a patched version with security vulnerable fix -->
-    <PackageReference Include="MessagePack" />
     <!-- Path property: PkgMicrosoft_CodeAnalysis_Common -->
     <!-- The path is needed so we can copy the runtime assembly into the NPM package. -->
     <PackageReference Include="Microsoft.CodeAnalysis.Common" GeneratePathProperty="true" />

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -580,7 +580,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public void ValidateSettings_WhenWorkingDirNotFound_Throws()
         {
             string executable = "bar.exe";
-            string workingDir = "c:\foo";
+            string workingDir = @"c:\foo";
             var debugger = GetDebugTargetsProvider();
             var profileName = "run";
 
@@ -610,7 +610,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
         public void ValidateSettings_WhenWorkingDirFound_DoesNotThrow()
         {
             string executable = "bar.exe";
-            string workingDir = "c:\foo";
+            string workingDir = @"c:\foo";
             var debugger = GetDebugTargetsProvider();
             var profileName = "run";
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManagerTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.ProjectSystem.Debug;
-using Microsoft.VisualStudio.ProjectSystem.VS.Build;
 using Microsoft.VisualStudio.Shell.Interop;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload


### PR DESCRIPTION
Addresses some build warnings and other IDE warnings seen while reading through code today.

- Remove duplicate package reference warning during builds
- Remove redundant using directive warnings during builds
- Remove an unused constructor parameter injected via MEF
- Fix invalid paths in test data, due to incorrect escaping

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9597)