### PR TITLE
Justin/test/xss

### DIFF
--- a/src/Common/ManagedCodeMarkers.vb
+++ b/src/Common/ManagedCodeMarkers.vb
@@ -1,4 +1,4 @@
-﻿' Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+﻿'Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 Imports System.Runtime.InteropServices
 

--- a/test/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPaletteExample.razor
+++ b/test/src/MudBlazor.Docs/Pages/Components/ColorPicker/Examples/ColorPickerPaletteExample.razor
@@ -1,0 +1,15 @@
+@namespace MudBlazor.Docs.Examples
+@using MudBlazor.Utilities
+<MudColorPicker PickerVariant="PickerVariant.Static" ColorPickerView="ColorPickerView.Palette" Palette="_customPalette" />
+@code {
+    private readonly IEnumerable<MudColor> _customPalette = new List<IEnumerable<MudColor>>
+    {
+        MudColor.GenerateTintShadePalette("#DC143C", shadeStep: 0),
+        MudColor.GenerateTintShadePalette("#1E90FF", tintStep: 0),
+        MudColor.GenerateTintShadePalette("#8E24AA"),
+        // Reverse for illustrative purposes
+        MudColor.GenerateTintShadePalette("#8E24AA").Reverse(),
+        MudColor.GenerateAnalogousPalette("#40E0D0"),
+        MudColor.GenerateGradientPalette("#1E90FF", "#32CD32"),
+    }.SelectMany(palette => palette);
+}


### PR DESCRIPTION
### Description

Follow-up PR for: [#10313](https://github.com/MudBlazor/MudBlazor/pull/10313)

This fixes an issue where setting numberOfColors = 1 in GenerateGradientPalette causes the following line:

`var t = i / (float)(numberOfColors - 1);`
to return NaN, resulting in the end color being white.

The fix adds a special case to handle the situation when numberOfColors = 1. An alternative approach would be to throw an exception when numberOfColors is less than two, but I believe this approach is better. If someone wants to create a multi-gradient palette, GenerateGradientPalette could be reused, and there could be scenarios where the number of colors per segment is equal to one, which would cause the same problem again.

How Has This Been Tested? How Has This Been Tested?
Unit tests, visually

### Type of Changes
 

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  Documentation (fix or improvement to the website or code docs)

### Checklist

- [ ]  The PR is submitted to the correct branch (dev).
- [ ]  My code follows the code style of this project.
- [ ]  I've added relevant tests.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9607)