### PR TITLE
Allow language service to get ProjectGuid earlier in common cases.

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -213,10 +213,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
                 {
                     Assumes.False(checklist.ContainsKey(slice));
 
-                    if (projectGuid is null)
-                    {
-                        projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
-                    }
+                    projectGuid ??= await _projectGuidService.GetProjectGuidAsync(cancellationToken);
 
                     // New slice. Create a workspace for it.
                     workspace = _workspaceFactory.Create(source, slice, JoinableCollection, JoinableFactory, projectGuid.Value, cancellationToken);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -205,16 +205,21 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
             // Remember the first slice's workspace. We may use it later, if the active workspace is removed.
             Workspace? firstWorkspace = null;
 
+            Guid? projectGuid = null;
+
             foreach ((ProjectConfigurationSlice slice, IActiveConfigurationSubscriptionSource source) in sources)
             {
                 if (!workspaceBySlice.TryGetValue(slice, out Workspace? workspace))
                 {
                     Assumes.False(checklist.ContainsKey(slice));
 
-                    Guid projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
+                    if (projectGuid is null)
+                    {
+                        projectGuid = await _projectGuidService.GetProjectGuidAsync(cancellationToken);
+                    }
 
                     // New slice. Create a workspace for it.
-                    workspace = _workspaceFactory.Create(source, slice, JoinableCollection, JoinableFactory, projectGuid, cancellationToken);
+                    workspace = _workspaceFactory.Create(source, slice, JoinableCollection, JoinableFactory, projectGuid.Value, cancellationToken);
 
                     if (workspace is null)
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/VsSafeProjectGuidService.cs
@@ -14,7 +14,7 @@ internal class VsSafeProjectGuidService : ISafeProjectGuidService
 {
     private readonly UnconfiguredProject _project;
     private readonly IUnconfiguredProjectTasksService _tasksService;
-    private readonly IVsService<SVsBackgroundSolution, IVsBackgroundSolution> _backgroundSolutionImport;
+    private readonly IVsService<IVsBackgroundSolution> _backgroundSolutionImport;
 
     [ImportingConstructor]
     public VsSafeProjectGuidService(


### PR DESCRIPTION
This PR is to adjust the logic so the language service pipeline can be established earlier in common cases.

Today, the code path waits project to be fully loaded to ensure the ProjectGuid would not be changed. The additional logic added here is to check whether project and solution has already agreed with each other on the ProjectGuid. In a few cases, we will still fall back to the original logic, including new projects, newly added projects, or potentially there is a conflicting between solution and project.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9683)