### PR TITLE
Remove global.json

### DIFF
--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -46,9 +46,9 @@
 
     <!-- https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#options -->
     <!-- The 'force' flag overrides the existing .sln file if one already exists. -->
-    <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" />
+    <Exec Command="dotnet new sln -n $(MSBuildProjectName) --force" WorkingDirectory="$(ArtifactsDir)" />
     <!-- https://stackoverflow.com/a/3012224/294804 -->
-    <Exec Command="dotnet sln &quot;$(ArtifactsDir)$(MSBuildProjectName).sln&quot; add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ') --solution-folder=&quot;$(ArtifactsDir)&quot;" />
+    <Exec Command="dotnet sln $(MSBuildProjectName).sln add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ') --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />
   </Target>
 

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -71,7 +71,7 @@
     <Message Importance="normal" Text="Relative path: %(BuildProjectWithRel.RelPath)" />
 
     <!-- Add each BuildProject to the solution. -->
-    <Exec Command="dotnet sln &quot;$(ArtifactsDirRelative)/$(MSBuildProjectName).sln&quot; add &quot;%(BuildProjectWithRel.RelPath)&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(DriveRootPath)" />
+    <Exec Command="dotnet sln &quot;$(ArtifactsDirRelative)/$(MSBuildProjectName).sln&quot; add &quot;%(BuildProjectWithRel.RelPath)&quot;" WorkingDirectory="$(DriveRootPath)" />
 
     <!-- Build the solution. -->
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -44,11 +44,17 @@
     <Message Text="Including 'Setup' projects..." Importance="high" Condition="'$(SetupProjects)' == 'true'" />
     <Message Text="Configuration: $(Configuration)" Importance="high" />
 
+    <!-- Create a solution file for the projects to be built. -->
+
     <!-- https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#options -->
-    <!-- The 'force' flag overrides the existing .sln file if one already exists. -->
-    <Exec Command="dotnet new sln -n $(MSBuildProjectName) --force" WorkingDirectory="$(ArtifactsDir)" />
-    <!-- https://stackoverflow.com/a/3012224/294804 -->
-    <Exec Command="dotnet sln $(MSBuildProjectName).sln add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ') --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
+
+    <!-- Create the solution. Use 'force' to override existing. -->
+    <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(ArtifactsDir)" />
+
+    <!-- Add each BuildProject to the solution. -->
+    <Exec Command="dotnet sln $(MSBuildProjectName).sln add &quot;%(BuildProject.FullPath)&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
+
+    <!-- Build the solution. -->
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />
   </Target>
 

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -48,7 +48,7 @@
     <!-- The 'force' flag overrides the existing .sln file if one already exists. -->
     <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" />
     <!-- https://stackoverflow.com/a/3012224/294804 -->
-    <Exec Command="dotnet sln $(ArtifactsDir)$(MSBuildProjectName).sln add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ')" />
+    <Exec Command="dotnet sln $(ArtifactsDir)$(MSBuildProjectName).sln add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ') --solution-folder $(ArtifactsDir)" />
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />
   </Target>
 

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -53,8 +53,16 @@
     <!-- Create the solution. Use 'force' to override existing. -->
     <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(ArtifactsDir)" />
 
+    <Exec
+      Command="powershell -NoProfile -Command &quot;Write-Output ((Resolve-Path -Relative '%(BuildProject.FullPath)'))&quot;"
+      WorkingDirectory="$(ArtifactsDir)">
+      <Output TaskParameter="ConsoleOutput" ItemName="RelativeBuildProjectPath" />
+    </Exec>
+
+    <Message Importance="normal" Text="Relative paths: @(RelativeBuildProjectPath)" />
+
     <!-- Add each BuildProject to the solution. -->
-    <Exec Command="dotnet sln $(MSBuildProjectName).sln add &quot;$([System.IO.Path]::GetRelativePath('$(ArtifactsDir)', '%(BuildProject.FullPath)'))&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
+    <Exec Command="dotnet sln $(MSBuildProjectName).sln add &quot;%(RelativeBuildProjectPath.Identity)&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
 
     <!-- Build the solution. -->
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -48,7 +48,7 @@
     <!-- The 'force' flag overrides the existing .sln file if one already exists. -->
     <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" />
     <!-- https://stackoverflow.com/a/3012224/294804 -->
-    <Exec Command="dotnet sln $(ArtifactsDir)$(MSBuildProjectName).sln add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ') --solution-folder $(ArtifactsDir)" />
+    <Exec Command="dotnet sln &quot;$(ArtifactsDir)$(MSBuildProjectName).sln&quot; add @(BuildProject -> '&quot;%(FullPath)&quot;', ' ') --solution-folder=&quot;$(ArtifactsDir)&quot;" />
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />
   </Target>
 

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -50,19 +50,28 @@
 
     <Exec Command="dotnet --info" WorkingDirectory="$(ArtifactsDir)" />
 
+    <PropertyGroup>
+      <DriveRootPath>$([System.IO.Path]::GetPathRoot('$(ArtifactsDir)'))</DriveRootPath>
+      <ArtifactsDirRelative>$([System.String]::Copy('$(ArtifactsDir)').Substring(3))</ArtifactsDirRelative>
+    </PropertyGroup>
+
     <!-- Create the solution. Use 'force' to override existing. -->
-    <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(ArtifactsDir)" />
+    <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(DriveRootPath)" />
 
-    <Exec
-      Command="powershell -NoProfile -Command &quot;Write-Output ((Resolve-Path -Relative '%(BuildProject.FullPath)'))&quot;"
-      WorkingDirectory="$(ArtifactsDir)">
-      <Output TaskParameter="ConsoleOutput" ItemName="RelativeBuildProjectPath" />
-    </Exec>
+    <Message Importance="normal" Text="Absolute paths: @(BuildProject)" />
 
-    <Message Importance="normal" Text="Relative paths: @(RelativeBuildProjectPath)" />
+    <!-- Strip the drive letter and backslash, e.g. D:\ => -->
+    <ItemGroup>
+      <BuildProjectWithRel Include="@(BuildProject)">
+        <!-- Trim the first three characters: D:\ -->
+        <RelPath>$([System.String]::Copy('%(BuildProject.FullPath)').Substring(3))</RelPath>
+      </BuildProjectWithRel>
+    </ItemGroup>
+
+    <Message Importance="normal" Text="Relative path: %(BuildProjectWithRel.RelPath)" />
 
     <!-- Add each BuildProject to the solution. -->
-    <Exec Command="dotnet sln $(MSBuildProjectName).sln add &quot;%(RelativeBuildProjectPath.Identity)&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
+    <Exec Command="dotnet sln &quot;$(ArtifactsDirRelative)/$(MSBuildProjectName).sln&quot; add &quot;%(BuildProjectWithRel.RelPath)&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(DriveRootPath)" />
 
     <!-- Build the solution. -->
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -48,6 +48,8 @@
 
     <!-- https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-new#options -->
 
+    <Exec Command="dotnet --info" WorkingDirectory="$(ArtifactsDir)" />
+
     <!-- Create the solution. Use 'force' to override existing. -->
     <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(ArtifactsDir)" />
 

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -50,6 +50,9 @@
 
     <Exec Command="dotnet --info" WorkingDirectory="$(ArtifactsDir)" />
 
+    <!-- Due to bug https://github.com/dotnet/sdk/issues/47008 we cannot pass paths that contain drive letters to "dotnet sln add".
+         We do some contortion here to make the paths relative, and run them from the root directory. This code is a big ugly because
+         there's no Path.GetRelativePath on .NET Framework. -->
     <PropertyGroup>
       <DriveRootPath>$([System.IO.Path]::GetPathRoot('$(ArtifactsDir)'))</DriveRootPath>
       <ArtifactsDirRelative>$([System.String]::Copy('$(ArtifactsDir)').Substring(3))</ArtifactsDirRelative>
@@ -58,8 +61,6 @@
     <!-- Create the solution. Use 'force' to override existing. -->
     <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(DriveRootPath)" />
 
-    <Message Importance="normal" Text="Absolute paths: @(BuildProject)" />
-
     <!-- Strip the drive letter and backslash, e.g. D:\ => -->
     <ItemGroup>
       <BuildProjectWithRel Include="@(BuildProject)">
@@ -67,8 +68,6 @@
         <RelPath>$([System.String]::Copy('%(BuildProject.FullPath)').Substring(3))</RelPath>
       </BuildProjectWithRel>
     </ItemGroup>
-
-    <Message Importance="normal" Text="Relative path: %(BuildProjectWithRel.RelPath)" />
 
     <!-- Add each BuildProject to the solution. -->
     <Exec Command="dotnet sln &quot;$(ArtifactsDirRelative)/$(MSBuildProjectName).sln&quot; add &quot;%(BuildProjectWithRel.RelPath)&quot;" WorkingDirectory="$(DriveRootPath)" />

--- a/eng/Build.proj
+++ b/eng/Build.proj
@@ -54,7 +54,7 @@
     <Exec Command="dotnet new sln -n $(MSBuildProjectName) -o $(ArtifactsDir) --force" WorkingDirectory="$(ArtifactsDir)" />
 
     <!-- Add each BuildProject to the solution. -->
-    <Exec Command="dotnet sln $(MSBuildProjectName).sln add &quot;%(BuildProject.FullPath)&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
+    <Exec Command="dotnet sln $(MSBuildProjectName).sln add &quot;$([System.IO.Path]::GetRelativePath('$(ArtifactsDir)', '%(BuildProject.FullPath)'))&quot; --solution-folder=&quot;$(ArtifactsDir)&quot;" WorkingDirectory="$(ArtifactsDir)" />
 
     <!-- Build the solution. -->
     <MSBuild Projects="$(ArtifactsDir)$(MSBuildProjectName).sln" Targets="@(BuildTarget)" BuildInParallel="true" Condition="'@(BuildTarget)' != ''" />

--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -138,13 +138,6 @@ jobs:
     inputs:
       forceReinstallCredentialProvider: true
 
-  # Ensure the required .NET SDK version is installed.
-  - task: UseDotNet@2
-    displayName: Use .NET SDK from global.json
-    inputs:
-      packageType: 'sdk'
-      useGlobalJson: true
-
   # Runs the full build of the projects in the repository. See Build.proj for details.
   - script: $(Build.SourcesDirectory)/build.cmd /v:normal /p:Configuration=$(BuildConfiguration) /p:CIBuild=true
     displayName: Build All Projects

--- a/eng/pipelines/templates/build-pull-request.yml
+++ b/eng/pipelines/templates/build-pull-request.yml
@@ -35,7 +35,7 @@ jobs:
     inputs:
       packageType: runtime
       # This should match the target of our unit test projects.
-      version: 8.0.x
+      version: 9.0.x
 
   # Allows for accessing the internal AzDO feed (vs-impl-internal) for project restore via Azure Artifacts Credential Provider.
   # See: https://github.com/microsoft/artifacts-credprovider#automatic-usage

--- a/eng/pipelines/templates/build-pull-request.yml
+++ b/eng/pipelines/templates/build-pull-request.yml
@@ -29,13 +29,6 @@ jobs:
     inputs:
       forceReinstallCredentialProvider: true
 
-  # Ensure the required .NET SDK version is installed.
-  - task: UseDotNet@2
-    displayName: Use .NET SDK from global.json
-    inputs:
-      packageType: 'sdk'
-      useGlobalJson: true
-
   # Ensure the .NET runtime needed by our unit tests is installed.
   - task: UseDotNet@2
     displayName: Install .NET Runtime

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "9.0.107",
-    "rollForward": "latestFeature"
-  }
-}

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/LaunchProfilesDebugLaunchProvider.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Buffers.PooledObjects;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/HotReload/ProjectHotReloadSessionTests.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using System.Diagnostics;
 using Microsoft.VisualStudio.Debugger.Contracts.EditAndContinue;
 using Microsoft.VisualStudio.Debugger.Contracts.HotReload;
 using Microsoft.VisualStudio.HotReload.Components.DeltaApplier;
 using Microsoft.VisualStudio.ProjectSystem.Debug;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Microsoft.VisualStudio.ProjectSystem.VS.Debug;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.HotReload;
 
@@ -642,26 +640,6 @@ public class ProjectHotReloadSessionTests
         configuredProject.Setup(c => c.Services)
             .Returns(configuredProjectServices.Object);
         configuredProject.Setup(c => c.UnconfiguredProject)
-            .Returns(unconfiguredProject.Object);
-
-        return configuredProject.Object;
-    }
-
-    private static ConfiguredProject CreateConfiguredProjectWithDebugProvider()
-    {
-        var launchProvider = new Mock<IInternalDebugLaunchProvider>();
-        launchProvider
-            .Setup(p => p.LaunchWithProfileAsync(It.IsAny<DebugLaunchOptions>(), It.IsAny<ILaunchProfile>()))
-            .Returns(Task.CompletedTask);
-
-        var unconfiguredProject = new Mock<UnconfiguredProject>();
-        unconfiguredProject
-            .Setup(p => p.FullPath)
-            .Returns("C:\\Test\\Project.csproj");
-
-        var configuredProject = new Mock<ConfiguredProject>();
-        configuredProject
-            .Setup(c => c.UnconfiguredProject)
             .Returns(unconfiguredProject.Object);
 
         return configuredProject.Object;


### PR DESCRIPTION
This file was added in #9649 to pin a specific SDK version in order to work around issues in CI builds. This change removes that, in the hope that CI images no longer experience this issue. Having a `global.json` file requires keeping it updated for security reasons, and we'd rather avoid that overhead here, and let the CI machines do the right thing by default.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9658)