### PR TITLE
Set AsyncLazy.SuppressRecursiveFactoryDetection to true

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/LanguageServiceErrorListProvider.cs
@@ -36,7 +36,10 @@ internal partial class LanguageServiceErrorListProvider : IVsErrorListProvider
 
         _isLspPullDiagnosticsEnabled = new AsyncLazy<bool>(
             async () => await projectSystemOptions.IsLspPullDiagnosticsEnabledAsync(CancellationToken.None),
-            joinableTaskContext.Factory);
+            joinableTaskContext.Factory)
+        {
+            SuppressRecursiveFactoryDetection = true
+        };
     }
 
     public void SuspendRefresh()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishItemsOutputGroupProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishItemsOutputGroupProvider.cs
@@ -34,7 +34,10 @@ internal class PublishItemsOutputGroupProvider : IOutputGroupProvider
     {
         _outputGroups = new AsyncLazy<IImmutableSet<IOutputGroup>>(
             GetOutputGroupMetadataAsync,
-            projectThreadingService.JoinableTaskFactory);
+            projectThreadingService.JoinableTaskFactory)
+        {
+            SuppressRecursiveFactoryDetection = true
+        };
 
         async Task<IImmutableSet<IOutputGroup>> GetOutputGroupMetadataAsync()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugProfileEnumValuesGenerator.cs
@@ -19,21 +19,21 @@ internal class DebugProfileEnumValuesGenerator : IDynamicEnumValuesGenerator
         ILaunchSettingsProvider profileProvider,
         IProjectThreadingService threadingService)
     {
-        Requires.NotNull(profileProvider);
-        Requires.NotNull(threadingService);
-
         _listedValues = new AsyncLazy<ICollection<IEnumValue>>(
             () =>
             {
                 ILaunchSettings? snapshot = profileProvider.CurrentSnapshot;
 
                 ICollection<IEnumValue> values = snapshot is null
-                    ? Array.Empty<IEnumValue>()
+                    ? []
                     : GetEnumeratorEnumValues(snapshot);
 
                 return Task.FromResult(values);
             },
-            threadingService.JoinableTaskFactory);
+            threadingService.JoinableTaskFactory)
+        {
+            SuppressRecursiveFactoryDetection = true
+        };
     }
 
     public Task<ICollection<IEnumValue>> GetListedValuesAsync()


### PR DESCRIPTION
This avoids the overhead associated with the type's re-entrancy prevention in cases where we the code cannot call itself.

See https://github.com/microsoft/vs-threading/pull/1265 for more information.

@lifengl proposed this improvement as part of #9623. One occurrence is addressed in that PR. Others are here in this PR.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9624)