### PR TITLE
Expose ContextAndRuleProviderState, IProjectState, and QueryProjectPropertiesContext to Support JSPS Launch Profiles UI

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ContextAndRuleProviderState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ContextAndRuleProviderState.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 /// to pass the state their child producers will need, but allows the actual binding
 /// of the <see cref="Rule"/> to be delayed until needed.
 /// </summary>
-internal sealed class ContextAndRuleProviderState
+public sealed class ContextAndRuleProviderState
 {
     public ContextAndRuleProviderState(IProjectState projectState, QueryProjectPropertiesContext propertiesContext, Rule rule)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IProjectState.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/IProjectState.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 /// significantly reduce the amount of work we need to do.
 /// </para>
 /// </remarks>
-internal interface IProjectState
+public interface IProjectState
 {
     /// <summary>
     /// Binds the specified schema to a particular context within the given project configuration.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/QueryProjectPropertiesContext.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 /// manner that can be passed from one provider to another and is also suitable as a
 /// key into a cache (such as the <see cref="IProjectState"/>).
 /// </remarks>
-internal sealed class QueryProjectPropertiesContext : IProjectPropertiesContext, IEquatable<QueryProjectPropertiesContext>
+public sealed class QueryProjectPropertiesContext : IProjectPropertiesContext, IEquatable<QueryProjectPropertiesContext>
 {
     /// <summary>
     /// A well-known context representing the project file as a whole.
@@ -84,7 +84,7 @@ internal sealed class QueryProjectPropertiesContext : IProjectPropertiesContext,
     /// Creates a <see cref="QueryProjectPropertiesContext"/> from a Project Query API
     /// <see cref="EntityIdentity"/>.
     /// </summary>
-    public static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? propertiesContext)
+    internal static bool TryCreateFromEntityId(EntityIdentity id, [NotNullWhen(true)] out QueryProjectPropertiesContext? propertiesContext)
     {
         if (id.TryGetValue(ProjectModelIdentityKeys.ProjectPath, out string? projectPath))
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/PublicAPI.Unshipped.txt
@@ -1,0 +1,22 @@
+Microsoft.VisualStudio.ProjectSystem.VS.Query.ContextAndRuleProviderState
+Microsoft.VisualStudio.ProjectSystem.VS.Query.ContextAndRuleProviderState.ContextAndRuleProviderState(Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState! projectState, Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext! propertiesContext, Microsoft.Build.Framework.XamlTypes.Rule! rule) -> void
+Microsoft.VisualStudio.ProjectSystem.VS.Query.ContextAndRuleProviderState.ProjectState.get -> Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.ContextAndRuleProviderState.PropertiesContext.get -> Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.ContextAndRuleProviderState.Rule.get -> Microsoft.Build.Framework.XamlTypes.Rule!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState
+Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState.BindToRuleAsync(Microsoft.VisualStudio.ProjectSystem.ProjectConfiguration! projectConfiguration, string! schemaName, Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext! propertiesContext) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.ProjectSystem.Properties.IRule?>!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState.GetDataVersionAsync(Microsoft.VisualStudio.ProjectSystem.ProjectConfiguration! configuration) -> System.Threading.Tasks.Task<(string! versionKey, long versionNumber)?>!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState.GetKnownConfigurationsAsync() -> System.Threading.Tasks.Task<System.Collections.Immutable.IImmutableSet<Microsoft.VisualStudio.ProjectSystem.ProjectConfiguration!>?>!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState.GetMetadataVersionAsync() -> System.Threading.Tasks.Task<(string! versionKey, long versionNumber)?>!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.IProjectState.GetSuggestedConfigurationAsync() -> System.Threading.Tasks.Task<Microsoft.VisualStudio.ProjectSystem.ProjectConfiguration?>!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.Equals(Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext? other) -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.File.get -> string!
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.IsProjectFile.get -> bool
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.ItemName.get -> string?
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.ItemType.get -> string?
+Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.QueryProjectPropertiesContext(bool isProjectFile, string! file, string? itemType, string? itemName) -> void
+override Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.Equals(object! obj) -> bool
+override Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.GetHashCode() -> int
+static Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.TryCreateFromEntityId(Microsoft.VisualStudio.ProjectSystem.Query.EntityIdentity! id, out Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext? propertiesContext) -> bool
+static readonly Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext.ProjectFile -> Microsoft.VisualStudio.ProjectSystem.VS.Query.QueryProjectPropertiesContext!


### PR DESCRIPTION
The TS/JS team would like to add a version of the launch profiles UI for JSPS projects that reads/writes from` launch.json `rather than `launchsettings.json`. By making `ContextAndRuleProviderState`, `IProjectState`, and `QueryProjectPropertiesContext  `public, we can reuse several of the QueryDataProviders dotnet has already implemented to populate the launch profiles UI.

For example, the [UIPropertyFromRuleDataProducer](src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyFromRuleDataProducer.cs) class is expecting context of the type `ContextAndRuleProviderState`, and I would like this class to populate UI properties for the JSPS scenario as well.

I have already confirmed that these changes will allow the launch.json UI to work properly:
![Screenshot 2024-12-11 152811](https://github.com/user-attachments/assets/4959f070-b3a1-4c50-9fff-053532f4ff83)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9621)