### PR TITLE
Fix NFE about version regression on configuration switch

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -337,7 +337,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
                 // for example from Debug to Release.
                 ConfiguredProject configuredProject = update.Value.ConfiguredProject;
 
-                IComparable version = GetConfiguredProjectVersion(update);
+                IComparable version = GetVersion(update);
 
                 foreach (IProjectEvaluationHandler evaluationHandler in _updateHandlers.EvaluationHandlers)
                 {
@@ -451,7 +451,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
                     Assumes.Present(parser);
 
-                    IComparable version = GetConfiguredProjectVersion(update);
+                    IComparable version = GetVersion(update);
 
                     BuildOptions added   = parser.Parse(projectChange.Difference.AddedItems,   _baseDirectory);
                     BuildOptions removed = parser.Parse(projectChange.Difference.RemovedItems, _baseDirectory);
@@ -544,9 +544,9 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         }
     }
 
-    private static IComparable GetConfiguredProjectVersion(IProjectValueVersions update)
+    private static IComparable GetVersion(IProjectValueVersions update)
     {
-        return update.DataSourceVersions[ProjectDataSources.ConfiguredProjectVersion];
+        return new CompositeVersion(update.DataSourceVersions);
     }
 
     public async Task WriteAsync(Func<IWorkspace, Task> action, CancellationToken cancellationToken)
@@ -598,6 +598,46 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
     {
         // Ensure we unblock any code waiting for initialization, and surface the error to the caller.
         _contextCreated.TrySetException(exception);
+    }
+
+    /// <summary>
+    /// Combines both the configured project version and the active configured project version
+    /// into a single comparable value. In this way, we can ensure we order updates correctly,
+    /// even when the active configuration changes.
+    /// </summary>
+    private sealed class CompositeVersion(IImmutableDictionary<NamedIdentity, IComparable> versions) : IComparable
+    {
+        private readonly IComparable _configuredProjectVersion = versions[ProjectDataSources.ConfiguredProjectVersion];
+        private readonly IComparable _activeConfigurationVersion = versions[ProjectDataSources.ActiveProjectConfiguration];
+
+        public int CompareTo(object obj)
+        {
+            if (obj is not CompositeVersion other)
+            {
+                throw new ArgumentException("Cannot compare to a non-CompositeVersion object.");
+            }
+
+            // The active configuration version will only increase. Every time the configuration
+            // changes, this value goes up.
+            //
+            // We check this *before* checking the configured project version, because when
+            // switching active configuration, the configured project version can go *down*.
+            // However, it's important for our processing of evaluation and build data that
+            // the version is monotonic (only increases).
+            //
+            // We achieve monotonicity by combining these two versions.
+            int c = _activeConfigurationVersion.CompareTo(other._activeConfigurationVersion);
+
+            if (c is not 0)
+            {
+                // Active configuration differs, so compare on this alone.
+                return c;
+            }
+
+            // Active configuration is identical. Compare the configured project versions
+            // for that configuration directly.
+            return _configuredProjectVersion.CompareTo(other._configuredProjectVersion);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1833278

In #8321, we optimised how we handle Roslyn projects in the language service during configuration switches, such as from Debug to Release.

Before that PR, we maintained different pipelines for each configuration. That PR re-uses the same pipeline between configurations, instead applying a delta representing the switch. This makes configuration switches a lot faster.

Project data flows through with version numbers, and each configuration tracks versions to ensure that evaluation and build data is applied with correct sequencing.

The previous PR introduced the chance for an unexpected regression in configured project version, which would lead to an exception that'd trigger a NFE and gold bar in VS.

> Attempted to push a project evaluation that regressed in version.

This is one of the top NFEs in the project system.

The fix here is to consider multiple versions in each update. We combine a version that increments when the active configuration changes along with the actual configured project version. Then, when comparing versions, we first compare the active configuration version, and only if they match would we then compare the configured project version. This gives us a monotonically increasing sequence of updates across both configuration switches and project changes, which will satisfy the consuming code and prevent the NFE.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9606)