### PR TITLE
Disable DTB error info bars for now

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DesignTimeBuilds/DesignTimeBuildLoggerProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DesignTimeBuilds/DesignTimeBuildLoggerProvider.cs
@@ -3,7 +3,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Framework;
-using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.ProjectSystem.Build;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Microsoft.VisualStudio.ProjectSystem.VS.UI.InfoBars;
@@ -183,6 +182,14 @@ internal sealed class DesignTimeBuildLoggerProvider(ITelemetryService telemetryS
 
             void ReportBuildErrors()
             {
+                // Disabled for now, as we have too many false positives. Will revisit.
+
+                // (These lines prevent compile warnings.)
+                _ = projectFaultHandlerService;
+                _ = infoBarService;
+                _ = project;
+
+                /*
                 if (_succeeded is not false)
                 {
                     // Only report a failure if the build failed. Specific targets can have
@@ -197,6 +204,7 @@ internal sealed class DesignTimeBuildLoggerProvider(ITelemetryService telemetryS
                         KnownMonikers.StatusError,
                         CancellationToken.None),
                     project.UnconfiguredProject);
+                */
             }
         }
 


### PR DESCRIPTION
We see these errors popping up during regular operations such as branch switches. I'd hoped that they would present themselves as cancellations, however we don't see ` BuildCanceledEventArgs` in our logger. These are advertised as real failures. There's nothing the user can do about these, so it's not helpful to tell the user about them.

I hope to revisit this in 17.14 to see if there's still a way to provide helpful warnings when actionable errors occur, without any noise from internal and unactionable errors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9633)