### PR TITLE
Revert "Register background task critical to load projects."

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="17.13.38047-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.15.10-pre" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.14.20" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.12.2159" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.13.38055-preview.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,7 +55,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="17.13.38047-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.14.20" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.15.10-pre" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.13.38055-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.12.2159" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.13.38055-preview.1" />

--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>18.0.75-pre</CPSPackageVersion>
+    <CPSPackageVersion>18.0.62-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>18.0.62-pre</CPSPackageVersion>
+    <CPSPackageVersion>18.0.75-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -288,24 +288,14 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
                 object? hostObject = _unconfiguredProject.Services.HostObject;
 
-                JoinableTask initialWorkspaceCreationTask = _joinableTaskFactory.RunAsync(async () =>
-                {
-                    // Call into Roslyn to initialize language service for this project
-                    _context = await _workspaceProjectContextFactory.Value.CreateProjectContextAsync(
-                        _projectGuid,
-                        _contextId,
-                        languageName,
-                        evaluationData,
-                        hostObject,
-                        cancellationToken);
-                });
-
-                if (!initialWorkspaceCreationTask.IsCompleted)
-                {
-                    _unconfiguredProject.Services.ProjectAsynchronousTasks!.RegisterAsyncTask(initialWorkspaceCreationTask, ProjectCriticalOperation.Load);
-                }
-
-                await initialWorkspaceCreationTask;
+                // Call into Roslyn to initialize language service for this project
+                _context = await _workspaceProjectContextFactory.Value.CreateProjectContextAsync(
+                    _projectGuid,
+                    _contextId,
+                    languageName,
+                    evaluationData,
+                    hostObject,
+                    cancellationToken);
 
                 evaluationData.Release();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectTasksService.cs
@@ -95,7 +95,6 @@ internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksServic
         JoinableTask<T> task = _threadingService.JoinableTaskFactory.RunAsync(action);
 
         _prioritizedTasks.Add(task);
-        _tasksService.RegisterAsyncTask(task, ProjectCriticalOperation.Load);
 
         return task.Task;
     }
@@ -109,7 +108,6 @@ internal class UnconfiguredProjectTasksService : IUnconfiguredProjectTasksServic
         JoinableTask task = _threadingService.JoinableTaskFactory.RunAsync(action);
 
         _prioritizedTasks.Add(task);
-        _tasksService.RegisterAsyncTask(task, ProjectCriticalOperation.Load);
 
         return task.Task;
     }


### PR DESCRIPTION
Reverts dotnet/project-system#9672

This introduced a regression from Roslyn starting too early.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9681)