### PR TITLE
Adding AppliesTo attribute to query providers

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchProfileActionProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 [QueryActionProvider(ProjectModelActionNames.SetLaunchProfilePropertyValue, typeof(SetLaunchProfilePropertyValue))]
 [QueryDataProviderZone(ProjectModelZones.Cps)]
 [Export(typeof(IQueryActionProvider))]
+[AppliesTo(ProjectCapability.DotNet)]
 internal sealed class LaunchProfileActionProvider : IQueryActionProvider
 {
     public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
@@ -26,6 +26,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 [QueryActionProvider(ProjectModelActionNames.DuplicateLaunchProfile, typeof(DuplicateLaunchProfile))]
 [QueryDataProviderZone(ProjectModelZones.Cps)]
 [Export(typeof(IQueryActionProvider))]
+[AppliesTo(ProjectCapability.DotNet)]
 internal sealed class ProjectActionProvider : IQueryActionProvider
 {
     public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)


### PR DESCRIPTION
The project team is working on supporting multiple query providers for different project systems. The JavaScript project team aims to add launch profiles action providers. Currently, the issue is that the .NET provider takes precedence, preventing their provider from being invoked. The AppliesTo attribute will be used to select the appropriate provider based on capability. At present, we are not reading this attribute on the query side, so it will not have any impact.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9631)