### PR TITLE
Add IFileWatcherService so we can enable VS Code File Watcher for dotnet-project-system-vscode services

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/FileWatch/IFileWatcherService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/FileWatch/IFileWatcherService.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
+
+using System.Runtime.Serialization;
+
+namespace Microsoft.VisualStudio.FileWatch;
+
+public interface IFileWatcherService : IDisposable
+{
+    event EventHandler<FileWatcherEventArgs> OnDidCreate;
+
+    event EventHandler<FileWatcherEventArgs> OnDidChange;
+
+    event EventHandler<FileWatcherEventArgs> OnDidDelete;
+}
+
+[DataContract]
+public class FileWatcherEventArgs : EventArgs
+{
+    /// <summary>
+    /// The Watcher Change Type. It can be: 'created', 'changed' or 'deleted'.
+    /// </summary>
+    [DataMember(Name = "watcherChangeType")]
+    public WatcherChangeTypes WatcherChangeType { get; init; }
+
+    /// <summary>
+    /// The URI File System Path
+    /// </summary>
+    [DataMember(Name = "fsPath")]
+    public string? FsPath { get; init; }
+}

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -1046,10 +1046,8 @@ internal class LaunchSettingsUnderTest : LaunchSettingsProvider
         IProjectFaultHandlerService projectFaultHandler,
         IDefaultLaunchProfileProvider defaultLaunchProfileProvider,
         JoinableTaskContext joinableTaskContext)
-      : base(project, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, projectProperties, projectFaultHandler, joinableTaskContext)
+      : base(project, projectServices, fileSystem, commonProjectServices, projectSubscriptionService, projectProperties, projectFaultHandler, new SimpleFileWatcher(), joinableTaskContext)
     {
-        // Block the code from setting up one on the real file system. Since we block, it we need to set up the fileChange scheduler manually
-        FileWatcher = new SimpleFileWatcher();
         // Make the unit tests run faster
         FileChangeProcessingDelay = TimeSpan.FromMilliseconds(50);
         FileChangeScheduler = new TaskDelayScheduler(FileChangeProcessingDelay, commonProjectServices.ThreadingService,


### PR DESCRIPTION
## What does this PR do

This PR adds a new **public** interface: `IFileWatcherService`, which will be consumed by `LaunchSettingsProvider`.

This PR also implement that interface for `SimpleFileWatcher` class and export it as MEF component.

## Why

This provides an opportunity to consume [`VsCodeFileWatchService`](https://devdiv.visualstudio.com/DevDiv/_git/vs-green?path=/src/services/VsCodeFileWatcherService.ts&version=GCb6780635964185b6594f8eaf3e106a9868c2b5ab&line=12&lineEnd=13&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) in [LaunchProfileHandlerAggregator](https://dev.azure.com/devdiv/DevDiv/_git/dotnet-project-system-vscode?path=/src/Microsoft.VisualStudio.ProjectSystem.Managed.VSCode/ProjectSystem/Launch/LaunchProfileHandlerAggregator.cs&version=GBmain&_a=contents&line=19&lineStyle=plain&lineEnd=19&lineStartColumn=16&lineEndColumn=46) for vs-green if `Prefer Visual Studio Code File System Watchers` option is enabled, which could be helpful to reduce the number of inotify watches on linux when user opens a large project.

## relevant issues
- https://github.com/microsoft/vscode-dotnettools/issues/360
- [[C# Dev Kit] Enable VS Code File watcher in C# Dev Kit](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1884591/)
- [[C# Dev Kit] LaunchSettingsProvider creates a high number of watchers in linux that are excluded via "files.watcherExclude"](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1901377)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9662)