### PR TITLE
Add 'Assembly Title' to the project properties UI

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/ApplicationPropertyPage.xaml
@@ -272,6 +272,11 @@
                   Description="Specifies the name of the output file that will hold the assembly manifest."
                   Category="General" />
 
+  <StringProperty Name="AssemblyTitle"
+                  DisplayName="Assembly title"
+                  Description="Specifies the title embedded in the output assembly."
+                  Category="General" />
+
   <StringProperty Name="RootNamespace"
                   DisplayName="Default namespace"
                   Description="Specifies the base namespace for files added to the project."

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.cs.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Název sestavení</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Nainstalovat jiné architektury</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.de.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Assemblyname</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Andere Frameworks installieren</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.es.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Nombre del ensamblado</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Instalar otras plataformas</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.fr.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Nom d'assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Installer d'autres frameworks</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.it.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Nome dell'assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Installa altri framework</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ja.xlf
@@ -267,6 +267,16 @@
         <target state="translated">アセンブリ名</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">別のフレームワークをインストールする</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ko.xlf
@@ -267,6 +267,16 @@
         <target state="translated">어셈블리 이름</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">기타 프레임워크 설치</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pl.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Nazwa zestawu</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Zainstaluj inne platformy</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.pt-BR.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Nome do assembly</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Instalar outras estruturas</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.ru.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Имя сборки</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Установить другие платформы</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.tr.xlf
@@ -267,6 +267,16 @@
         <target state="translated">Bütünleştirilmiş kod adı</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">Diğer çerçeveleri yükle</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hans.xlf
@@ -267,6 +267,16 @@
         <target state="translated">程序集名称</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">安装其他框架</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/PropertyPages/xlf/ApplicationPropertyPage.xaml.zh-Hant.xlf
@@ -267,6 +267,16 @@
         <target state="translated">組件名稱</target>
         <note />
       </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|Description">
+        <source>Specifies the title embedded in the output assembly.</source>
+        <target state="new">Specifies the title embedded in the output assembly.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="StringProperty|AssemblyTitle|DisplayName">
+        <source>Assembly title</source>
+        <target state="new">Assembly title</target>
+        <note />
+      </trans-unit>
       <trans-unit id="StringProperty|InstallOtherFrameworks|DisplayName">
         <source>Install other frameworks</source>
         <target state="translated">安裝其他架構</target>


### PR DESCRIPTION
This adds the ability to override the AssemblyTitleAttribute for the project's output assembly. Without this, the value is always hard-coded to that of the project's file name.

Requested in https://developercommunity.visualstudio.com/t/Cannot-set-assembly-title-AssemblyTitle/10445147

![image](https://github.com/user-attachments/assets/6c34a2f8-b841-41ed-8af2-bbe9a12f67b8)

![image](https://github.com/user-attachments/assets/f55819dc-7334-4458-9842-c396405aa5a3)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9669)