### PR TITLE
New capability to turn off default namespace logic for SFG in VB

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.VisualBasic.DesignTime.targets
@@ -42,6 +42,8 @@
                           SharedProjectReferences;
                           ProjectPropertiesEditor;" />
 
+    <ProjectCapability Include="NoDefaultSingleFileGenNamespace" Condition="'$(DisableNoDefaultSingleFileGenNamespace)' != 'true'" />
+
     <ProjectCapability Include="EnableMyApplication" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
 
     <ProjectCapability Include="EnableMyApplication" Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(UseWindowsForms)' == 'true' And '$(TargetFrameworkVersion)' != '' And $([MSBuild]::VersionGreaterThanOrEquals('$(TargetFrameworkVersion)','5.0'))" />


### PR DESCRIPTION
Defining a new capability to turn off the default namespace calculation logic in VB projects.
This matches the behavior in classic VB projects.
The new capability can be turned off by specifying this property in the project file:
```xml
<DisableNoDefaultSingleFileGenNamespace>true</DisableNoDefaultSingleFileGenNamespace>
```
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9670)