### PR TITLE
Register background task critical to load projects.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="17.13.38047-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.14.20" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.15.10-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.12.2159" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.13.38055-preview.1" />

--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>18.0.62-pre</CPSPackageVersion>
+    <CPSPackageVersion>18.0.75-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -95,6 +95,7 @@ internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksServic
         JoinableTask<T> task = _threadingService.JoinableTaskFactory.RunAsync(action);
 
         _prioritizedTasks.Add(task);
+        _tasksService.RegisterAsyncTask(task, ProjectCriticalOperation.Load);
 
         return task.Task;
     }
@@ -108,6 +109,7 @@ internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksServic
         JoinableTask task = _threadingService.JoinableTaskFactory.RunAsync(action);
 
         _prioritizedTasks.Add(task);
+        _tasksService.RegisterAsyncTask(task, ProjectCriticalOperation.Load);
 
         return task.Task;
     }


### PR DESCRIPTION
This allows those tasks to be able to access UI thread earlier than it blocks the UI thread later.

This is a part of the effort to improve the solution loading experience.