### PR TITLE
Use .NET 8 for OneLocBuildSetup

### DIFF
--- a/eng/pipelines/templates/generate-localization.yml
+++ b/eng/pipelines/templates/generate-localization.yml
@@ -19,6 +19,14 @@ jobs:
     displayName: === Generate Localization ===
     condition: false
 
+  # Ensure the .NET runtime needed by OneLocBuildSetup is installed.
+  - task: UseDotNet@2
+    displayName: Install .NET Runtime
+    inputs:
+      packageType: runtime
+      # This should match the target in OneLocBuildSetup.csproj.
+      version: 8.0.x
+
   # Creates the LocProject.json and perform some necessary file copying and renaming.
   - task: DotNetCoreCLI@2
     displayName: Run Setup

--- a/eng/tools/OneLocBuildSetup/OneLocBuildSetup.csproj
+++ b/eng/tools/OneLocBuildSetup/OneLocBuildSetup.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <!-- This value must match that in generate-localization.yml, for the UseDotNet task. -->
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes build failures during the localization stage on the insertion PR pipeline.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9638)