### PR TITLE
Avoid extra JTF collection/factory

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -91,7 +91,10 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
                 return !await vsShell.IsCommandLineModeAsync()
                     || await vsShell.IsPopulateSolutionCacheModeAsync();
             },
-            threadingService.JoinableTaskFactory);
+            threadingService.JoinableTaskFactory)
+        {
+            SuppressRecursiveFactoryDetection = true
+        };
     }
 
     public Task LoadAsync()


### PR DESCRIPTION
`LanguageServiceHost` uses its own JTF collection and factory to track its work.

This class derives from `OnceInitializedOnceDisposedAsync`, which also has its own collection and factory.

@lifengl recently noticed this while investigating a hang and suggested that we reuse the base class's objects to reduce allocations and potentially even help avoid deadlocks.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9623)