### PR TITLE
Use new GetProjectDirectory method to reduce string allocations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="17.13.38047-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.12.12" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.13.3-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.12.2159" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.13.38055-preview.1" />
@@ -65,7 +65,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.12.19" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.12.19" />
-    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.13.38055-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.13.38299-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.13.0-preview-1-35408-014" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.13.17-preview1-ga15b669c04" />

--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>17.13.16-pre</CPSPackageVersion>
+    <CPSPackageVersion>17.13.42-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -240,7 +240,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
 
             // If no working directory specified in the profile, we default to output directory. If for some reason the output directory
             // is not specified, fall back to the project folder.
-            string projectFolderFullPath = Path.GetDirectoryName(_project.UnconfiguredProject.FullPath) ?? string.Empty;
+            string projectFolderFullPath = _project.UnconfiguredProject.GetProjectDirectory();
             string defaultWorkingDir = await ProjectAndExecutableLaunchHandlerHelpers.GetDefaultWorkingDirectoryAsync(configuredProject, projectFolderFullPath, _fileSystem);
 
             string? commandLineArgs = resolvedProfile.CommandLineArgs is null

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/DynamicItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/DynamicItemHandler.cs
@@ -64,7 +64,7 @@ internal class DynamicItemHandler(UnconfiguredProject project) : IWorkspaceUpdat
 
             if (!_paths.Contains(fullPath))
             {
-                string[]? folderNames = FileItemServices.GetLogicalFolderNames(Path.GetDirectoryName(project.FullPath), fullPath, metadata);
+                string[]? folderNames = FileItemServices.GetLogicalFolderNames(project.GetProjectDirectory(), fullPath, metadata);
 
                 logger.WriteLine("Adding dynamic file '{0}'", fullPath);
                 context.AddDynamicFile(fullPath, folderNames);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -41,7 +41,6 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     private readonly JoinableTaskCollection _joinableTaskCollection;
     private readonly JoinableTaskFactory _joinableTaskFactory;
     private readonly CancellationToken _unloadCancellationToken;
-    private readonly string _baseDirectory;
 
     /// <summary>Completes when the workspace has integrated build data.</summary>
     private readonly TaskCompletionSource _contextCreated = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -117,8 +116,6 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         _joinableTaskCollection = joinableTaskCollection;
         _joinableTaskFactory = joinableTaskFactory;
         _unloadCancellationToken = unloadCancellationToken;
-
-        _baseDirectory = Path.GetDirectoryName(_unconfiguredProject.FullPath);
 
         // We take ownership of the lifetime of the provided update handlers, and dispose them
         // when this workspace is disposed.
@@ -453,8 +450,10 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
                     IComparable version = GetConfiguredProjectVersion(update);
 
-                    BuildOptions added   = parser.Parse(projectChange.Difference.AddedItems,   _baseDirectory);
-                    BuildOptions removed = parser.Parse(projectChange.Difference.RemovedItems, _baseDirectory);
+                    string baseDirectory = _unconfiguredProject.GetProjectDirectory();
+
+                    BuildOptions added   = parser.Parse(projectChange.Difference.AddedItems,   baseDirectory);
+                    BuildOptions removed = parser.Parse(projectChange.Difference.RemovedItems, baseDirectory);
 
                     foreach (ICommandLineHandler commandLineHandler in _updateHandlers.CommandLineHandlers)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -560,7 +560,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
 
                 try
                 {
-                    FileWatcher = new SimpleFileWatcher(Path.GetDirectoryName(_commonProjectServices.Project.FullPath),
+                    FileWatcher = new SimpleFileWatcher(_commonProjectServices.Project.GetProjectDirectory(),
                                                         true,
                                                         NotifyFilters.FileName | NotifyFilters.Size | NotifyFilters.LastWrite,
                                                         LaunchSettingsFilename,
@@ -894,7 +894,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug
             // see: https://github.com/dotnet/project-system/issues/2316.
 
             // Default to the project directory if we're not able to get the AppDesigner folder.
-            string folder = Path.GetDirectoryName(_commonProjectServices.Project.FullPath);
+            string folder = _commonProjectServices.Project.GetProjectDirectory();
             
             if (_projectProperties.Value is not null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ProjectAndExecutableLaunchHandlerHelpers.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ProjectAndExecutableLaunchHandlerHelpers.cs
@@ -208,7 +208,7 @@ internal static class ProjectAndExecutableLaunchHandlerHelpers
         // If the working directory is relative, it will be relative to the project root so make it a full path
         if (!string.IsNullOrWhiteSpace(runWorkingDirectory) && !Path.IsPathRooted(runWorkingDirectory))
         {
-            runWorkingDirectory = Path.Combine(Path.GetDirectoryName(project.UnconfiguredProject.FullPath) ?? string.Empty, runWorkingDirectory);
+            runWorkingDirectory = Path.Combine(project.UnconfiguredProject.GetProjectDirectory(), runWorkingDirectory);
         }
 
         string runArguments = await properties.GetEvaluatedPropertyValueAsync("RunArguments");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationIconValueProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties.Package
                 try
                 {
                     propertyValue = Path.GetFileName(unevaluatedPropertyValue);
-                    var destinationInfo = new FileInfo(Path.Combine(Path.GetDirectoryName(_unconfiguredProject.FullPath), propertyValue));
+                    var destinationInfo = new FileInfo(Path.Combine(_unconfiguredProject.GetProjectDirectory(), propertyValue));
                     if (destinationInfo.Exists && destinationInfo.IsReadOnly)
                     {
                         // The file cannot be copied over; return the previous value.

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -211,7 +211,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Debug
             if (outdir is null || outdir == @"doesntExist\")
             {
                 Assert.Equal(@"c:\test\project\test.exe", targets[0].Executable);
-                Assert.Equal(@"c:\test\project", targets[0].CurrentDirectory);
+                Assert.Equal(@"c:\test\project\", targets[0].CurrentDirectory);
             }
             else
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
@@ -28,7 +28,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new CompileItemHandler(project);
-            var projectDir = Path.GetDirectoryName(project.FullPath);
+            var projectDir = project.GetProjectDirectory();
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
@@ -57,7 +57,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new CompileItemHandler(project);
-            var projectDir = Path.GetDirectoryName(project.FullPath);
+            var projectDir = project.GetProjectDirectory();
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler_CommandLineTests.cs
@@ -23,14 +23,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             void onSourceFileAdded(string s) => Assert.True(sourceFilesPushedToWorkspace.Add(s));
             void onSourceFileRemoved(string s) => sourceFilesPushedToWorkspace.Remove(s);
 
-            var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\Myproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\MyProject.csproj");
             var context = IWorkspaceProjectContextMockFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
             var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new CompileItemHandler(project);
             var projectDir = project.GetProjectDirectory();
-            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
-            var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
+            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: [@"C:\file1.cs", @"C:\file2.cs", @"C:\file1.cs"], baseDirectory: projectDir, sdkDirectory: null));
+            var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: [], baseDirectory: projectDir, sdkDirectory: null));
 
             handler.Handle(context, 10, added: added, removed: empty, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
@@ -38,7 +38,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             Assert.Contains(@"C:\file1.cs", sourceFilesPushedToWorkspace);
             Assert.Contains(@"C:\file2.cs", sourceFilesPushedToWorkspace);
 
-            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"C:\file1.cs", @"C:\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
+            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: [@"C:\file1.cs", @"C:\file1.cs"], baseDirectory: projectDir, sdkDirectory: null));
             handler.Handle(context, 10, added: empty, removed: removed, new ContextState(isActiveEditorContext: true, isActiveConfiguration: false), logger: logger);
 
             Assert.Single(sourceFilesPushedToWorkspace);
@@ -52,14 +52,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             void onSourceFileAdded(string s) => Assert.True(sourceFilesPushedToWorkspace.Add(s));
             void onSourceFileRemoved(string s) => sourceFilesPushedToWorkspace.Remove(s);
 
-            var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\ProjectFolder\Myproject.csproj");
+            var project = UnconfiguredProjectFactory.Create(fullPath: @"C:\ProjectFolder\MyProject.csproj");
             var context = IWorkspaceProjectContextMockFactory.CreateForSourceFiles(project, onSourceFileAdded, onSourceFileRemoved);
             var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new CompileItemHandler(project);
             var projectDir = project.GetProjectDirectory();
-            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"file1.cs", @"..\ProjectFolder\file1.cs" }, baseDirectory: projectDir, sdkDirectory: null));
-            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
+            var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: [@"file1.cs", @"..\ProjectFolder\file1.cs"], baseDirectory: projectDir, sdkDirectory: null));
+            var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: [], baseDirectory: projectDir, sdkDirectory: null));
 
             handler.Handle(context, 10, added: added, removed: removed, new ContextState(true, false), logger: logger);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/MetadataReferenceItemHandlerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new MetadataReferenceItemHandler(project);
-            var projectDir = Path.GetDirectoryName(project.FullPath);
+            var projectDir = project.GetProjectDirectory();
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:C:\Assembly1.dll", @"/reference:C:\Assembly2.dll", @"/reference:C:\Assembly1.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var empty = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 
@@ -48,7 +48,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices.Handlers
             var logger = Mock.Of<IManagedProjectDiagnosticOutputService>();
 
             var handler = new MetadataReferenceItemHandler(project);
-            var projectDir = Path.GetDirectoryName(project.FullPath);
+            var projectDir = project.GetProjectDirectory();
             var added = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new[] { @"/reference:Assembly1.dll", @"/reference:C:\ProjectFolder\Assembly2.dll", @"/reference:..\ProjectFolder\Assembly3.dll" }, baseDirectory: projectDir, sdkDirectory: null));
             var removed = BuildOptions.FromCommandLineArguments(CSharpCommandLineParser.Default.Parse(args: new string[] { }, baseDirectory: projectDir, sdkDirectory: null));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceTests.cs
@@ -294,7 +294,7 @@ public class WorkspaceTests
         workspaceProjectContextFactory.VerifyAll();
         workspaceProjectContext.VerifyAll();
         unconfiguredProjectServices.VerifyAll();
-        unconfiguredProject.VerifyAll();
+        unconfiguredProject.Verify();
 
         Assert.Same(workspaceProjectContext.Object, workspace.Context);
     }
@@ -754,7 +754,7 @@ public class WorkspaceTests
 
         workspaceProjectContextFactory.VerifyAll();
         unconfiguredProjectServices.VerifyAll();
-        unconfiguredProject.VerifyAll();
+        unconfiguredProject.Verify();
     }
 
     [Theory] // Configurations          Project GUID                               Expected
@@ -808,12 +808,12 @@ public class WorkspaceTests
         IProjectSubscriptionUpdate? buildRuleUpdate = null)
     {
         var commandLineParserService = new Mock<ICommandLineParserService>(MockBehavior.Strict);
-        commandLineParserService.Setup(o => o.Parse(It.IsAny<IEnumerable<string>>(), """C:\MyProject""")).Returns(EmptyBuildOptions);
+        commandLineParserService.Setup(o => o.Parse(It.IsAny<IEnumerable<string>>(), """C:\MyProject\""")).Returns(EmptyBuildOptions);
 
         slice ??= ProjectConfigurationSlice.Create(ImmutableStringDictionary<string>.EmptyOrdinal.Add("TargetFramework", "net6.0"));
         unconfiguredProject ??= UnconfiguredProjectFactory.ImplementFullPath("""C:\MyProject\MyProject.csproj""");
         projectGuid ??= Guid.NewGuid();
-        updateHandlers ??= new UpdateHandlers(Array.Empty<ExportFactory<IWorkspaceUpdateHandler>>());
+        updateHandlers ??= new UpdateHandlers([]);
         logger ??= IManagedProjectDiagnosticOutputServiceFactory.Create();
         activeWorkspaceProjectContextTracker ??= IActiveEditorContextTrackerFactory.Create();
         commandLineParserServices ??= new(ImportOrderPrecedenceComparer.PreferenceOrder.PreferredComesFirst) { commandLineParserService.Object };


### PR DESCRIPTION
Avoids calling `Path.GetDirectoryName` in a bunch of places, which will allocate a new string for each call. The new extension method in CPS provides a singleton string for the project.

Needs https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/595076 or newer to insert before being merged.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9603)