### PR TITLE
Fixing a comment and moving one line of code

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Build/BuildUtilities.cs
@@ -110,7 +110,7 @@ internal static class BuildUtilities
     }
 
     /// <summary>
-    /// Renames a value inside a delimited property.
+    /// Removes a value inside a delimited property.
     /// </summary>
     /// <param name="project">Xml representation of the MsBuild project.</param>
     /// <param name="evaluatedPropertyValue">Original evaluated value of the property.</param>
@@ -126,7 +126,6 @@ internal static class BuildUtilities
         Requires.NotNull(evaluatedPropertyValue);
         Requires.NotNullOrEmpty(propertyName);
 
-        ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
         var newValue = new StringBuilder();
         bool valueFound = false;
         foreach (string value in GetPropertyValues(evaluatedPropertyValue))
@@ -146,6 +145,7 @@ internal static class BuildUtilities
             }
         }
 
+        ProjectPropertyElement property = GetOrAddProperty(project, propertyName);
         property.Value = newValue.ToString();
 
         if (!valueFound)


### PR DESCRIPTION
The comment for `RemovePropertyValue` incorrectly states that the value is renamed.

Further `property` is declared way before it is used.  Moved the declaration closer to its first usage.

Ran build.cmd.  Build passed with flying colors.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9643)