### PR TITLE
Fixed serialization of the HighDpiMode value

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
+++ b/src/Microsoft.VisualStudio.Editors/MyApplication/MyApplicationDataSerializer.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.VisualStudio.Editors.MyApplication
             WriteElementString("SplashScreen", "", o.SplashScreenNoRootNS)
             WriteElementStringRaw("MinimumSplashScreenDisplayTime", "", Xml.XmlConvert.ToString(CType(o.MinimumSplashScreenDisplayTime, Integer)))
             WriteElementStringRaw("SaveMySettingsOnExit", "", Xml.XmlConvert.ToString(CType(o.SaveMySettingsOnExit, Boolean)))
-            WriteElementStringRaw("HighDpiMode", "", Xml.XmlConvert.ToString(CType(o.HighDpiMode, Boolean)))
+            WriteElementStringRaw("HighDpiMode", "", Xml.XmlConvert.ToString(CType(o.HighDpiMode, Integer)))
             WriteEndElement(o)
         End Sub 'Write2_MyApplicationData
 


### PR DESCRIPTION
Fixes [ADO#2300157](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2300157)

### Context
@drewnoakes fixed a typo in the name of the element used for HighDpiMode serialization, so the deserializer now picks up that value. However, there is a type mismatch. The value is serialized as a boolean, but the deserializer converts it to an Int32. The exception thrown by this failed conversion causes problems when editing VB WinForms project properties in Visual Studio.

### Fix
The value is now serialized as Int32.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9629)