### PR TITLE
Fix "collection modified" exception

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBars/VsInfoBarService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UI/InfoBars/VsInfoBarService.cs
@@ -47,7 +47,10 @@ internal sealed class VsInfoBarService : IInfoBarService
         {
             lock (s_entries)
             {
-                foreach (InfoBar entry in s_entries)
+                // Copy the list to avoid "collection modified during enumeration" exceptions,
+                // as when the last project associated with an info bar is closed, we will
+                // remove that entry from the list.
+                foreach (InfoBar entry in s_entries.ToList())
                 {
                     entry.OnProjectClosed(_project);
                 }


### PR DESCRIPTION
When signalling project close to an info bar entry, if there are no other remaining projects associated with that info bar, it will be removed from the collection. That triggers an exception.

The fix is to make a defensive copy before enumerating, so that the original can be safely modified while the copy is enumerated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9620)