### PR TITLE
Improve perf of accessing configured values in tree, particularly during solution load

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeProvider.cs
@@ -50,7 +50,7 @@ internal sealed partial class DependenciesTreeProvider : ProjectTreeProviderBase
     private readonly IActiveConfiguredValue<IConfiguredProjectExports> _activeConfiguredProjectExports;
     private readonly CancellationSeries _treeUpdateCancellationSeries;
     private readonly IProjectAccessor _projectAccessor;
-    private readonly ITaskDelayScheduler _debounce;
+    private readonly TaskDelayScheduler _debounce;
 
     [Import]
     private DependenciesTreeBuilder TreeBuilder { get; set; } = null!;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeProvider.cs
@@ -494,16 +494,11 @@ internal sealed partial class DependenciesTreeProvider : ProjectTreeProviderBase
     /// A private implementation of <see cref="IProjectTreeActionHandlerContext"/> for use with
     /// <see cref="IProjectTreeActionHandler"/> exports.
     /// </summary>
-    private sealed class ProjectDependencyTreeRemovalActionHandlerContext : IProjectTreeActionHandlerContext
+    private sealed class ProjectDependencyTreeRemovalActionHandlerContext(IProjectTreeProvider treeProvider) : IProjectTreeActionHandlerContext
     {
-        public IProjectTreeProvider TreeProvider { get; }
+        public IProjectTreeProvider TreeProvider { get; } = treeProvider;
 
         public IProjectTreeActionHandler SuccessorHandlerDelegator => throw new NotImplementedException();
-
-        public ProjectDependencyTreeRemovalActionHandlerContext(IProjectTreeProvider treeProvider)
-        {
-            TreeProvider = treeProvider;
-        }
     }
 
     // NOTE this interface is needed to work around accessiblity issues when making MyConfiguredProjectExports non-private

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/DependenciesTreeProvider.cs
@@ -52,6 +52,9 @@ internal sealed partial class DependenciesTreeProvider : ProjectTreeProviderBase
     private readonly IProjectAccessor _projectAccessor;
     private readonly TaskDelayScheduler _debounce;
 
+    // NOTE we use a property import here as importing this via the constructor creates a loop between
+    // DependenciesTreeProvider and DependenciesTreeBuilder. A property import allows MEF to break that
+    // circular dependency.
     [Import]
     private DependenciesTreeBuilder TreeBuilder { get; set; } = null!;
 


### PR DESCRIPTION
Fixes #2707

Lifeng reported that calling `GetActiveConfiguredProjectExports` on the base class was taking 0.5 seconds of CPU while loading Roslyn.sln.

This change uses `IActiveConfiguredValue<>` to cache the instance, to improve performance while building dependencies trees across the solution during solution load.

The same optimisation is applied to `ImportTreeProvider` as well.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9686)