### PR TITLE
Add PrunePackageReference support in project-system

### DIFF
--- a/docs/design-time-builds.md
+++ b/docs/design-time-builds.md
@@ -195,6 +195,7 @@ CollectFrameworkReferences                     | NuGet      | Returns non-transi
 CollectNuGetAuditSuppressions                  | NuGet      | Returns `NuGetAuditSuppress` items. Supports package restore.
 CollectPackageDownloads                        | NuGet      | Returns `PackageDownload` items. Supports package restore.
 CollectPackageReferences                       | NuGet      | Returns `PackageReference` items. Supports package restore.
+CollectPrunePackageReferences                  | NuGet      | Returns `PrunePackageReference` items. Supports package restore.
 CollectResolvedCompilationReferencesDesignTime | DNPS       |
 CollectResolvedSDKReferencesDesignTime         | SDK        |
 CollectSuggestedVisualStudioComponentIds       | DNPS       | Supports in-product acquisition (IPA).

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/VsTargetFrameworkInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/Snapshots/VsTargetFrameworkInfo.cs
@@ -33,6 +33,7 @@ internal class VsTargetFrameworkInfo(TargetFrameworkInfo targetFrameworkInfo) : 
                     new KeyValuePair<string, IReadOnlyList<IVsReferenceItem2>>("PackageReference", ToItems(targetFrameworkInfo.PackageReferences)),
                     new KeyValuePair<string, IReadOnlyList<IVsReferenceItem2>>("PackageVersion", ToItems(targetFrameworkInfo.CentralPackageVersions)),
                     new KeyValuePair<string, IReadOnlyList<IVsReferenceItem2>>("ProjectReference", ToItems(targetFrameworkInfo.ProjectReferences)),
+                    new KeyValuePair<string, IReadOnlyList<IVsReferenceItem2>>("PrunePackageReference", ToItems(targetFrameworkInfo.PrunePackageReferences)),
                 ]);
             return _items;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -377,6 +377,18 @@
       <RuleInjection>None</RuleInjection>
     </XamlPropertyRule>
 
+    <Compile Update="ProjectSystem\Rules\CollectedPrunePackageReference.cs">
+      <DependentUpon>CollectedPrunePackageReference.xaml</DependentUpon>
+    </Compile>
+    <XamlPropertyRule Include="ProjectSystem\Rules\CollectedPrunePackageReference.xaml">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <XlfInput>false</XlfInput>
+      <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
+      <SubType>Designer</SubType>
+      <DataAccess>None</DataAccess>
+      <RuleInjection>None</RuleInjection>
+    </XamlPropertyRule>
+  
     <Compile Update="ProjectSystem\Rules\CollectedPackageDownload.cs">
       <DependentUpon>CollectedPackageDownload.xaml</DependentUpon>
     </Compile>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -427,6 +427,12 @@
        This can (and should) be removed when we no longer need to support SDKs older than 8.0.400. -->
   <Target Name="CollectNuGetAuditSuppressions" Returns="@(NuGetAuditSuppress)" />
 
+  <!-- This target is used to collect the PrunePackageReference items. It is defined by the .NET SDK starting in version 9.0.200, but we need this no-op
+       implementation when using older SDKs that don't have it; otherwise our design-time builds will fail. The NuGet.targets file in the SDK is imported
+       _after_ this file, and will override this implementation with the real one (when present).
+       This can (and should) be removed when we no longer need to support SDKs older than 9.0.200. -->
+  <Target Name="CollectPrunePackageReferences" Returns="@(PrunePackageReference)">
+
   <!-- Collect any VS setup component IDs that should be installed for this project to work correctly in VS. -->
   <Target Name="CollectSuggestedVisualStudioComponentIds"
           Returns="@(SuggestedVisualStudioComponentId)"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreConfiguredInputDataSource.cs
@@ -17,6 +17,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
         CollectedPackageDownload.SchemaName,
         CollectedPackageVersion.SchemaName,
         CollectedNuGetAuditSuppressions.SchemaName,
+        CollectedPrunePackageReference.SchemaName,
         CollectedPackageReference.SchemaName])]
     internal class PackageRestoreConfiguredInputDataSource : ChainedProjectValueDataSourceBase<PackageRestoreConfiguredInput>, IPackageRestoreConfiguredInputDataSource
     {
@@ -28,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             .Add(CollectedPackageDownload.SchemaName)           // Build
             .Add(CollectedPackageVersion.SchemaName)            // Build
             .Add(CollectedNuGetAuditSuppressions.SchemaName)    // Build
+            .Add(CollectedPrunePackageReference.SchemaName)     // Build
             .Add(CollectedPackageReference.SchemaName);         // Build
 
         private readonly IProjectSubscriptionService _projectSubscriptionService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             IProjectRuleSnapshot packageReferences = update.GetSnapshotOrEmpty(CollectedPackageReference.SchemaName);
             IProjectRuleSnapshot packageVersions = update.GetSnapshotOrEmpty(CollectedPackageVersion.SchemaName);
             IProjectRuleSnapshot nuGetAuditSuppress = update.GetSnapshotOrEmpty(CollectedNuGetAuditSuppressions.SchemaName);
+            IProjectRuleSnapshot prunePackageReferences = update.GetSnapshotOrEmpty(CollectedPrunePackageReference.SchemaName);
             IProjectRuleSnapshot toolReferences = update.GetSnapshotOrEmpty(DotNetCliToolReference.SchemaName);
 
             // For certain project types such as UWP, "TargetFrameworkMoniker" != the moniker that restore uses
@@ -39,6 +40,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
                 ToReferenceItems(packageReferences.Items),
                 ToReferenceItems(packageVersions.Items),
                 ToReferenceItems(nuGetAuditSuppress.Items),
+                ToReferenceItems(prunePackageReferences.Items),
                 properties);
 
             return new ProjectRestoreInfo(

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreLogger.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreLogger.cs
@@ -61,6 +61,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             LogReferenceItems(logger, "Project References", targetFrameworkInfo.ProjectReferences);
             LogReferenceItems(logger, "Package References", targetFrameworkInfo.PackageReferences);
             LogReferenceItems(logger, "NuGet Audit Suppressions", targetFrameworkInfo.NuGetAuditSuppress);
+            LogReferenceItems(logger, "Prune Package References", targetFrameworkInfo.PrunePackageReferences);
 
             // CPM typically adds a lot of items, normally the same set for all projects in the solution, and for individual projects
             // many of the items aren't referenced by the project. While this is diagnostic logging, PackageVersions are particularly

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/TargetFrameworkInfo.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/TargetFrameworkInfo.cs
@@ -19,6 +19,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             ImmutableArray<ReferenceItem> packageReferences,
             ImmutableArray<ReferenceItem> centralPackageVersions,
             ImmutableArray<ReferenceItem> nuGetAuditSuppress,
+            ImmutableArray<ReferenceItem> prunePackageReferences,
             IImmutableDictionary<string, string> properties)
         {
             TargetFrameworkMoniker = targetFrameworkMoniker;
@@ -28,6 +29,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
             PackageReferences = packageReferences;
             CentralPackageVersions = centralPackageVersions;
             NuGetAuditSuppress = nuGetAuditSuppress;
+            PrunePackageReferences = prunePackageReferences;
             Properties = properties;
         }
 
@@ -44,6 +46,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore
         public ImmutableArray<ReferenceItem> CentralPackageVersions { get; }
 
         public ImmutableArray<ReferenceItem> NuGetAuditSuppress { get; }
+
+        public ImmutableArray<ReferenceItem> PrunePackageReferences { get; }
 
         public IImmutableDictionary<string, string> Properties { get; }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPrunePackageReference.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPrunePackageReference.cs
@@ -1,0 +1,12 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.ProjectSystem
+{
+    [ExcludeFromCodeCoverage]
+    [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
+    internal partial class CollectedPrunePackageReference
+    {
+    }
+}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPrunePackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPrunePackageReference.xaml
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information. -->
+<Rule Name="CollectedPrunePackageReference"
+      PageTemplate="generic"
+      xmlns="http://schemas.microsoft.com/build/2009/properties">
+
+  <!-- Represents the set of <PrunePackageReference /> items that are gathered during a design-time build to be pushed to Solution Restore service -->
+
+  <Rule.DataSource>
+    <DataSource HasConfigurationCondition="False"
+                ItemType="PrunePackageReference"
+                MSBuildTarget="CollectPrunePackageReferences"
+                Persistence="ProjectFile"
+                SourceOfDefaultValue="AfterContext"
+                SourceType="TargetResults" />
+  </Rule.DataSource>
+
+
+  <StringProperty Name="Version"
+                  Visible="false" />
+
+</Rule>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPrunePackageReference.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/CollectedPrunePackageReference.xaml
@@ -15,7 +15,6 @@
                 SourceType="TargetResults" />
   </Rule.DataSource>
 
-
   <StringProperty Name="Version"
                   Visible="false" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/NuGetRestore.xaml
@@ -101,6 +101,10 @@
                   ReadOnly="True"
                   Visible="False" />
 
+  <StringProperty Name="RestoreEnablePackagePruning"
+                  ReadOnly="True"
+                  Visible="False" />
+
   <StringProperty Name="RestoreFallbackFolders"
                   ReadOnly="True"
                   Visible="False" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/RuleExporter.cs
@@ -167,6 +167,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.Rules
             public static int CollectedNuGetAuditSuppressionsRule;
 
             /// <summary>
+            ///     Represents the design-time build items containing the versions of packages to be pruned that are passed to restore.
+            /// </summary>
+            [ExportRule(nameof(CollectedPrunePackageReference), PropertyPageContexts.ProjectSubscriptionService)]
+            [AppliesTo(ProjectCapability.PackageReferences)]
+            [Order(Order.Default)]
+            public static int CollectedPrunePackageReferencesRule;
+
+            /// <summary>
             ///     Represents the evaluation properties that are passed that are passed to restore.
             /// </summary>
             [ExportRule(nameof(NuGetRestore), PropertyPageContexts.ProjectSubscriptionService)]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/Snapshots/RestoreBuilderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/PackageRestore/Snapshots/RestoreBuilderTests.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System;
-
 namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore;
 
 public class RestoreBuilderTests


### PR DESCRIPTION
Design at https://github.com/NuGet/Home/blob/dev/accepted/2024/prune-package-reference.md. 

This adds support for `PrunePackageReference` with a `Version` attribute and the `RestoreEnablePackagePruning` property. 

I know in the past we've had to do certain things to get CDK working. cc @tmeschter 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9610)