### PR TITLE
Fix 'SetEvaluatedUIPropertyValue' is not supported Exception in JSPS

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileProjectActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileProjectActionProvider.cs
@@ -18,11 +18,14 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 /// </para>
 /// </summary>
 [QueryDataProvider(ProjectSystem.Query.Metadata.ProjectType.TypeName, ProjectModel.ModelName)]
-[QueryActionProvider(ProjectModelActionNames.SetEvaluatedUIPropertyValue, typeof(SetEvaluatedUIPropertyValue))]
-[QueryActionProvider(ProjectModelActionNames.SetUnevaluatedUIPropertyValue, typeof(SetUnevaluatedUIPropertyValue))]
+[QueryActionProvider(ProjectModelActionNames.AddLaunchProfile, typeof(AddLaunchProfile))]
+[QueryActionProvider(ProjectModelActionNames.RemoveLaunchProfile, typeof(RemoveLaunchProfile))]
+[QueryActionProvider(ProjectModelActionNames.RenameLaunchProfile, typeof(RenameLaunchProfile))]
+[QueryActionProvider(ProjectModelActionNames.DuplicateLaunchProfile, typeof(DuplicateLaunchProfile))]
 [QueryDataProviderZone(ProjectModelZones.Cps)]
 [Export(typeof(IQueryActionProvider))]
-internal sealed class ProjectActionProvider : IQueryActionProvider
+[AppliesTo(ProjectCapability.DotNet)]
+internal sealed class LaunchProfileProjectActionProvider : IQueryActionProvider
 {
     public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)
     {
@@ -30,10 +33,12 @@ internal sealed class ProjectActionProvider : IQueryActionProvider
 
         return executableStep.Action switch
         {
-            ProjectModelActionNames.SetEvaluatedUIPropertyValue => new ProjectSetEvaluatedUIPropertyValueAction((SetEvaluatedUIPropertyValue)executableStep),
-            ProjectModelActionNames.SetUnevaluatedUIPropertyValue => new ProjectSetUnevaluatedUIPropertyValueAction((SetUnevaluatedUIPropertyValue)executableStep),
+            ProjectModelActionNames.AddLaunchProfile => new AddLaunchProfileAction((AddLaunchProfile)executableStep),
+            ProjectModelActionNames.RemoveLaunchProfile => new RemoveLaunchProfileAction((RemoveLaunchProfile)executableStep),
+            ProjectModelActionNames.RenameLaunchProfile => new RenameLaunchProfileAction((RenameLaunchProfile)executableStep),
+            ProjectModelActionNames.DuplicateLaunchProfile => new DuplicateLaunchProfileAction((DuplicateLaunchProfile)executableStep),
 
-            _ => throw new InvalidOperationException($"{nameof(ProjectActionProvider)} does not handle action '{executableStep.Action}'.")
+            _ => throw new InvalidOperationException($"{nameof(LaunchProfileProjectActionProvider)} does not handle action '{executableStep.Action}'.")
         };
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
@@ -21,8 +21,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 [QueryActionProvider(ProjectModelActionNames.SetEvaluatedUIPropertyValue, typeof(SetEvaluatedUIPropertyValue))]
 [QueryActionProvider(ProjectModelActionNames.SetUnevaluatedUIPropertyValue, typeof(SetUnevaluatedUIPropertyValue))]
 [QueryDataProviderZone(ProjectModelZones.Cps)]
-[AppliesTo(ProjectCapabilities.AlwaysApplicable)]
 [Export(typeof(IQueryActionProvider))]
+[AppliesTo(ProjectCapabilities.AlwaysApplicable)]
 internal sealed class ProjectActionProvider : IQueryActionProvider
 {
     public IQueryActionExecutor CreateQueryActionDataTransformer(ExecutableStep executableStep)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/ProjectActionProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 [QueryActionProvider(ProjectModelActionNames.SetEvaluatedUIPropertyValue, typeof(SetEvaluatedUIPropertyValue))]
 [QueryActionProvider(ProjectModelActionNames.SetUnevaluatedUIPropertyValue, typeof(SetUnevaluatedUIPropertyValue))]
 [QueryDataProviderZone(ProjectModelZones.Cps)]
+[AppliesTo(ProjectCapabilities.AlwaysApplicable)]
 [Export(typeof(IQueryActionProvider))]
 internal sealed class ProjectActionProvider : IQueryActionProvider
 {


### PR DESCRIPTION
Adding an` [AppliesTo] `filter to `ProjectActionProvider ` in [this](https://github.com/dotnet/project-system/commit/3ea13d2998039c8673209497edde8df411a9a182) PR broke the functionality of updating project properties for JSPS. JavaScript projects are relying on dotnet's properties provider for this. Removing the `[AppliesTo] ` attribute fixes this problem.