### PR TITLE
Use newer Roslyn API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -398,6 +398,7 @@ dotnet_diagnostic.IDE0220.severity = warning      # Add explicit cast
 dotnet_diagnostic.IDE0250.severity = warning      # Struct can be made 'readonly'
 dotnet_diagnostic.IDE0251.severity = suggestion   # Struct methods can be made 'readonly'
 dotnet_diagnostic.IDE0270.severity = suggestion   # Use coalesce expression
+dotnet_diagnostic.IDE0300.severity = suggestion   # Use collection expression
 dotnet_diagnostic.IDE1006.severity = warning      # Naming styles                                 Task Open()                                         Task OpenAsync()
 dotnet_diagnostic.IDE1006WithoutSuggestion.severity = suggestion
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -39,7 +39,7 @@ indent_size = 2
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
-dotnet_style_require_accessibility_modifiers = always:warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
 
 # No blank line between System.* and Microsoft.*
 dotnet_separate_import_directive_groups = false

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,41 +35,42 @@
     <PackageVersion Include="Nerdbank.GitVersioning"                                                 Version="3.6.79-alpha" />
     <PackageVersion Include="Nerdbank.Streams"                                                       Version="2.12.87" />
     <PackageVersion Include="System.IO.Pipelines"                                                    Version="9.0.0" />
-    <PackageVersion Include="StreamJsonRpc"                                                          Version="2.22.7" />
+    <PackageVersion Include="StreamJsonRpc"                                                          Version="2.23.32-alpha" />
 
     <!-- VS SDK -->
     <!-- https://dev.azure.com/azure-public/vside/_artifacts/feed/vssdk -->
-    <PackageVersion Include="EnvDTE"                                                                 Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.8.55" />
-    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.13.13-preview" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.13.41" />
-    <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="17.13.38047-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.DataTools.Interop"                               Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces"                             Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="17.13.38047-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.15.10-pre" />
-    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="17.13.38055-preview.1" />
+    <PackageVersion Include="EnvDTE"                                                                 Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.Internal.VisualStudio.Interop"                                Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.9.11-beta" />
+    <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.14.116" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.13.50" />
+    <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.DataTools.Interop"                               Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Designer.Interfaces"                             Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Editor"                                          Version="18.0.300-preview" />
+    <PackageVersion Include="Microsoft.VisualStudio.ImageCatalog"                                    Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.15.15-pre" />
+    <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.12.2159" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design"                                    Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.14.8" />
-    <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="17.13.38055-preview.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.14.14" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.14.14" />
-    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="17.14.39795" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Design"                                    Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Shell.Framework"                                 Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Telemetry"                                       Version="17.14.18" />
+    <PackageVersion Include="Microsoft.VisualStudio.TemplateWizardInterface"                         Version="18.0.1755-preview.1" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading"                                       Version="17.15.3-alpha" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"                             Version="17.15.3-alpha" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.13.0-preview-1-35408-014" />
     <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.13.17-preview1-ga15b669c04" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="9.0.0" />
     <PackageVersion Include="System.Formats.Asn1"                                                    Version="8.0.1" />
-    <PackageVersion Include="Microsoft.VSDesigner"                                                   Version="17.13.38055-preview.1" />
-    <PackageVersion Include="VsWebSite.Interop"                                                      Version="17.13.38055-preview.1" />
+    <PackageVersion Include="Microsoft.VSDesigner"                                                   Version="18.0.1755-preview.1" />
+    <PackageVersion Include="VsWebSite.Interop"                                                      Version="18.0.1755-preview.1" />
 
     <!-- CPS -->
     <!-- Find versions at https://dev.azure.com/azure-public/vside/_artifacts/feed/vs-impl -->
@@ -82,18 +83,18 @@
     <PackageVersion Include="Microsoft.VisualStudio.ProjectSystem.XamlTypes"                         Version="$(CPSPackageVersion)" />
 
     <!-- Roslyn -->
-    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="4.13.0-1.24505.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="4.13.0-1.24505.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis"                                                 Version="5.0.0-1.25321.102" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common"                                          Version="5.0.0-1.25321.102" />
     <PackageVersion Include="Microsoft.CSharp"                                                       Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="4.13.0-1.24505.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="4.13.0-1.24505.1" />
+    <PackageVersion Include="Microsoft.Net.Compilers.Toolset"                                        Version="5.0.0-1.25321.102" />
+    <PackageVersion Include="Microsoft.VisualStudio.LanguageServices"                                Version="5.0.0-1.25321.102" />
 
     <!-- Analyzers -->
-    <PackageVersion Include="CSharpIsNullAnalyzer"                                                   Version="0.1.329" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                       Version="3.11.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="4.13.0-1.24505.1" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="4.13.0-1.24505.1" />
-    <PackageVersion Include="Roslyn.Diagnostics.Analyzers"                                           Version="3.11.0-beta1.24454.1" />
+    <PackageVersion Include="CSharpIsNullAnalyzer"                                                   Version="0.1.593" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"                                       Version="5.0.0-1.25321.102" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle"                                Version="5.0.0-1.25321.102" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeStyle"                           Version="5.0.0-1.25321.102" />
+    <PackageVersion Include="Roslyn.Diagnostics.Analyzers"                                           Version="5.0.0-1.25321.102" />
 
     <!-- NuGet -->
     <PackageVersion Include="NuGet.VisualStudio"                                                     Version="17.13.0-preview.1.10" />
@@ -101,7 +102,7 @@
     <!-- Framework packages -->
     <PackageVersion Include="Microsoft.IO.Redist"                                                    Version="6.1.0" />
     <!-- Pin version to avoid CVE in System.Text.Json 8.0.4 -->
-    <PackageVersion Include="System.Text.Json"                                                    Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json"                                                       Version="9.0.0" />
 
     <!-- MSBuild (for tests only) -->
     <PackageVersion Include="Microsoft.Build"                                                        Version="17.13.0-preview-24504-04" />
@@ -137,10 +138,10 @@
     <PackageVersion Include="MSTest.TestFramework"                                                   Version="2.1.2" />
 
     <!-- Localization -->
-    <PackageVersion Include="CommandLineParser"                                                     Version="2.9.1" />
+    <PackageVersion Include="CommandLineParser"                                                      Version="2.9.1" />
 
     <!-- MessagePack -->
-    <PackageVersion Include="MessagePack"                                                           Version="2.5.192" />
+    <PackageVersion Include="MessagePack"                                                            Version="2.5.198" />
   </ItemGroup>
 
 </Project>

--- a/eng/imports/VisualStudio.props
+++ b/eng/imports/VisualStudio.props
@@ -26,6 +26,7 @@
     <!-- VS SDK -->
     <PackageReference Include="Microsoft.Internal.VisualStudio.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" />
+    <PackageReference Include="Microsoft.VisualStudio.Editor" />
     <PackageReference Include="Microsoft.VisualStudio.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/SolutionBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/SolutionBuildManager.cs
@@ -143,7 +143,7 @@ internal sealed class SolutionBuildManager : OnceInitializedOnceDisposedAsync, I
 
         if (count == 0)
         {
-            return Array.Empty<IVsHierarchy>();
+            return [];
         }
 
         // Get all of the dependent projects, and add them to our list

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -50,7 +50,7 @@ internal class CreateFileFromTemplateService : ICreateFileFromTemplateService
         {
             HierarchyId parentId = _projectVsServices.VsProject.GetHierarchyId(directoryName);
             var result = new VSADDRESULT[1];
-            string[] files = new string[] { templateFilePath };
+            string[] files = [templateFilePath];
             _projectVsServices.VsProject.AddItemWithSpecific(parentId, VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, fileName, (uint)files.Length, files, IntPtr.Zero, 0, Guid.Empty, null, Guid.Empty, result);
 
             if (result[0] == VSADDRESULT.ADDRESULT_Success)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/ProjectLaunchTargetsProvider.cs
@@ -250,7 +250,7 @@ internal class ProjectLaunchTargetsProvider :
                 _outputTypeChecker,
                 validateSettings);
 
-            if (runnableProjectInfo == null)
+            if (runnableProjectInfo is null)
             {
                 return null;
             }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Debug/StartupProjectHelper.cs
@@ -62,7 +62,7 @@ internal class StartupProjectHelper : IStartupProjectHelper
             return results.ToImmutableAndFree();
         }
 
-        return ImmutableArray<T>.Empty;
+        return [];
     }
 
     public ImmutableArray<string> GetFullPathsOfStartupProjects()
@@ -86,6 +86,6 @@ internal class StartupProjectHelper : IStartupProjectHelper
             return results.ToImmutableAndFree();
         }
 
-        return ImmutableArray<string>.Empty;
+        return [];
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/DteEnvironmentOptions.cs
@@ -36,9 +36,6 @@ internal class DteEnvironmentOptions : IEnvironmentOptions
     {
         EnvDTE.Properties? properties = _dte.Value.get_Properties(category, page);
 
-        if (properties is not null)
-        {
-            properties.Item(option).Value = newValue;
-        }
+        properties?.Item(option).Value = newValue;
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderAddItemHintReceiver.cs
@@ -11,7 +11,7 @@ internal class OrderAddItemHintReceiver : IProjectChangeHintReceiver
 {
     private readonly IProjectAccessor _accessor;
 
-    private ImmutableHashSet<string> _previousIncludes = ImmutableHashSet<string>.Empty;
+    private ImmutableHashSet<string> _previousIncludes = [];
     private OrderingMoveAction _action = OrderingMoveAction.NoOp;
     private IProjectTree? _target;
     private bool _isHinting;
@@ -78,7 +78,7 @@ internal class OrderAddItemHintReceiver : IProjectChangeHintReceiver
     {
         _action = OrderingMoveAction.NoOp;
         _target = null;
-        _previousIncludes = ImmutableHashSet<string>.Empty;
+        _previousIncludes = [];
         _isHinting = false;
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelper.cs
@@ -122,7 +122,7 @@ internal static class OrderingHelper
         Requires.NotNull(project);
         Requires.NotNull(target);
 
-        ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Above);
+        ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, [], MoveAction.Above);
         if (referenceElement is null)
         {
             return false;
@@ -139,7 +139,7 @@ internal static class OrderingHelper
         Requires.NotNull(project);
         Requires.NotNull(target);
 
-        ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, ImmutableArray<string>.Empty, MoveAction.Below);
+        ProjectItemElement? referenceElement = TryGetReferenceElement(project, target, [], MoveAction.Below);
         if (referenceElement is null)
         {
             return false;
@@ -436,11 +436,11 @@ internal static class OrderingHelper
         if (referenceProjectTree is not null)
         {
             // The reference element is the element for which moved items will be above or below it.
-            ProjectItemElement? referenceElement = TryGetReferenceElement(project, referenceProjectTree, ImmutableArray<string>.Empty, moveAction);
+            ProjectItemElement? referenceElement = TryGetReferenceElement(project, referenceProjectTree, [], moveAction);
 
             if (referenceElement is not null)
             {
-                ImmutableArray<ProjectItemElement> elements = GetItemElements(project, projectTree, ImmutableArray<string>.Empty);
+                ImmutableArray<ProjectItemElement> elements = GetItemElements(project, projectTree, []);
                 return TryMoveElements(elements, referenceElement, moveAction);
             }
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/TemplateDetailsExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Input/Commands/TemplateDetailsExtensions.cs
@@ -37,7 +37,7 @@ internal static class TemplateDetailsExtensions
     {
         if (!map.TryGetValue(commandId, out ImmutableArray<TemplateDetails> list))
         {
-            list = ImmutableArray<TemplateDetails>.Empty;
+            list = [];
         }
 
         list = list.Add(new TemplateDetails(capability, dirNamePackage, Convert.ToUInt32(dirNameId), templateNamePackage, Convert.ToUInt32(templateNameId)));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -264,10 +264,7 @@ internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IP
                 // We removed the primary workspace
 
                 // If we have a new primary workspace, use it.
-                if (firstWorkspace is not null)
-                {
-                    firstWorkspace.IsPrimary = true;
-                }
+                firstWorkspace?.IsPrimary = true;
 
                 // Set the new primary workspace (or theoretically null if no slices exist).
                 _primaryWorkspace = firstWorkspace;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -670,7 +670,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
 
             if (items.Count == 0)
             {
-                return ImmutableArray<string>.Empty;
+                return [];
             }
 
             return items.Select(item => item.EvaluatedInclude).ToImmutableArray();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/WorkspaceFactory.cs
@@ -211,7 +211,7 @@ internal class WorkspaceFactory : IWorkspaceFactory
                         bufferedBuilds.Add(input);
 
                         // Return an empty enumerable. We don't yet want to produce any outputs.
-                        return Enumerable.Empty<IProjectVersionedValue<WorkspaceUpdate>>();
+                        return [];
                     }
                     else
                     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectCapabilitiesMissingVetoProjectLoad.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/ProjectCapabilitiesMissingVetoProjectLoad.cs
@@ -69,7 +69,7 @@ internal partial class ProjectCapabilitiesMissingVetoProjectLoad : IVetoProjectP
         Assembly assembly = typeof(ProjectCapabilitiesMissingVetoProjectLoad).Assembly;
 
         return assembly.GetCustomAttributes<ProjectTypeRegistrationAttribute>()
-                       .Select(a => new ProjectType('.' + a.DefaultProjectExtension, a.Capabilities!.Split(new[] { ';', ' ' }, StringSplitOptions.RemoveEmptyEntries)))
+                       .Select(a => new ProjectType('.' + a.DefaultProjectExtension, a.Capabilities!.Split([';', ' '], StringSplitOptions.RemoveEmptyEntries)))
                        .ToImmutableArray();
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/DotNetImportsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/DotNetImportsEnumProvider.cs
@@ -37,7 +37,7 @@ internal class DotNetImportsEnumProvider : IDynamicEnumValuesProvider, IDynamicE
 
         if (compilation is null)
         {
-            return Enumerable.Empty<string>();
+            return [];
         }
 
         List<string> namespaceNames = new List<string>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationFrameworkValueProvider.cs
@@ -8,8 +8,7 @@ using static Microsoft.VisualStudio.ProjectSystem.Properties.PropertyNames;
 namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 
 [ExportInterceptingPropertyValueProvider(
-new[]
-{
+[
     ApplicationFramework,
     EnableVisualStyles,
     SingleInstance,
@@ -19,7 +18,7 @@ new[]
     ShutdownMode,
     SplashScreen,
     MinimumSplashScreenDisplayTime
-},
+],
 ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 [AppliesTo(ProjectCapability.WPF + "|" + ProjectCapability.WindowsForms)]
 internal sealed class ApplicationFrameworkValueProvider : InterceptingPropertyValueProviderBase

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/StartupObjectsEnumProvider.cs
@@ -65,7 +65,7 @@ internal sealed class StartupObjectsEnumProvider([Import(typeof(VisualStudioWork
 
             IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();
 
-            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, searchForEntryPointsInFormsOnly);
+            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation, searchForEntryPointsInFormsOnly);
 
             if (entryPoints is not null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -5,14 +5,16 @@ using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
-using Project = Microsoft.CodeAnalysis.Project;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic;
 
+/// <summary>
+/// Returns the set of splash screen forms in a project.
+/// </summary>
 [ExportDynamicEnumValuesProvider("SplashScreenEnumProvider")]
 [AppliesTo(ProjectCapability.VisualBasic)]
 [method: ImportingConstructor]
-internal class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties propertiesProvider) : IDynamicEnumValuesProvider
+internal sealed class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties propertiesProvider) : IDynamicEnumValuesProvider
 {
     public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
     {
@@ -27,10 +29,10 @@ internal class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] 
             && bool.TryParse(pair.Value, out bool optionValue)
             && optionValue) ?? false;
 
-        return Task.FromResult<IDynamicEnumValuesGenerator>(new SplashScreenEnumGenerator(workspace, unconfiguredProject, propertiesProvider, includeEmptyValue, true));
+        return Task.FromResult<IDynamicEnumValuesGenerator>(new SplashScreenEnumGenerator(workspace, unconfiguredProject, propertiesProvider, includeEmptyValue, searchForEntryPointsInFormsOnly: true));
     }
 
-    internal class SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties properties, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly) : IDynamicEnumValuesGenerator
+    private sealed class SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties properties, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly) : IDynamicEnumValuesGenerator
     {
         public bool AllowCustomValues => false;
 
@@ -55,7 +57,7 @@ internal class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] 
 
             if (includeEmptyValue)
             {
-                enumValues.Add(new PageEnumValue(new EnumValue { Name = string.Empty, DisplayName = VSResources.StartupObjectNotSet }));
+                enumValues.Add(new PageEnumValue(new EnumValue { Name = "", DisplayName = VSResources.StartupObjectNotSet }));
             }
 
             IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -11,22 +11,9 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic;
 
 [ExportDynamicEnumValuesProvider("SplashScreenEnumProvider")]
 [AppliesTo(ProjectCapability.VisualBasic)]
-internal class SplashScreenEnumProvider : IDynamicEnumValuesProvider
+[method: ImportingConstructor]
+internal class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties propertiesProvider) : IDynamicEnumValuesProvider
 {
-    private readonly Workspace _workspace;
-    private readonly UnconfiguredProject _unconfiguredProject;
-    private readonly ProjectProperties _properties;
-
-    [ImportingConstructor]
-    public SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace,
-                                    UnconfiguredProject unconfiguredProject,
-                                    ProjectProperties propertiesProvider)
-    {
-        _workspace = workspace;
-        _unconfiguredProject = unconfiguredProject;
-        _properties = propertiesProvider;
-    }
-
     public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
     {
         // We only include a value representing the "not set" state if requested. This is
@@ -40,50 +27,41 @@ internal class SplashScreenEnumProvider : IDynamicEnumValuesProvider
             && bool.TryParse(pair.Value, out bool optionValue)
             && optionValue) ?? false;
 
-        return Task.FromResult<IDynamicEnumValuesGenerator>(new SplashScreenEnumGenerator(_workspace, _unconfiguredProject, _properties, includeEmptyValue, true));
+        return Task.FromResult<IDynamicEnumValuesGenerator>(new SplashScreenEnumGenerator(workspace, unconfiguredProject, propertiesProvider, includeEmptyValue, true));
     }
 
-    internal class SplashScreenEnumGenerator : IDynamicEnumValuesGenerator
+    internal class SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties properties, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly) : IDynamicEnumValuesGenerator
     {
         public bool AllowCustomValues => false;
-        private readonly Workspace _workspace;
-        private readonly UnconfiguredProject _unconfiguredProject;
-        private readonly ProjectProperties _properties;
-        private readonly bool _includeEmptyValue;
-        private readonly bool _searchForEntryPointsInFormsOnly;
-
-        public SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties properties, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly)
-        {
-            _workspace = workspace;
-            _unconfiguredProject = unconfiguredProject;
-            _properties = properties;
-            _includeEmptyValue = includeEmptyValue;
-            _searchForEntryPointsInFormsOnly = searchForEntryPointsInFormsOnly;
-        }
 
         public async Task<ICollection<IEnumValue>> GetListedValuesAsync()
         {
-            Project? project = _workspace.CurrentSolution.Projects.FirstOrDefault(p => PathHelper.IsSamePath(p.FilePath!, _unconfiguredProject.FullPath));
+            Project? project = workspace.CurrentSolution.Projects.FirstOrDefault(p => PathHelper.IsSamePath(p.FilePath!, unconfiguredProject.FullPath));
+
             if (project is null)
             {
-                return Array.Empty<IEnumValue>();
+                return [];
             }
 
             Compilation? compilation = await project.GetCompilationAsync();
+
             if (compilation is null)
             {
                 // Project does not support compilations
-                return Array.Empty<IEnumValue>();
+                return [];
             }
 
-            List<IEnumValue> enumValues = new();
-            if (_includeEmptyValue)
+            List<IEnumValue> enumValues = [];
+
+            if (includeEmptyValue)
             {
                 enumValues.Add(new PageEnumValue(new EnumValue { Name = string.Empty, DisplayName = VSResources.StartupObjectNotSet }));
             }
 
             IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();
-            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, _searchForEntryPointsInFormsOnly);
+
+            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, searchForEntryPointsInFormsOnly);
+
             if (entryPoints is not null)
             {
                 enumValues.AddRange(entryPoints.Select(ep =>
@@ -97,7 +75,8 @@ internal class SplashScreenEnumProvider : IDynamicEnumValuesProvider
             }
 
             // Remove selected startup object (if any) from the list, as a user should not be able to select it again.
-            ConfigurationGeneral configuration = await _properties.GetConfigurationGeneralPropertiesAsync();
+            ConfigurationGeneral configuration = await properties.GetConfigurationGeneralPropertiesAsync();
+
             object? startupObjectObject = await configuration.StartupObject.GetValueAsync();
 
             if (startupObjectObject is string { Length: > 0 } startupObject)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -62,7 +62,7 @@ internal sealed class SplashScreenEnumProvider([Import(typeof(VisualStudioWorksp
 
             IEntryPointFinderService? entryPointFinderService = project.Services.GetService<IEntryPointFinderService>();
 
-            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation.GlobalNamespace, searchForEntryPointsInFormsOnly);
+            IEnumerable<INamedTypeSymbol>? entryPoints = entryPointFinderService?.FindEntryPoints(compilation, searchForEntryPointsInFormsOnly);
 
             if (entryPoints is not null)
             {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsQueryVersionProviderExport.cs
@@ -36,7 +36,7 @@ internal class LaunchSettingsQueryVersionProviderExport : OnceInitializedOnceDis
     /// <summary>
     /// The set of change notification observers.
     /// </summary>
-    private ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>> _observers = ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>>.Empty;
+    private ImmutableHashSet<IObserver<QueryDataSourceChangeNotification>> _observers = [];
     /// <remarks>
     /// Used to keep track of whether or not a new subscriber has received its initial snapshot.
     /// </remarks>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsTracker.cs
@@ -56,11 +56,8 @@ internal class LaunchSettingsTracker : IProjectDynamicLoadComponent
 
     public Task UnloadAsync()
     {
-        if (_launchSettingsProviderLink is not null)
-        {
-            _launchSettingsProviderLink.Dispose();
-            _launchSettingsProviderLink = null;
-        }
+        _launchSettingsProviderLink?.Dispose();
+        _launchSettingsProviderLink = null;
 
         _versionProvider.OnLaunchSettingsTrackerDeactivated(this);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/ProjectLaunchProfileHandler.cs
@@ -90,7 +90,7 @@ internal class ProjectLaunchProfileHandler : IProjectLaunchProfileHandler
             return createLaunchProfileValues(launchSettings);
         }
 
-        return Enumerable.Empty<IEntityValue>();
+        return [];
 
         IEnumerable<IEntityValue> createLaunchProfileValues(ILaunchSettings launchSettings)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/LaunchProfileTypeDataProvider.cs
@@ -59,7 +59,7 @@ internal class LaunchProfileTypeFromProjectDataProducer : QueryDataFromProviderS
             return createLaunchProfileTypeValues();
         }
 
-        return Enumerable.Empty<IEntityValue>();
+        return [];
 
         IEnumerable<IEntityValue> createLaunchProfileTypeValues()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/PropertyPageDataProducer.cs
@@ -107,7 +107,7 @@ internal static class PropertyPageDataProducer
             return createPropertyPageValues();
         }
 
-        return Enumerable.Empty<IEntityValue>();
+        return [];
 
         IEnumerable<IEntityValue> createPropertyPageValues()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducer.cs
@@ -37,7 +37,7 @@ internal static class SupportedValueDataProducer
             return createSupportedValues(enumValues);
         }
 
-        return Enumerable.Empty<IEntityValue>();
+        return [];
 
         IEnumerable<IEntityValue> createSupportedValues(ReadOnlyCollection<ProjectSystem.Properties.IEnumValue> enumValues)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducer.cs
@@ -51,7 +51,7 @@ internal static class UIPropertyEditorDataProducer
             return createEditorValues();
         }
 
-        return Enumerable.Empty<IEntityValue>();
+        return [];
 
         IEnumerable<IEntityValue> createEditorValues()
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/PropertyPages/UIPropertyValueDataProducer.cs
@@ -21,7 +21,7 @@ internal static class UIPropertyValueDataProducer
 
         var identity = new EntityIdentity(
             ((IEntityWithId)parent).Id,
-            Enumerable.Empty<KeyValuePair<string, string>>());
+            []);
 
         return await CreateUIPropertyValueValueAsync(parent.EntityRuntime, identity, configuration, property, requestedProperties);
     }
@@ -99,7 +99,7 @@ internal static class UIPropertyValueDataProducer
             }
             else
             {
-                configurations = Enumerable.Empty<ProjectConfiguration>();
+                configurations = [];
             }
         }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Refactor/VisualStudioRefactorNotifyService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Refactor/VisualStudioRefactorNotifyService.cs
@@ -38,7 +38,7 @@ internal class VisualStudioRefactorNotifyService : IRefactorNotifyService
         refactorNotify.OnBeforeGlobalSymbolRenamed(cItemsAffected: (uint)ids.Length,
                                                    rgItemsAffected: ids,
                                                    cRQNames: 1,
-                                                   rglpszRQName: new[] { rqName },
+                                                   rglpszRQName: [rqName],
                                                    lpszNewName: newName,
                                                    promptContinueOnFail: 1);
     }
@@ -61,7 +61,7 @@ internal class VisualStudioRefactorNotifyService : IRefactorNotifyService
         refactorNotify.OnGlobalSymbolRenamed(cItemsAffected: (uint)ids.Length,
                                              rgItemsAffected: ids,
                                              cRQNames: 1,
-                                             rglpszRQName: new[] { rqName },
+                                             rglpszRQName: [rqName],
                                              lpszNewName: newName);
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputSnapshot.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputSnapshot.cs
@@ -9,7 +9,7 @@ internal class DesignTimeInputSnapshot
     public static readonly DesignTimeInputSnapshot Empty = new(
         EmptyCollections.OrdinalStringSet,
         EmptyCollections.OrdinalStringSet,
-        Enumerable.Empty<DesignTimeInputFileChange>(), string.Empty);
+        [], string.Empty);
 
     public DesignTimeInputSnapshot(ImmutableHashSet<string> inputs, ImmutableHashSet<string> sharedInputs, IEnumerable<DesignTimeInputFileChange> changedInputs, string tempPEOutputPath)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/TargetFrameworkContentCache.cs
@@ -26,7 +26,7 @@ internal sealed class TargetFrameworkContentCache : ITargetFrameworkContentCache
             }
             catch
             {
-                return ImmutableArray<FrameworkReferenceAssemblyItem>.Empty;
+                return [];
             }
 
             ImmutableArray<FrameworkReferenceAssemblyItem>.Builder results = ImmutableArray.CreateBuilder<FrameworkReferenceAssemblyItem>();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.Subscription.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.Subscription.cs
@@ -51,7 +51,7 @@ internal sealed partial class BuildUpToDateCheck
         /// </summary>
         private IDisposable? _link;
 
-        private ImmutableArray<ProjectConfiguration> _lastCheckedConfigurations = ImmutableArray<ProjectConfiguration>.Empty;
+        private ImmutableArray<ProjectConfiguration> _lastCheckedConfigurations = [];
 
         /// <summary>
         /// Cancelled when this instance is disposed.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckImplicitConfiguredInput.cs
@@ -441,7 +441,7 @@ internal sealed class UpToDateCheckImplicitConfiguredInput
 
         DateTime? lastItemsChangedAtUtc = LastItemsChangedAtUtc;
 
-        if (itemHash != ItemHash && ItemHash != null)
+        if (itemHash != ItemHash && ItemHash is not null)
         {
             // The set of items has changed.
             // For the case that the project loaded and no hash was available, do not touch lastItemsChangedAtUtc.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WPF/AppDotXamlDocument.cs
@@ -38,7 +38,7 @@ internal class AppDotXamlDocument : AppDotXamlDocument.IDebugLockCheck, AppDotXa
     private const char SingleQuote = '\'';
     private const char DoubleQuote = '"';
 
-    private static readonly char[] s_closingAngleBracketHelperCharacters = new[] { SingleQuote, DoubleQuote, '/', '>' };
+    private static readonly char[] s_closingAngleBracketHelperCharacters = [SingleQuote, DoubleQuote, '/', '>'];
 
     private readonly IVsTextLines _vsTextLines;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/WindowsForms/WindowsFormsEditorProvider.cs
@@ -17,13 +17,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 [Order(Order.BeforeDefault)] // Need to run before CPS's version before its deleted
 internal partial class WindowsFormsEditorProvider : IProjectSpecificEditorProvider
 {
-    private static readonly SubTypeDescriptor[] s_subTypeDescriptors = new[]
-    {
+    private static readonly SubTypeDescriptor[] s_subTypeDescriptors =
+    [
         new SubTypeDescriptor("Form",           VSResources.WindowsFormEditor_DisplayName, useDesignerByDefault: true),
         new SubTypeDescriptor("Designer",       VSResources.WindowsFormEditor_DisplayName, useDesignerByDefault: true),
         new SubTypeDescriptor("UserControl",    VSResources.UserControlEditor_DisplayName, useDesignerByDefault: true),
         new SubTypeDescriptor("Component",      VSResources.ComponentEditor_DisplayName,   useDesignerByDefault: false)
-    };
+    ];
 
     private readonly UnconfiguredProject _project;
     private readonly IProjectAsynchronousTasksService _projectAsynchronousTasksService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/WPF/Converters/Converters.LambdaMultiConverter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/WPF/Converters/Converters.LambdaMultiConverter.cs
@@ -56,10 +56,10 @@ internal static partial class Converters
             if (_convertBack is not null && value is TTo to)
             {
                 var values = _convertBack(to);
-                return new object[] { values.Item1, values.Item2 };
+                return [values.Item1, values.Item2];
             }
 
-            return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
+            return [DependencyProperty.UnsetValue, DependencyProperty.UnsetValue];
         }
     }
 
@@ -108,10 +108,10 @@ internal static partial class Converters
             if (_convertBack is not null && value is TTo to)
             {
                 var values = _convertBack(to);
-                return new object[] { values.Item1, values.Item2, values.Item3 };
+                return [values.Item1, values.Item2, values.Item3];
             }
 
-            return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
+            return [DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue];
         }
     }
 
@@ -161,10 +161,10 @@ internal static partial class Converters
             if (_convertBack is not null && value is TTo to)
             {
                 var values = _convertBack(to);
-                return new object[] { values.Item1, values.Item2, values.Item3, values.Item4 };
+                return [values.Item1, values.Item2, values.Item3, values.Item4];
             }
 
-            return new[] { DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue };
+            return [DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue, DependencyProperty.UnsetValue];
         }
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/WPF/Converters/Converters.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/WPF/Converters/Converters.cs
@@ -50,7 +50,7 @@ internal static partial class Converters
 {
     private const string DimensionSeparator = " & ";
 
-    public static ImmutableArray<string> ImmutableStringArray => ImmutableArray<string>.Empty;
+    public static ImmutableArray<string> ImmutableStringArray => [];
 
     public static IMultiValueConverter DimensionNames { get; } = new LambdaMultiConverter<ImmutableDictionary<string, string>, ImmutableArray<string>, string>(GetDimensionNames);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Annotations.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Annotations.cs
@@ -97,7 +97,7 @@ internal sealed class MemberNotNullAttribute : Attribute
     /// <param name="member">
     /// The field or property member that is promised to be not-null.
     /// </param>
-    public MemberNotNullAttribute(string member) => Members = new[] { member };
+    public MemberNotNullAttribute(string member) => Members = [member];
 
     /// <summary>Initializes the attribute with the list of field and property members.</summary>
     /// <param name="members">
@@ -123,7 +123,7 @@ internal sealed class MemberNotNullWhenAttribute : Attribute
     public MemberNotNullWhenAttribute(bool returnValue, string member)
     {
         ReturnValue = returnValue;
-        Members = new[] { member };
+        Members = [member];
     }
 
     /// <summary>Initializes the attribute with the specified return value condition and list of field and property members.</summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Collections/ImmutableStringHashSet.cs
@@ -6,7 +6,7 @@ namespace System.Collections.Immutable;
 
 internal static class ImmutableStringHashSet
 {
-    public static readonly ImmutableHashSet<string> EmptyOrdinal = ImmutableHashSet<string>.Empty;
+    public static readonly ImmutableHashSet<string> EmptyOrdinal = [];
 
     public static readonly ImmutableHashSet<string> EmptyOrdinalIgnoreCase = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Delimiter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Delimiter.cs
@@ -10,23 +10,23 @@ internal static class Delimiter
     /// <summary>
     /// Single, static instance of an array that contains a semi-colon ';', which is used to split strings, etc.
     /// </summary>
-    internal static readonly char[] Semicolon = new char[] { ';' };
+    internal static readonly char[] Semicolon = [';'];
 
     /// <summary>
     /// Single, static instance of an array that contains a period '.', which is used to split strings, etc.
     /// </summary>
-    internal static readonly char[] Period = new char[] { '.' };
+    internal static readonly char[] Period = ['.'];
 
     /// <summary>
     /// Single, static instance of an array that contains '+' and '-' characters.
     /// </summary>
-    internal static readonly char[] PlusAndMinus = new char[] { '+', '-' };
+    internal static readonly char[] PlusAndMinus = ['+', '-'];
 
     /// <summary>
     /// Single, static instance of an array that contains platform-specific path separators
     /// </summary>
-    internal static readonly char[] Path = new char[]
-    {
+    internal static readonly char[] Path =
+    [
         System.IO.Path.DirectorySeparatorChar, System.IO.Path.AltDirectorySeparatorChar
-    };
+    ];
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ImmutableCollectionLinqExtensions.cs
@@ -67,7 +67,7 @@ internal static class ImmutableCollectionLinqExtensions
     {
         if (dictionary.Count == 0)
         {
-            return ImmutableArray<TOutput>.Empty;
+            return [];
         }
 
         ImmutableArray<TOutput>.Builder builder = ImmutableArray.CreateBuilder<TOutput>(initialCapacity: dictionary.Count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/PooledObjects/PooledArray.cs
@@ -170,7 +170,7 @@ internal sealed partial class PooledArray<T> : IReadOnlyCollection<T>, IReadOnly
     {
         if (Count == 0)
         {
-            return ImmutableArray<U>.Empty;
+            return [];
         }
 
         var tmp = PooledArray<U>.GetInstance(Count);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyTriggeredBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/ImplicitlyTriggeredBuildManager.cs
@@ -18,14 +18,14 @@ internal sealed partial class ImplicitlyTriggeredBuildManager :
 #pragma warning restore CS0618 // Type or member is obsolete
 {
     private bool _isImplicitlyTriggeredBuild;
-    private ImmutableArray<string> _startupProjectFullPaths = ImmutableArray<string>.Empty;
+    private ImmutableArray<string> _startupProjectFullPaths = [];
 
     public bool IsImplicitlyTriggeredBuild => _isImplicitlyTriggeredBuild;
 
     public ImmutableArray<string> StartupProjectFullPaths => _startupProjectFullPaths;
 
     public void OnBuildStart()
-        => OnBuildStart(ImmutableArray<string>.Empty);
+        => OnBuildStart([]);
 
     public void OnBuildStart(ImmutableArray<string> startupProjectFullPaths)
     {
@@ -36,6 +36,6 @@ internal sealed partial class ImplicitlyTriggeredBuildManager :
     public void OnBuildEndOrCancel()
     {
         _isImplicitlyTriggeredBuild = false;
-        _startupProjectFullPaths = ImmutableArray<string>.Empty;
+        _startupProjectFullPaths = [];
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishItemsOutputGroupProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Build/PublishItemsOutputGroupProvider.cs
@@ -47,7 +47,7 @@ internal class PublishItemsOutputGroupProvider : IOutputGroupProvider
 
             return hasPublishItemsTarget
                 ? s_outputGroups
-                : ImmutableHashSet<IOutputGroup>.Empty;
+                : [];
         }
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Configuration/BaseProjectConfigurationDimensionProvider.cs
@@ -67,7 +67,7 @@ internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConf
 
         if (Strings.IsNullOrEmpty(propertyValue))
         {
-            return ImmutableArray<string>.Empty;
+            return [];
         }
         else
         {
@@ -92,7 +92,7 @@ internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConf
         ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project);
         if (values.IsEmpty)
         {
-            return Enumerable.Empty<KeyValuePair<string, string>>();
+            return [];
         }
         else
         {
@@ -118,7 +118,7 @@ internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConf
         ImmutableArray<string> values = await GetOrderedPropertyValuesAsync(project);
         if (values.IsEmpty)
         {
-            return Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+            return [];
         }
         else
         {
@@ -140,7 +140,7 @@ internal abstract class BaseProjectConfigurationDimensionProvider : IProjectConf
         if (defaultValue is not null)
             return new[] { new KeyValuePair<string, string>(DimensionName, defaultValue) };
 
-        return Enumerable.Empty<KeyValuePair<string, string>>();
+        return [];
     }
 
     /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfile.cs
@@ -149,10 +149,10 @@ internal class LaunchProfile : ILaunchProfile2, IPersistOption
         DoNotPersist = doNotPersist;
 
         EnvironmentVariables = environmentVariables.IsDefault
-            ? ImmutableArray<(string Key, string Value)>.Empty
+            ? []
             : environmentVariables;
         OtherSettings = otherSettings.IsDefault
-            ? ImmutableArray<(string Key, object Value)>.Empty
+            ? []
             : otherSettings;
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchProfileExtensions.cs
@@ -166,7 +166,7 @@ internal static class LaunchProfileExtensions
         return profile switch
         {
             ILaunchProfile2 launchProfile => launchProfile.EnvironmentVariables,
-            ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => Enumerable.Empty<(string Key, string Value)>(),
+            ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => [],
             ILaunchProfile { EnvironmentVariables: { } vars } => vars.OrderBy(pair => pair.Key, StringComparers.EnvironmentVariableNames).Select(pair => (pair.Key, pair.Value))
         };
     }
@@ -193,7 +193,7 @@ internal static class LaunchProfileExtensions
         return profile switch
         {
             ILaunchProfile2 launchProfile => launchProfile.OtherSettings,
-            ILaunchProfile { OtherSettings: null or { Count: 0 } } => Enumerable.Empty<(string Key, object Value)>(),
+            ILaunchProfile { OtherSettings: null or { Count: 0 } } => [],
             ILaunchProfile { OtherSettings: { } settings } => settings.OrderBy(pair => pair.Key, StringComparers.LaunchProfileProperties).Select(pair => (pair.Key, pair.Value))
         };
     }
@@ -257,7 +257,7 @@ internal static class LaunchProfileExtensions
         return profile switch
         {
             ILaunchProfile2 launchProfile => launchProfile.EnvironmentVariables,
-            ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => ImmutableArray<(string Key, string Value)>.Empty,
+            ILaunchProfile { EnvironmentVariables: null or { Count: 0 } } => [],
             ILaunchProfile { EnvironmentVariables: { } vars } => vars.OrderBy(pair => pair.Key, StringComparers.EnvironmentVariableNames).Select(pair => (pair.Key, pair.Value)).ToImmutableArray()
         };
     }
@@ -284,7 +284,7 @@ internal static class LaunchProfileExtensions
         return profile switch
         {
             ILaunchProfile2 launchProfile => launchProfile.OtherSettings,
-            ILaunchProfile { OtherSettings: null or { Count: 0 } } => ImmutableArray<(string Key, object Value)>.Empty,
+            ILaunchProfile { OtherSettings: null or { Count: 0 } } => [],
             ILaunchProfile { OtherSettings: { } vars } => vars.OrderBy(pair => pair.Key, StringComparers.EnvironmentVariableNames).Select(pair => (pair.Key, pair.Value)).ToImmutableArray()
         };
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsJsonEncoding.cs
@@ -217,8 +217,8 @@ internal static class LaunchSettingsJsonEncoding
         });
 
         return (
-            profiles?.ToImmutable() ?? ImmutableArray<LaunchProfile>.Empty,
-            otherSettings?.ToImmutable() ?? ImmutableArray<(string Name, object Value)>.Empty);
+            profiles?.ToImmutable() ?? [],
+            otherSettings?.ToImmutable() ?? []);
 
         LaunchProfile ReadProfile(string name)
         {
@@ -228,7 +228,7 @@ internal static class LaunchSettingsJsonEncoding
             string? workingDirectory = null;
             bool launchBrowser = false;
             string? launchUrl = null;
-            ImmutableArray<(string Name, string Value)> environmentVariables = ImmutableArray<(string Name, string Value)>.Empty;
+            ImmutableArray<(string Name, string Value)> environmentVariables = [];
             ImmutableArray<(string Name, object Value)>.Builder? otherSettings = null;
 
             ReadObject(property =>
@@ -292,7 +292,7 @@ internal static class LaunchSettingsJsonEncoding
                 launchBrowser: launchBrowser,
                 launchUrl: launchUrl,
                 environmentVariables: environmentVariables,
-                otherSettings: otherSettings?.ToImmutable() ?? ImmutableArray<(string Name, object Value)>.Empty);
+                otherSettings: otherSettings?.ToImmutable() ?? []);
         }
 
         object? ReadCustomProfileSetting(string propertyName)
@@ -360,7 +360,7 @@ internal static class LaunchSettingsJsonEncoding
                 builder.Add((property, ReadString()));
             });
 
-            return builder?.ToImmutable() ?? ImmutableArray<(string Name, string Value)>.Empty;
+            return builder?.ToImmutable() ?? [];
         }
 
         string ReadString()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -609,31 +609,19 @@ internal class LaunchSettingsProvider : ProjectValueDataSourceBase<ILaunchSettin
                 _project,
                 severity: ProjectFaultSeverity.Recoverable);
 
-            if (FileChangeScheduler is not null)
-            {
-                FileChangeScheduler.Dispose();
-                FileChangeScheduler = null;
-            }
+            FileChangeScheduler?.Dispose();
+            FileChangeScheduler = null;
 
             _sequentialTaskQueue.Dispose();
-
-            if (_versionedBroadcastBlock is not null)
-            {
-                _versionedBroadcastBlock.Complete();
-                _versionedBroadcastBlock = null;
-            }
-
-            if (_broadcastBlock is not null)
-            {
-                _broadcastBlock.Complete();
-                _broadcastBlock = null;
-            }
-
-            if (_projectRuleSubscriptionLink is not null)
-            {
-                _projectRuleSubscriptionLink.Dispose();
-                _projectRuleSubscriptionLink = null;
-            }
+            
+            _versionedBroadcastBlock?.Complete();
+            _versionedBroadcastBlock = null;
+            
+            _broadcastBlock?.Complete();
+            _broadcastBlock = null;
+            
+            _projectRuleSubscriptionLink?.Dispose();
+            _projectRuleSubscriptionLink = null;
 
             _firstSnapshotCompletionSource.TrySetCanceled();
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -230,7 +230,6 @@ internal class LaunchSettingsProvider : ProjectValueDataSourceBase<ILaunchSettin
             _commonProjectServices.ThreadingService,
             _projectServices.ProjectAsynchronousTasks.UnloadCancellationToken);
 
-
         // establish the file watcher. We don't need wait this, because files can be changed in the system anyway, so blocking our process
         // doesn't provide real benefit. It is of course possible that the file is changed before the watcher is established. To eliminate this
         // gap, we can recheck file after the watcher is established. I will skip this for now.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValue.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValue.cs
@@ -25,8 +25,5 @@ internal interface IActiveConfiguredValue<T>
     ///     Gets the value from the active <see cref="ConfiguredProject"/>; otherwise,
     ///     <see langword="null"/> if it does not exist.
     /// </summary>
-    public T Value
-    {
-        get;
-    }
+    T Value { get; }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValues.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredValues.cs
@@ -12,8 +12,5 @@ internal interface IActiveConfiguredValues<T>
     /// <summary>
     ///     Gets the applicable values from the active <see cref="ConfiguredProject"/>.
     /// </summary>
-    public IEnumerable<Lazy<T>> Values
-    {
-        get;
-    }
+    IEnumerable<Lazy<T>> Values { get; }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/ProjectCommandAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Input/ProjectCommandAttribute.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Input;
 internal class ProjectCommandAttribute : ExportAttribute
 {
     public ProjectCommandAttribute(string group, long commandId)
-        : this(group, new long[] { commandId })
+        : this(group, [commandId])
     {
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveEditorContextTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/ActiveEditorContextTracker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 [AppliesTo(ProjectCapability.DotNetLanguageService)]
 internal class ActiveEditorContextTracker : IActiveEditorContextTracker
 {
-    private ImmutableList<string> _contexts = ImmutableList<string>.Empty;
+    private ImmutableList<string> _contexts = [];
     private string? _activeIntellisenseProjectContext;
 
     // UnconfiguredProject is only included for scoping reasons.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpBuildOptions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/LanguageServices/FSharp/FSharpBuildOptions.cs
@@ -11,7 +11,7 @@ internal class FSharpBuildOptions : BuildOptions
                               ImmutableArray<CommandLineReference> metadataReferences,
                               ImmutableArray<CommandLineAnalyzerReference> analyzerReferences,
                               ImmutableArray<string> compileOptions)
-        : base(sourceFiles, additionalFiles, metadataReferences, analyzerReferences, ImmutableArray<string>.Empty)
+        : base(sourceFiles, additionalFiles, metadataReferences, analyzerReferences, [])
     {
         CompileOptions = compileOptions;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
@@ -101,7 +101,7 @@ internal partial class PackageRestoreDataSource : ChainedProjectValueDataSourceB
         // Check if out of date to prevent extra restore under some conditions.
         if (!_enabled || e.Value.RestoreInfo is null || IsRestoreDataVersionOutOfDate(e.DataSourceVersions) || IsProjectConfigurationVersionOutOfDate(e.Value.ConfiguredInputs))
         {
-            return Enumerable.Empty<IProjectVersionedValue<RestoreData>>();
+            return [];
         }
 
         bool succeeded = await RestoreCoreAsync(e.Value);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/Snapshots/RestoreBuilder.cs
@@ -9,8 +9,8 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore;
 /// </summary>
 internal static class RestoreBuilder
 {
-    public static readonly ImmutableArray<TargetFrameworkInfo> EmptyTargetFrameworks = ImmutableArray<TargetFrameworkInfo>.Empty;
-    public static readonly ImmutableArray<ReferenceItem> EmptyReferences = ImmutableArray<ReferenceItem>.Empty;
+    public static readonly ImmutableArray<TargetFrameworkInfo> EmptyTargetFrameworks = [];
+    public static readonly ImmutableArray<ReferenceItem> EmptyReferences = [];
 
     /// <summary>
     ///     Converts an immutable dictionary of rule snapshot data into an <see cref="ProjectRestoreInfo"/> instance.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestKindValueProvider.cs
@@ -25,7 +25,7 @@ internal sealed class ApplicationManifestKindValueProvider : InterceptingPropert
     private const string CustomManifestValue = "CustomManifest";
     private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
 
-    private static readonly string[] s_msBuildPropertyNames = { NoManifestMSBuildProperty, ApplicationManifestMSBuildProperty };
+    private static readonly string[] s_msBuildPropertyNames = [NoManifestMSBuildProperty, ApplicationManifestMSBuildProperty];
     
     [ImportingConstructor]
     public ApplicationManifestKindValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestPathValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ApplicationManifestPathValueProvider.cs
@@ -19,7 +19,7 @@ internal sealed class ApplicationManifestPathValueProvider : InterceptingPropert
     private readonly UnconfiguredProject _unconfiguredProject;
 
     private const string ApplicationManifestMSBuildProperty = "ApplicationManifest";
-    private static readonly string[] s_msBuildPropertyNames = { ApplicationManifestMSBuildProperty };
+    private static readonly string[] s_msBuildPropertyNames = [ApplicationManifestMSBuildProperty];
     
     [ImportingConstructor]
     public ApplicationManifestPathValueProvider(UnconfiguredProject project)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -11,12 +11,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 /// In the case of retrieving the values of those properties, this class looks for the associated properties found in the project's configuration.
 /// </summary>
 [ExportInterceptingPropertyValueProvider(
-    new[]
-    {
+    [
         InterceptedTargetFrameworkProperty,
         TargetPlatformProperty,
         TargetPlatformVersionProperty
-    },
+    ],
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 internal class CompoundTargetFrameworkValueProvider : InterceptingPropertyValueProviderBase
 {
@@ -31,7 +30,7 @@ internal class CompoundTargetFrameworkValueProvider : InterceptingPropertyValueP
     private bool? _useWPFProperty;
     private bool? _useWindowsFormsProperty;
     private bool? _useWinUIProperty;
-    private static readonly string[] s_msBuildPropertyNames = { TargetFrameworkProperty, TargetPlatformProperty, TargetPlatformVersionProperty, SupportedOSPlatformVersionProperty };
+    private static readonly string[] s_msBuildPropertyNames = [TargetFrameworkProperty, TargetPlatformProperty, TargetPlatformVersionProperty, SupportedOSPlatformVersionProperty];
     private static readonly Regex s_versionRegex = new(@"^net(?<version>[0-9.]+)$", RegexOptions.ExplicitCapture);
 
     private struct ComplexTargetFramework

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/ResourceSpecificationKindValueProvider.cs
@@ -14,7 +14,7 @@ internal sealed class ResourceSpecificationKindValueProvider : InterceptingPrope
     internal const string IconAndManifestValue = "IconAndManifest";
     internal const string ResourceFileValue = "ResourceFile";
 
-    private static readonly string[] s_msBuildPropertyNames = { Win32ResourceMSBuildProperty, ApplicationIconMSBuildProperty, ApplicationManifestMSBuildProperty };
+    private static readonly string[] s_msBuildPropertyNames = [Win32ResourceMSBuildProperty, ApplicationIconMSBuildProperty, ApplicationManifestMSBuildProperty];
 
     [ImportingConstructor]
     public ResourceSpecificationKindValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/TargetMultipleFrameworksValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/TargetMultipleFrameworksValueProvider.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 [ExportInterceptingPropertyValueProvider("TargetMultipleFrameworks", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 internal sealed class TargetMultipleFrameworksValueProvider : InterceptingPropertyValueProviderBase
 {
-    private static readonly string[] s_msBuildPropertyNames = { TargetFrameworksProperty, TargetFrameworkProperty};
+    private static readonly string[] s_msBuildPropertyNames = [TargetFrameworksProperty, TargetFrameworkProperty];
     
     public override Task<bool> IsValueDefinedInContextAsync(string propertyName, IProjectProperties defaultProperties)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/WPFValueProvider.cs
@@ -5,11 +5,10 @@ using Microsoft.VisualStudio.ProjectSystem.WPF;
 namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 
 [ExportInterceptingPropertyValueProvider(
-    new[]
-    {
+    [
         StartupURIPropertyName,
         ShutdownModePropertyName
-    },
+    ],
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 [AppliesTo(ProjectCapability.WPF)]
 internal class WPFValueProvider : InterceptingPropertyValueProviderBase

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/GenerateDocumentationFileValueProvider.cs
@@ -9,7 +9,7 @@ internal sealed class GenerateDocumentationFileValueProvider : InterceptingPrope
 
     private const string DocumentationFileMSBuildProperty = "DocumentationFile";
     private const string PublishDocumentationFileMSBuildProperty = "PublishDocumentationFile";
-    private static readonly string[] s_msBuildPropertyNames = { DocumentationFileMSBuildProperty };
+    private static readonly string[] s_msBuildPropertyNames = [DocumentationFileMSBuildProperty];
     
     [ImportingConstructor]
     public GenerateDocumentationFileValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/TreatWarningsAsErrorsValueProvider.cs
@@ -9,7 +9,7 @@ internal sealed class TreatWarningsAsErrorsValueProvider : InterceptingPropertyV
     private const string WarningsNotAsErrorsProperty = "WarningsNotAsErrors";
     private readonly ITemporaryPropertyStorage _temporaryPropertyStorage;
 
-    private static readonly string[] s_msBuildPropertyNames = { WarningsAsErrorsProperty, WarningsNotAsErrorsProperty };
+    private static readonly string[] s_msBuildPropertyNames = [WarningsAsErrorsProperty, WarningsNotAsErrorsProperty];
     
     [ImportingConstructor]
     public TreatWarningsAsErrorsValueProvider(ITemporaryPropertyStorage temporaryPropertyStorage)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningSeverityValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningSeverityValueProvider.cs
@@ -14,7 +14,7 @@ internal sealed class VBWarningSeverityValueProvider : InterceptingPropertyValue
     internal const string DisableAllValue = "DisableAll";
     internal const string AllAsErrorsValue = "AllAsErrors";
 
-    private static readonly string[] s_msBuildPropertyNames = { WarningSeverityPropertyName, WarningLevelPropertyName, TreatWarningsAsErrorsPropertyName };
+    private static readonly string[] s_msBuildPropertyNames = [WarningSeverityPropertyName, WarningLevelPropertyName, TreatWarningsAsErrorsPropertyName];
     
     public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
@@ -20,8 +20,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 /// </para>
 /// </remarks>
 [ExportInterceptingPropertyValueProvider(
-    new[]
-    {
+    [
         ImplicitConversionPropertyName,
         LateBindingPropertyName,
         ImplicitTypePropertyName,
@@ -32,7 +31,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
         InstanceVariableAccessesSharedMemberPropertyName,
         RecursiveOperatorOrPropertyAccessPropertyName,
         DuplicateOrOverlappingCatchBlocksPropertyName
-    },
+    ],
     ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 internal sealed class VBWarningsValueProvider : InterceptingPropertyValueProviderBase
 {
@@ -76,7 +75,7 @@ internal sealed class VBWarningsValueProvider : InterceptingPropertyValueProvide
 
     private const string DiagnosticIdSeparator = ",";
 
-    private static readonly string[] s_diagnosticIdSeparators = new[] { DiagnosticIdSeparator };
+    private static readonly string[] s_diagnosticIdSeparators = [DiagnosticIdSeparator];
 
     public override Task<string> OnGetEvaluatedPropertyValueAsync(string propertyName, string evaluatedPropertyValue, IProjectProperties defaultProperties)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/BuildPropertyPage/VBWarningsValueProvider.cs
@@ -217,7 +217,7 @@ internal sealed class VBWarningsValueProvider : InterceptingPropertyValueProvide
 
     private static ImmutableSortedSet<int> ParseIdList(string idList)
     {
-        ImmutableSortedSet<int> ids = ImmutableSortedSet<int>.Empty;
+        ImmutableSortedSet<int> ids = [];
         string[] idsAsStrings = idList.Split(s_diagnosticIdSeparators, StringSplitOptions.RemoveEmptyEntries);
         foreach (string idString in idsAsStrings)
         {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ExportInterceptingPropertyValueProviderAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ExportInterceptingPropertyValueProviderAttribute.cs
@@ -16,7 +16,7 @@ public sealed class ExportInterceptingPropertyValueProviderAttribute : ExportAtt
     /// class for a single intercepted property.
     /// </summary>
     public ExportInterceptingPropertyValueProviderAttribute(string propertyName, ExportInterceptingPropertyValueProviderFile file)
-        : this(new[] { propertyName }, file)
+        : this([propertyName], file)
     {
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/InterceptingPropertyValueProviderBase.cs
@@ -25,7 +25,7 @@ public abstract class InterceptingPropertyValueProviderBase : IInterceptingPrope
 
     public virtual Task<bool> IsValueDefinedInContextAsync(string propertyName, IProjectProperties defaultProperties)
     {
-        return IsValueDefinedInContextMSBuildPropertiesAsync(defaultProperties, new[]{ propertyName });
+        return IsValueDefinedInContextMSBuildPropertiesAsync(defaultProperties, [propertyName]);
     }
 
     internal static async Task<bool> IsValueDefinedInContextMSBuildPropertiesAsync(IProjectProperties defaultProperties, string[] msBuildPropertyNames)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ExportLaunchProfileExtensionValueProviderAttribute.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ExportLaunchProfileExtensionValueProviderAttribute.cs
@@ -16,7 +16,7 @@ public sealed class ExportLaunchProfileExtensionValueProviderAttribute : ExportA
     /// class for a single intercepted property.
     /// </summary>
     public ExportLaunchProfileExtensionValueProviderAttribute(string propertyName, ExportLaunchProfileExtensionValueProviderScope scope)
-        : this(new[] { propertyName }, scope)
+        : this([propertyName], scope)
     {
     }
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
@@ -142,7 +142,7 @@ internal class LaunchProfileProjectItemProvider : IProjectItemProvider
 
         return snapshot.Profiles.Count > 0
             ? s_itemTypes
-            : ImmutableSortedSet<string>.Empty;
+            : [];
     }
 
     public async Task<IProjectItem?> GetItemAsync(IProjectPropertiesContext context)
@@ -163,7 +163,7 @@ internal class LaunchProfileProjectItemProvider : IProjectItemProvider
 
         if (snapshot.Profiles.Count == 0)
         {
-            return Enumerable.Empty<IProjectItem>();
+            return [];
         }
 
         return snapshot.Profiles.Select(p => new ProjectItem(p.Name ?? string.Empty, _project.FullPath, this));

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectItemProvider.cs
@@ -247,13 +247,11 @@ internal class LaunchProfileProjectItemProvider : IProjectItemProvider
     private class ProjectItem : IProjectItem
     {
         private readonly string _name;
-        private readonly string _projectFilePath;
         private readonly LaunchProfileProjectItemProvider _provider;
 
         public ProjectItem(string name, string projectFilePath, LaunchProfileProjectItemProvider provider)
         {
             _name = name;
-            _projectFilePath = projectFilePath;
             _provider = provider;
 
             PropertiesContext = new ProjectPropertiesContext(name, projectFilePath);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
@@ -29,8 +29,8 @@ internal class LaunchProfileProjectProperties : IProjectProperties, IRuleAwarePr
     /// and as such they are always considered to exist on the profile, though they may
     /// not have a value.
     /// </remarks>
-    private static readonly string[] s_standardPropertyNames = new[]
-    {
+    private static readonly string[] s_standardPropertyNames =
+    [
         CommandNamePropertyName,
         ExecutablePathPropertyName,
         CommandLineArgumentsPropertyName,
@@ -38,7 +38,7 @@ internal class LaunchProfileProjectProperties : IProjectProperties, IRuleAwarePr
         LaunchBrowserPropertyName,
         LaunchUrlPropertyName,
         EnvironmentVariablesPropertyName
-    };
+    ];
 
     private readonly LaunchProfilePropertiesContext _context;
     private readonly ILaunchSettingsProvider3 _launchSettingsProvider;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/LaunchProfileProjectProperties.cs
@@ -130,7 +130,7 @@ internal class LaunchProfileProjectProperties : IProjectProperties, IRuleAwarePr
         ILaunchProfile? profile = snapshot.Profiles.FirstOrDefault(p => StringComparers.LaunchProfileNames.Equals(p.Name, _context.ItemName));
         if (profile is null)
         {
-            return Enumerable.Empty<string>();
+            return [];
         }
         ImmutableDictionary<string, object> globalSettings = snapshot.GlobalSettings;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/LaunchProfiles/ProjectLaunchProfileExtensionValueProvider.cs
@@ -16,8 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 /// </para>
 /// </summary>
 [ExportLaunchProfileExtensionValueProvider(
-    new[]
-    {
+    [
         AuthenticationModePropertyName,
         HotReloadEnabledPropertyName,
         NativeDebuggingPropertyName,
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
         RemoteDebugMachinePropertyName,
         SqlDebuggingPropertyName,
         WebView2DebuggingPropertyName
-    },
+    ],
     ExportLaunchProfileExtensionValueProviderScope.LaunchProfile)]
 internal class ProjectLaunchProfileExtensionValueProvider : ILaunchProfileExtensionValueProvider
 {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SingleRuleSupportedValuesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/SingleRuleSupportedValuesProvider.cs
@@ -14,7 +14,7 @@ internal abstract class SingleRuleSupportedValuesProvider : SupportedValuesProvi
 
     private readonly string _ruleName;
 
-    protected sealed override string[] RuleNames => new string[] { _ruleName };
+    protected sealed override string[] RuleNames => [_ruleName];
 
     protected SingleRuleSupportedValuesProvider(ConfiguredProject project, IProjectSubscriptionService subscriptionService, string ruleName, bool useNoneValue = false) : base(project, subscriptionService)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/VBDiagnosticSeverityEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/VBDiagnosticSeverityEnumProvider.cs
@@ -34,7 +34,7 @@ internal sealed class VBDiagnosticSeverityEnumProvider : SupportedValuesProvider
     private const string WarningValue = "Warning";
     private const string ErrorValue = "Error";
 
-    private static readonly string[] s_ruleNames = new[] { TreatWarningsAsErrorsRuleProvider.RuleName };
+    private static readonly string[] s_ruleNames = [TreatWarningsAsErrorsRuleProvider.RuleName];
 
     private static readonly List<IEnumValue> s_warningsAsErrorsOffEnumList = new()
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/AppDesigner.xaml.cs
@@ -8,5 +8,5 @@ namespace Microsoft.VisualStudio.ProjectSystem;
 [SuppressMessage("Style", "IDE0016:Use 'throw' expression")]
 internal partial class AppDesigner
 {
-    internal static string[] SchemaNameArray = new string[] { SchemaName };
+    internal static string[] SchemaNameArray = [SchemaName];
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Legacy/LegacyDependencySubscriber.cs
@@ -82,7 +82,7 @@ internal sealed class LegacyDependencySubscriber : IDependencySubscriber
                 groupNodeFlags: rootNode.Flags);
 
             _snapshot = ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>>.Empty
-                .Add(_dependencyType, ImmutableArray<IDependency>.Empty);
+                .Add(_dependencyType, []);
         }
 
         public ImmutableDictionary<DependencyGroupType, ImmutableArray<IDependency>> Update(IDependenciesChanges changes)

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/MSBuildDependencies/MSBuildDependencyFactoryBase.cs
@@ -480,7 +480,7 @@ internal abstract class MSBuildDependencyFactoryBase : IMSBuildDependencyFactory
         bool? isImplicitMetadata = buildProperties?.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined);
         isImplicitMetadata ??= evaluationProperties?.GetBoolProperty(ProjectItemMetadata.IsImplicitlyDefined);
 
-        if (isImplicitMetadata != null)
+        if (isImplicitMetadata is not null)
         {
             return isImplicitMetadata.Value;
         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/StringExtensions.cs
@@ -9,7 +9,7 @@ internal static class StringExtensions
         string[] values = value.Split(separator);
 
         if (values.Length == 1 && string.IsNullOrEmpty(values[0]))
-            return Array.Empty<string>();
+            return [];
 
         return values;
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/ProjectSystemHostConfiguration.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Environment/ProjectSystemHostConfiguration.cs
@@ -10,12 +10,12 @@ internal sealed class ProjectSystemHostConfiguration : VisualStudioHostConfigura
 {
     // This combined with TestBase.IncludeReferencedAssembliesInHostComposition set to false, deliberately limit
     // the number of assemblies added to the composition to reduce MEF composition errors in the build log.
-    internal static readonly string[] CompositionAssemblyPaths = new[] {
+    internal static readonly string[] CompositionAssemblyPaths = [
                 typeof(VisualStudioHostConfiguration).Assembly.Location,        // Microsoft.Test.Apex.VisualStudio
                 typeof(HostConfiguration).Assembly.Location,                    // Microsoft.Test.Apex.Framework
                 typeof(ProjectSystemHostConfiguration).Assembly.Location,       // This assembly
                 typeof(OmniLogSink).Assembly.Location,                          // Omni
-                };
+                ];
 
     public ProjectSystemHostConfiguration()
     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
@@ -20,7 +20,7 @@ public abstract class ProjectLayoutTestBase : IntegrationTestBase
     /// Paths of temporary workspaces to delete when the test fixture completes.
     /// Each path is a root, so should be deleted recursively.
     /// </summary>
-    private ImmutableList<string> _rootPaths = ImmutableList<string>.Empty;
+    private ImmutableList<string> _rootPaths = [];
 
     /// <summary>
     /// Verifies that the "Dependencies" node of <paramref name="project"/> has a structure that

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/ProjectLayoutTestBase.cs
@@ -90,13 +90,13 @@ public abstract class ProjectLayoutTestBase : IntegrationTestBase
                 thisSame = false;
             }
 
-            if (actual is not null && expect?.Icon != null && !AssertExtensions.AreEqual(expect.Icon.Value, actual.ExpandedIconMoniker))
+            if (actual is not null && expect?.Icon is not null && !AssertExtensions.AreEqual(expect.Icon.Value, actual.ExpandedIconMoniker))
             {
                 same = false;
                 thisSame = false;
             }
 
-            var actualIcon = actual?.ExpandedIconMoniker == null
+            var actualIcon = actual?.ExpandedIconMoniker is null
                 ? "null"
                 : ImageMonikerDebuggerDisplay.FromImageMoniker(actual.ExpandedIconMoniker.Value.ToImageMoniker());
 
@@ -106,7 +106,7 @@ public abstract class ProjectLayoutTestBase : IntegrationTestBase
                     .Append(' ', depth * 4)
                     .Append(expect.Text ?? actual!.Name)
                     .Append(' ')
-                    .AppendLine(expect.Icon != null
+                    .AppendLine(expect.Icon is not null
                         ? ImageMonikerDebuggerDisplay.FromImageMoniker(expect.Icon.Value)
                         : actualIcon);
             }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Utilities/AssertExtensions.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.IntegrationTests/Utilities/AssertExtensions.cs
@@ -11,7 +11,7 @@ internal static class AssertExtensions
 {
     public static void AreEqual(this Assert assert, ImageMoniker expected, ExportableImageMoniker? actual)
     {
-        if (actual == null)
+        if (actual is null)
         {
             throw new AssertFailedException($"ImageMoniker did not match.{Environment.NewLine}Expected: {S(expected)}{Environment.NewLine}Actual: null");
         }
@@ -33,7 +33,7 @@ internal static class AssertExtensions
 
     public static bool AreEqual(ImageMoniker expected, ExportableImageMoniker? actual)
     {
-        if (actual == null)
+        if (actual is null)
         {
             return false;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices.UnitTests/ProjectSystem/ProjectTreeParserTests.cs
@@ -416,8 +416,8 @@ public class ProjectTreeParserTests
     {
         // Remove the newlines from the start and end of input and expected so that 
         // it makes it easier inside the test to layout the repro.
-        input = input.Trim(new[] { '\n', '\r' });
-        expected = expected.Trim(new[] { '\n', '\r' });
+        input = input.Trim(['\n', '\r']);
+        expected = expected.Trim(['\n', '\r']);
 
         var parser = new ProjectTreeParser(input);
         var writer = new ProjectTreeWriter(parser.Parse(), options | ProjectTreeWriterOptions.Tags);
@@ -429,7 +429,7 @@ public class ProjectTreeParserTests
 
     private static void AssertThrows(string input, ProjectTreeFormatError error)
     {
-        input = input.Trim(new[] { '\n', '\r' });
+        input = input.Trim(['\n', '\r']);
 
         var parser = new ProjectTreeParser(input);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.MutableProjectTree.cs
@@ -203,7 +203,7 @@ internal partial class ProjectTreeParser
             if (filePath is not null)
                 FilePath = filePath;
 
-            if (visible != null)
+            if (visible is not null)
                 Visible = visible.Value;
 
             if (flags is not null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/ProjectTreeParser.cs
@@ -20,7 +20,7 @@ internal partial class ProjectTreeParser
 
     public static IProjectTree Parse(string value)
     {
-        value = value.Trim(new char[] { '\r', '\n' });
+        value = value.Trim(['\r', '\n']);
 
         var parser = new ProjectTreeParser(value);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/Tokenizer.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeParser/Tokenizer.cs
@@ -32,7 +32,7 @@ internal partial class Tokenizer
     public void Skip(TokenType expected)
     {
         Token? token = ReadToken();
-        if (token == null)
+        if (token is null)
         {
             throw FormatException(ProjectTreeFormatError.DelimiterExpected_EncounteredEndOfString, $"Expected '{(char)expected}' but encountered end of string.");
         }
@@ -57,7 +57,7 @@ internal partial class Tokenizer
     public void Close()
     {
         Token? token = ReadToken();
-        if (token != null)
+        if (token is not null)
             throw FormatException(ProjectTreeFormatError.EndOfStringExpected, $"Expected end-of-string, but encountered '{token.Value.Value}'.");
     }
 
@@ -78,7 +78,7 @@ internal partial class Tokenizer
         var identifier = new StringBuilder();
 
         Token? token;
-        while ((token = PeekToken()) != null)
+        while ((token = PeekToken()) is not null)
         {
             Token t = token.Value;
 
@@ -99,7 +99,7 @@ internal partial class Tokenizer
 
         // Are we at the end of the string?
         Token? token = ReadToken();    // Consume token, so "position" is correct
-        if (token == null)
+        if (token is null)
         {
             throw FormatException(ProjectTreeFormatError.IdExpected_EncounteredEndOfString, "Expected identifier, but encountered end-of-string.");
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicityTriggeredBuildStateFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IImplicityTriggeredBuildStateFactory.cs
@@ -12,7 +12,7 @@ internal class IImplicityTriggeredBuildStateFactory
             .Returns(implicitBuild);
 
         mock.SetupGet(state => state.StartupProjectFullPaths)
-            .Returns(startupProjects?.ToImmutableArray() ?? ImmutableArray<string>.Empty);
+            .Returns(startupProjects?.ToImmutableArray() ?? []);
 
         return mock.Object;
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IInterceptingPropertyValueProviderMetadataFactory.cs
@@ -11,7 +11,7 @@ internal static class IInterceptingPropertyValueProviderMetadataFactory
         var mock = new Mock<IInterceptingPropertyValueProviderMetadata2>();
 
         mock.SetupGet(s => s.PropertyNames)
-            .Returns(new[] { propertyName });
+            .Returns([propertyName]);
 
         return mock.Object;
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchProfileExtensionValueProviderMetadataFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchProfileExtensionValueProviderMetadataFactory.cs
@@ -20,6 +20,6 @@ internal static class ILaunchProfileExtensionValueProviderMetadataFactory
 
     public static ILaunchProfileExtensionValueProviderMetadata Create(string propertyName)
     {
-        return Create(new[] { propertyName });
+        return Create([propertyName]);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ILaunchSettingsProviderFactory.cs
@@ -38,7 +38,7 @@ internal static class ILaunchSettingsProviderFactory
 
         var initialLaunchProfiles = launchProfiles is not null
             ? launchProfiles.ToImmutableList()
-            : ImmutableList<ILaunchProfile>.Empty;
+            : [];
 
         var initialGlobalSettings = globalSettings ?? ImmutableDictionary<string, object>.Empty;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
@@ -8,7 +8,7 @@ internal static class IProjectCapabilitiesScopeFactory
 {
     public static IProjectCapabilitiesScope Create(IEnumerable<string>? capabilities = null)
     {
-        capabilities ??= Enumerable.Empty<string>();
+        capabilities ??= [];
         var snapshot = new Mock<IProjectCapabilitiesSnapshot>();
         snapshot.Setup(s => s.IsProjectCapabilityPresent(It.IsAny<string>())).Returns((string capability) => capabilities.Contains(capability));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ImmutableOrderedDictionary.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ImmutableOrderedDictionary.cs
@@ -8,7 +8,7 @@ internal sealed class ImmutableOrderedDictionary<TKey, TValue>
     : IImmutableDictionary<TKey, TValue>,
       IDataWithOriginalSource<KeyValuePair<TKey, TValue>>
 {
-    public static ImmutableOrderedDictionary<TKey, TValue> Empty { get; } = new(Enumerable.Empty<KeyValuePair<TKey, TValue>>());
+    public static ImmutableOrderedDictionary<TKey, TValue> Empty { get; } = new([]);
 
     private readonly Dictionary<TKey, TValue> _dic;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/ActiveConfiguredProjectsLoaderTests.cs
@@ -5,9 +5,9 @@ namespace Microsoft.VisualStudio.ProjectSystem;
 public class ActiveConfiguredProjectsLoaderTests
 {
     [Theory]
-    [InlineData(new object[] { new[] { "Debug|x86" } })]
-    [InlineData(new object[] { new[] { "Debug|x86", "Release|x86" } })]
-    [InlineData(new object[] { new[] { "Debug|x86", "Release|x86", "Release|AnyCPU" } })]
+    [InlineData([new[] { "Debug|x86" }])]
+    [InlineData([new[] { "Debug|x86", "Release|x86" }])]
+    [InlineData([new[] { "Debug|x86", "Release|x86", "Release|AnyCPU" }])]
     public async Task WhenActiveConfigurationChanges_LoadsConfiguredProject(string[] configurationNames)
     {
         var configurationGroups = IConfigurationGroupFactory.CreateFromConfigurationNames(configurationNames);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ImplicitlyActiveDimensionProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Configuration/ImplicitlyActiveDimensionProviderTests.cs
@@ -20,7 +20,7 @@ public class ImplicitlyActiveDimensionProviderTests
     {
         var provider = CreateInstance();
 
-        var result = provider.GetImplicitlyActiveDimensions(Enumerable.Empty<string>());
+        var result = provider.GetImplicitlyActiveDimensions([]);
 
         Assert.Empty(result);
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
@@ -41,7 +41,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.NativeDebuggingProperty, value.Value)));
+            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.NativeDebuggingProperty, value.Value)));
 
         Assert.Equal(expected, data.IsNativeDebuggingEnabled());
     }
@@ -55,7 +55,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.SqlDebuggingProperty, value.Value)));
+            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.SqlDebuggingProperty, value.Value)));
 
         Assert.Equal(expected, data.IsSqlDebuggingEnabled());
     }
@@ -69,7 +69,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value == null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugEnabledProperty, value.Value)));
+            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugEnabledProperty, value.Value)));
 
         Assert.Equal(expected, data.IsRemoteDebugEnabled());
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchProfileExtensionsTests.cs
@@ -41,7 +41,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.NativeDebuggingProperty, value.Value)));
+            otherSettings: value is null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.NativeDebuggingProperty, value.Value)));
 
         Assert.Equal(expected, data.IsNativeDebuggingEnabled());
     }
@@ -55,7 +55,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.SqlDebuggingProperty, value.Value)));
+            otherSettings: value is null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.SqlDebuggingProperty, value.Value)));
 
         Assert.Equal(expected, data.IsSqlDebuggingEnabled());
     }
@@ -69,7 +69,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugEnabledProperty, value.Value)));
+            otherSettings: value is null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugEnabledProperty, value.Value)));
 
         Assert.Equal(expected, data.IsRemoteDebugEnabled());
     }
@@ -83,7 +83,7 @@ public class LaunchProfileExtensionsTests
         var data = new LaunchProfile(
             name: null,
             commandName: null,
-            otherSettings: value is null ? ImmutableArray<(string, object)>.Empty : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugMachineProperty, value)));
+            otherSettings: value is null ? [] : ImmutableArray.Create<(string, object)>((LaunchProfileExtensions.RemoteDebugMachineProperty, value)));
 
         Assert.Equal(expected, data.RemoteDebugMachine());
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/HotReload/ProjectHotReloadSessionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/HotReload/ProjectHotReloadSessionTests.cs
@@ -592,7 +592,7 @@ public class ProjectHotReloadSessionTests
         mockDeltaApplier.Setup(d => d.ApplyUpdatesAsync(It.IsAny<ImmutableArray<ManagedHotReloadUpdate>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(ApplyResult.Success);
         mockDeltaApplier.Setup(d => d.GetCapabilitiesAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ImmutableArray<string>.Empty);
+            .ReturnsAsync([]);
 
         var mockDeltaApplierCreator = new Mock<IManagedDeltaApplierCreator>();
         mockDeltaApplierCreator.Setup(c => c.CreateManagedDeltaApplier(It.IsAny<string>()))

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/AssemblyInfoPropertiesProviderTests.cs
@@ -40,7 +40,7 @@ internal class TestProjectFileOrAssemblyInfoPropertiesProvider : AbstractProject
                 ? new[] { new Lazy<IInterceptingPropertyValueProvider, IInterceptingPropertyValueProviderMetadata2>(
                     () => IInterceptingPropertyValueProviderFactory.Create(),
                     IInterceptingPropertyValueProviderMetadataFactory.Create("TestPropertyName")) }
-                : new[] { interceptingProvider },
+                : [interceptingProvider],
               project: project,
               getActiveProjectId: getActiveProjectId ?? (() => Task.FromResult(workspace.CurrentSolution.ProjectIds.SingleOrDefault())),
               workspace: workspace,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/InterceptedProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/InterceptedProjectPropertiesTests.cs
@@ -18,7 +18,7 @@ public class InterceptedProjectPropertiesTests
         for (int i = 0; i < capabilities.Length; i++)
         {
             var mockProviderMetadata = new Mock<IInterceptingPropertyValueProviderMetadata2>();
-            mockProviderMetadata.Setup(x => x.PropertyNames).Returns(new[] { MockPropertyName });
+            mockProviderMetadata.Setup(x => x.PropertyNames).Returns([MockPropertyName]);
             mockProviderMetadata.Setup(x => x.AppliesTo).Returns(capabilities[i]);
             metadataCollection[i] = mockProviderMetadata.Object;
         }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectItemProviderTests.cs
@@ -316,7 +316,7 @@ public class LaunchProfilesProjectItemProviderTests
     [Fact]
     public async Task WhenAddingMultipleItems_TheReturnedItemsHaveTheCorrectNames()
     {
-        ImmutableList<ILaunchProfile> newProfiles = ImmutableList<ILaunchProfile>.Empty;
+        ImmutableList<ILaunchProfile> newProfiles = [];
         var launchSettingsProvider = ILaunchSettingsProviderFactory.Create(
             addOrUpdateProfileCallback: (p, a) =>
             {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesProviderTests.cs
@@ -9,9 +9,9 @@ public class LaunchProfilesProjectPropertiesProviderTests
     private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
 
     private static readonly IEnumerable<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
-        Enumerable.Empty<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
-    private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders = 
-        Enumerable.Empty<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>();
+        [];
+    private static readonly IEnumerable<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
+        [];
 
     [Fact]
     public void DefaultProjectPath_IsTheProjectPath()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/LaunchProfiles/LaunchProfilesProjectPropertiesTests.cs
@@ -11,9 +11,9 @@ public class LaunchProfilesProjectPropertiesTests
     private const string DefaultTestProjectPath = @"C:\alpha\beta\gamma.csproj";
 
     private static readonly ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyLaunchProfileExtensionValueProviders =
-        ImmutableArray<Lazy<ILaunchProfileExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>.Empty;
+        [];
     private static readonly ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>> EmptyGlobalSettingExtensionValueProviders =
-        ImmutableArray<Lazy<IGlobalSettingExtensionValueProvider, ILaunchProfileExtensionValueProviderMetadata>>.Empty;
+        [];
 
     [Fact]
     public void WhenRetrievingItemProperties_TheContextHasTheExpectedValues()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
@@ -274,9 +274,9 @@ public class AppDesignerFolderSpecialFileProviderTests
 
     private static ProjectProperties CreateProperties(string appDesignerFolderName)
     {
-        return ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), new[] {
+        return ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), [
                 new PropertyPageData(AppDesigner.SchemaName, AppDesigner.FolderNameProperty, appDesignerFolderName)
-            });
+            ]);
     }
 
     private static AppDesignerFolderSpecialFileProvider CreateInstance(IPhysicalProjectTree? physicalProjectTree = null, ProjectProperties? properties = null)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/AppDesignerFolderProjectTreePropertiesProviderTests.cs
@@ -689,7 +689,7 @@ public class AppDesignerFolderProjectTreePropertiesProviderTests
         if (folderName is not null)
             ruleSnapshots = ruleSnapshots.Add(AppDesigner.SchemaName, AppDesigner.FolderNameProperty, folderName);
 
-        if (contentOnlyVisibleInShowAllFiles != null)
+        if (contentOnlyVisibleInShowAllFiles is not null)
             ruleSnapshots = ruleSnapshots.Add(AppDesigner.SchemaName, AppDesigner.ContentsVisibleOnlyInShowAllFilesProperty, contentOnlyVisibleInShowAllFiles.Value.ToString());
 
         provider.UpdateProjectTreeSettings(ruleSnapshots, ref projectTreeSettings);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Dependencies/DependenciesTreeBuilderTests.cs
@@ -120,7 +120,7 @@ public sealed class DependenciesTreeBuilderTests
     [Fact]
     public async Task BuildTreeAsync_SingleSlice_EmptyDependenciesCollection_ShowsEmptyGroupNode()
     {
-        var snapshot = CreateDependenciesSnapshot(new() { [_slice] = new() { [DependencyGroupTypes.Packages] = Array.Empty<IDependency>() } });
+        var snapshot = CreateDependenciesSnapshot(new() { [_slice] = new() { [DependencyGroupTypes.Packages] = [] } });
 
         var tree = await _builder.BuildTreeAsync(null, snapshot, CancellationToken.None);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Order/TreeItemOrderPropertyProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Tree/Order/TreeItemOrderPropertyProviderTests.cs
@@ -136,8 +136,7 @@ public class TreeItemOrderPropertyProviderTests
                 },
 
                 // 2. nested ordering with folders that should also be ordered
-                new object[]
-                {
+                [
                     new List<(string type, string include)>
                     {
                         ("Compile", "Order/Order.fs"),
@@ -174,7 +173,7 @@ public class TreeItemOrderPropertyProviderTests
                         ("app.fsproj", null, false, true, "X:\\Project\\app.fsproj"),
                         ("app.sln", null, false, true, "X:\\Project\\app.sln")
                     }
-                }
+                ]
             };
         }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Text/LazyStringSplitTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Text/LazyStringSplitTests.cs
@@ -41,7 +41,7 @@ public sealed class LazyStringSplitTests
         Assert.Equal(expected, list);
 
         // Equivalence with string.Split
-        Assert.Equal(expected, input.Split(new[] { delimiter }, StringSplitOptions.RemoveEmptyEntries));
+        Assert.Equal(expected, input.Split([delimiter], StringSplitOptions.RemoveEmptyEntries));
     }
 
     [Fact]

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IProjectCapabilitiesScopeFactory.cs
@@ -6,7 +6,7 @@ internal static class IProjectCapabilitiesScopeFactory
 {
     public static IProjectCapabilitiesScope Create(IEnumerable<string>? capabilities = null)
     {
-        capabilities ??= Enumerable.Empty<string>();
+        capabilities ??= [];
         var snapshot = new Mock<IProjectCapabilitiesSnapshot>();
         snapshot.Setup(s => s.IsProjectCapabilityPresent(It.IsAny<string>())).Returns((string capability) => capabilities.Contains(capability));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IVsSolutionFactory.cs
@@ -29,7 +29,7 @@ internal static class IVsSolutionFactory
         var mock = new Mock<IVsSolution>();
         mock.Setup(x => x.AdviseSolutionEvents(It.IsAny<IVsSolutionEvents>(), out adviseCookie)).Returns(VSConstants.S_OK);
         mock.Setup(x => x.UnadviseSolutionEvents(It.IsAny<uint>())).Returns(VSConstants.S_OK);
-        if (isFullyLoaded != null)
+        if (isFullyLoaded is not null)
         {
             object value = isFullyLoaded.Value;
             mock.Setup(x => x.GetProperty(It.IsAny<int>(), out value)).Returns(VSConstants.S_OK);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManagerTests.cs
@@ -43,7 +43,7 @@ public class ImplicitlyTriggeredDebugBuildManagerTests
     [Fact]
     public async Task StartupProjectsArePassedThrough()
     {
-        ImmutableArray<string> startupProjectPaths = ImmutableArray<string>.Empty;
+        ImmutableArray<string> startupProjectPaths = [];
         Action<ImmutableArray<string>> onImplicitBuildStartWithStartPaths = paths => startupProjectPaths = paths;
 
         var buildManager = await CreateInitializedInstanceAsync(
@@ -82,7 +82,7 @@ public class ImplicitlyTriggeredDebugBuildManagerTests
             IProjectThreadingServiceFactory.Create(),
             solutionBuildManager,
             IImplicitlyTriggeredBuildManagerFactory.Create(onImplicitBuildStart, onImplicitBuildEndOrCancel, onImplicitBuildStartWithStartupPaths),
-            IStartupProjectHelperFactory.Create(startupProjectFullPaths ?? ImmutableArray<string>.Empty));
+            IStartupProjectHelperFactory.Create(startupProjectFullPaths ?? []));
         
         await instance.LoadAsync();
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
@@ -101,11 +101,11 @@ public partial class ComponentVerificationTests
     public void CertainExportsMustNotBeMarkedWithDynamicCapabilities(Type type)
     {
         string[] contractsWithFixedCapabilities =
-        {
+        [
             ExportContractNames.VsTypes.ProjectNodeComExtension,
             "Microsoft.VisualStudio.ProjectSystem.ConfiguredProject.AutoLoad",
             "Microsoft.VisualStudio.ProjectSystem.Project.AutoLoad",
-        };
+        ];
 
         var definition = ComponentComposition.Instance.FindComposablePartDefinition(type);
 
@@ -140,12 +140,12 @@ public partial class ComponentVerificationTests
 
         static IEnumerable<string> GetCapabilitiesFromProjectType(string capabilities)
         {
-            return capabilities.Split(new char[] { ';', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            return capabilities.Split([';', ' '], StringSplitOptions.RemoveEmptyEntries);
         }
 
         static IEnumerable<string> GetRawCapabilities(string appliesTo)
         {
-            return appliesTo.Split(new char[] { '&', '|', '(', ')', ' ', '!', }, StringSplitOptions.RemoveEmptyEntries);
+            return appliesTo.Split(['&', '|', '(', ')', ' ', '!',], StringSplitOptions.RemoveEmptyEntries);
         }
     }
 
@@ -361,7 +361,7 @@ public partial class ComponentVerificationTests
     /// </summary>
     private static bool ContainsExpression(string? capability)
     {
-        return capability?.IndexOfAny(new char[] { '&', '|', '!' }) >= 0;
+        return capability?.IndexOfAny(['&', '|', '!']) >= 0;
     }
 
     /// <summary>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentVerificationTests.cs
@@ -254,11 +254,11 @@ public partial class ComponentVerificationTests
 
             var contracts = ComponentComposition.Instance.Contracts;
 
-            if (contracts.TryGetValue(importDefinition.ContractName, out ComponentComposition.ContractMetadata importContractMetadata) && importContractMetadata.Scope != null)
+            if (contracts.TryGetValue(importDefinition.ContractName, out ComponentComposition.ContractMetadata importContractMetadata) && importContractMetadata.Scope is not null)
             {
                 foreach (KeyValuePair<MemberRef?, ExportDefinition> export in definition.ExportDefinitions)
                 {
-                    if (contracts.TryGetValue(export.Value.ContractName, out ComponentComposition.ContractMetadata exportContractMetadata) && exportContractMetadata.Scope != null)
+                    if (contracts.TryGetValue(export.Value.ContractName, out ComponentComposition.ContractMetadata exportContractMetadata) && exportContractMetadata.Scope is not null)
                     {
                         // Do we import from a child scope but export to a parent scope? ie Importing ConfiguredProject, but exporting to an UnconfiguredProject service would be invalid
                         if (exportContractMetadata.Scope < importContractMetadata.Scope)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -63,7 +63,7 @@ public class CreateFileFromTemplateServiceTests
             Assert.Equal(VSADDITEMOPERATION.VSADDITEMOP_RUNWIZARD, itemOperation);
             Assert.Equal(fileName, itemName);
             Assert.Equal((uint)1, cOpen);
-            Assert.Equal(new string[] { templateFilePath }, files);
+            Assert.Equal([templateFilePath], files);
 
             result[0] = expectedResult ? VSADDRESULT.ADDRESULT_Success : VSADDRESULT.ADDRESULT_Failure;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Debug/ProjectLaunchTargetsProviderTests.cs
@@ -717,7 +717,7 @@ public class ProjectLaunchTargetsProviderTests
         var configuredProjectServices = Mock.Of<ConfiguredProjectServices>(o =>
             o.ProjectPropertiesProvider == delegateProvider);
 
-        var capabilitiesScope = scope ?? IProjectCapabilitiesScopeFactory.Create(capabilities: Enumerable.Empty<string>());
+        var capabilitiesScope = scope ?? IProjectCapabilitiesScopeFactory.Create(capabilities: []);
 
         var configuredProject = Mock.Of<ConfiguredProject>(o =>
             o.UnconfiguredProject == project &&

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksDynamicMenuCommandTests.cs
@@ -14,7 +14,7 @@ public class DebugFrameworksDynamicMenuCommandTests
     {
         var startupHelper = new Mock<IStartupProjectHelper>();
         startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
-                     .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
+                     .Returns([]);
 
         var command = CreateInstance(startupHelper.Object);
         Assert.False(command.ExecCommand(0, EventArgs.Empty));
@@ -85,7 +85,7 @@ public class DebugFrameworksDynamicMenuCommandTests
     {
         var startupHelper = new Mock<IStartupProjectHelper>();
         startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
-                     .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
+                     .Returns([]);
 
         var command = CreateInstance(startupHelper.Object);
         Assert.False(command.QueryStatusCommand(0, EventArgs.Empty));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/DebugFrameworksMenuTextUpdaterTests.cs
@@ -23,7 +23,7 @@ public class DebugFrameworkMenuTextUpdaterTests
     {
         var startupHelper = new Mock<IStartupProjectHelper>();
         startupHelper.Setup(x => x.GetExportFromDotNetStartupProjects<IActiveDebugFrameworkServices>(ProjectCapability.LaunchProfiles))
-                     .Returns(ImmutableArray<IActiveDebugFrameworkServices>.Empty);
+                     .Returns([]);
 
         var command = new TestDebugFrameworkPropertyMenuTextUpdater(startupHelper.Object);
         command.QueryStatus();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Input/Commands/Ordering/OrderingHelperTests.cs
@@ -435,7 +435,7 @@ public class OrderingHelperTests
 
         var project = new Project(projectRootElement);
 
-        var elements = OrderingHelper.GetItemElements(project, tree.Children[0], ImmutableArray<string>.Empty);
+        var elements = OrderingHelper.GetItemElements(project, tree.Children[0], []);
 
         Assert.True(OrderingHelper.TryMoveElementsAbove(project, elements, tree.Children[2]));
         Assert.True(project.IsDirty);
@@ -488,7 +488,7 @@ public class OrderingHelperTests
 
         var project = new Project(projectRootElement);
 
-        var elements = OrderingHelper.GetItemElements(project, tree.Children[0], ImmutableArray<string>.Empty);
+        var elements = OrderingHelper.GetItemElements(project, tree.Children[0], []);
 
         Assert.True(OrderingHelper.TryMoveElementsBelow(project, elements, tree.Children[2]));
         Assert.True(project.IsDirty);
@@ -551,7 +551,7 @@ public class OrderingHelperTests
 
         var project = new Project(projectRootElement);
 
-        var elements = OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty);
+        var elements = OrderingHelper.GetItemElements(project, updatedTree.Children[2], []);
 
         Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
         Assert.True(project.IsDirty);
@@ -618,8 +618,8 @@ public class OrderingHelperTests
         var project = new Project(projectRootElement);
 
         var elements =
-            OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty)
-            .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[3], ImmutableArray<string>.Empty));
+            OrderingHelper.GetItemElements(project, updatedTree.Children[2], [])
+            .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[3], []));
 
         Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
         Assert.True(project.IsDirty);
@@ -691,8 +691,8 @@ public class OrderingHelperTests
         var project = new Project(projectRootElement);
 
         var elements =
-            OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[0], ImmutableArray<string>.Empty)
-            .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[1], ImmutableArray<string>.Empty));
+            OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[0], [])
+            .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2].Children[0].Children[1], []));
 
         Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
         Assert.True(project.IsDirty);
@@ -767,8 +767,8 @@ public class OrderingHelperTests
         var project = CreateProjectWithImport(projectRootElement, projectImportElement, tempPath, testPropsFile);
 
         var elements =
-            OrderingHelper.GetItemElements(project, updatedTree.Children[0], ImmutableArray<string>.Empty)
-            .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2], ImmutableArray<string>.Empty));
+            OrderingHelper.GetItemElements(project, updatedTree.Children[0], [])
+            .AddRange(OrderingHelper.GetItemElements(project, updatedTree.Children[2], []));
 
         Assert.True(OrderingHelper.TryMoveElementsToTop(project, elements, tree), "TryMoveElementsToTop returned false.");
         Assert.True(project.IsDirty);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharp/CSharpLanguageFeaturesProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/CSharp/CSharpLanguageFeaturesProviderTests.cs
@@ -104,7 +104,7 @@ public class CSharpLanguageFeaturesProviderTests
 
         Assert.Throws<ArgumentException>("namespaceNames", () =>
         {
-            provider.ConcatNamespaces(new string[0]);
+            provider.ConcatNamespaces([]);
         });
     }
 
@@ -115,7 +115,7 @@ public class CSharpLanguageFeaturesProviderTests
 
         Assert.Throws<ArgumentException>("namespaceNames", () =>
         {
-            provider.ConcatNamespaces(new string[] { null! });
+            provider.ConcatNamespaces([null!]);
         });
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -152,7 +152,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
     [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
     public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
     {
-        string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+        string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
         var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
         var context = IWorkspaceProjectContextMockFactory.Create();
@@ -172,7 +172,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
     [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
     public void ApplyProjectBuild_WithExistingEvaluationChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
     {
-        string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+        string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
         var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
         var context = IWorkspaceProjectContextMockFactory.Create();
@@ -232,7 +232,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
     [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
     public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
     {
-        string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+        string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
         var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
         var context = IWorkspaceProjectContextMockFactory.Create();
@@ -252,7 +252,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
     [InlineData("A.cs;B.cs;C.cs",                  "A.cs;E.cs;F.cs",                @"C:\Project\B.cs;C:\Project\C.cs")]
     public void ApplyProjectBuild_WithExistingDesignTimeChanges_CanRemoveItem(string currentFiles, string filesToRemove, string expected)
     {
-        string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+        string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
         var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
         var context = IWorkspaceProjectContextMockFactory.Create();
@@ -270,7 +270,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
     [InlineData("A.cs;B.cs",                       "A.cs;B.cs",         "B.cs;A.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]
     public void ApplyProjectEvaluation_WithExistingEvaluationChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
     {
-        string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+        string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
         var handler = CreateInstanceWithEvaluationItems(@"C:\Project\Project.csproj", currentFiles);
         var context = IWorkspaceProjectContextMockFactory.Create();
@@ -289,7 +289,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
     [InlineData("A.cs;B.cs",                       "A.cs;B.cs",         "B.cs;A.cs",                     @"C:\Project\A.cs;C:\Project\B.cs")]
     public void ApplyProjectEvaluation_WithExistingDesignTimeChanges_CanRenameItem(string currentFiles, string originalNames, string newNames, string expected)
     {
-        string[] expectedFiles = expected.Length == 0 ? Array.Empty<string>() : expected.Split(';');
+        string[] expectedFiles = expected.Length == 0 ? [] : expected.Split(';');
 
         var handler = CreateInstanceWithDesignTimeItems(@"C:\Project\Project.csproj", currentFiles);
         var context = IWorkspaceProjectContextMockFactory.Create();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/Handlers/AbstractEvaluationCommandLineHandlerTests.cs
@@ -119,7 +119,7 @@ public partial class AbstractEvaluationCommandLineHandlerTests
 
         ApplyProjectEvaluation(context, handler, 1, difference, metadata: metadata);
 
-        string[] expectedFiles = new[] { @"C:\Project\B.cs", @"C:\Project\C.cs" };
+        string[] expectedFiles = [@"C:\Project\B.cs", @"C:\Project\C.cs"];
         Assert.Equal(expectedFiles.OrderBy(f => f), handler.FileNames.OrderBy(f => f));
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/UpdateHandlersTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/UpdateHandlersTests.cs
@@ -10,7 +10,7 @@ public sealed class UpdateHandlersTests
         var exportFactory = ExportFactoryFactory.Implement(
             factory: () => Mock.Of<IWorkspaceUpdateHandler>(MockBehavior.Loose));
 
-        UpdateHandlers instance = new(new[] { exportFactory });
+        UpdateHandlers instance = new([exportFactory]);
     }
 
     [Fact]
@@ -22,7 +22,7 @@ public sealed class UpdateHandlersTests
             factory: () => Mock.Of<IWorkspaceUpdateHandler>(MockBehavior.Loose),
             disposeAction: () => disposeCount++);
 
-        UpdateHandlers instance = new(new[] { exportFactory });
+        UpdateHandlers instance = new([exportFactory]);
 
         Assert.Equal(0, disposeCount);
 
@@ -38,7 +38,7 @@ public sealed class UpdateHandlersTests
     [Fact]
     public void EvaluationRulesPopulated()
     {
-        using UpdateHandlers instance = new(new[] { Create("Rule1"), Create("Rule2"), Create("Rule3") });
+        using UpdateHandlers instance = new([Create("Rule1"), Create("Rule2"), Create("Rule3")]);
 
         Assert.Equal(ImmutableHashSet.Create("Rule1", "Rule2", "Rule3", "ConfigurationGeneral"), instance.EvaluationRules);
 
@@ -61,12 +61,12 @@ public sealed class UpdateHandlersTests
         var evaluationHandler = new Mock<IProjectEvaluationHandler>(MockBehavior.Loose).Object;
         var sourceItemHandler = new Mock<ISourceItemsHandler>(MockBehavior.Loose).Object;
 
-        using UpdateHandlers instance = new(new[]
-        {
+        using UpdateHandlers instance = new(
+        [
             ExportFactoryFactory.Implement<IWorkspaceUpdateHandler>(factory: () => commandLineHandler),
             ExportFactoryFactory.Implement<IWorkspaceUpdateHandler>(factory: () => evaluationHandler),
             ExportFactoryFactory.Implement<IWorkspaceUpdateHandler>(factory: () => sourceItemHandler)
-        });
+        ]);
 
         Assert.Equal(new[] { commandLineHandler }, instance.CommandLineHandlers);
         Assert.Equal(new[] { evaluationHandler }, instance.EvaluationHandlers);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AuthenticationModeEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/AuthenticationModeEnumProviderTests.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using Microsoft.VisualStudio.Mocks;
-using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
@@ -41,10 +40,10 @@ public class AuthenticationModeEnumProviderTests
 
         var values = await generator.GetListedValuesAsync();
 
-        Assert.Collection(values, new Action<IEnumValue>[]
-        {
+        Assert.Collection(values,
+        [
             ev => { Assert.Equal(expected: "cheetah", actual: ev.Name); Assert.Equal(expected: "Fast authentication!", actual: ev.DisplayName); },
             ev => { Assert.Equal(expected: "tortoise", actual: ev.Name); Assert.Equal(expected: "Sloooow authentication...", actual: ev.DisplayName); }
-        });
+        ]);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/LaunchTargetPropertyPageEnumProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/LaunchTargetPropertyPageEnumProviderTests.cs
@@ -41,11 +41,11 @@ public class LaunchTargetPropertyPageEnumProviderTests
 
         var values = await generator.GetListedValuesAsync();
 
-        Assert.Collection(values, new Action<IEnumValue>[]
-        {
+        Assert.Collection(values,
+        [
             ev => { Assert.Equal(expected: "BetaCommandPageId", actual: ev.Name); Assert.Equal(expected: "Beta", actual: ev.DisplayName); },
             ev => { Assert.Equal(expected: "GammaCommandPageId", actual: ev.Name); Assert.Equal(expected: "Gamma", actual: ev.DisplayName); }
-        });
+        ]);
     }
 
     private static IPropertyPagesCatalogProvider GetCatalogProviderAndData()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/PropertyPages/PropertyPageTests.cs
@@ -58,7 +58,7 @@ public class PropertyPageTests
     {
         Assert.Throws<ArgumentNullException>(() =>
         {
-            Move(new RECT[0]);
+            Move([]);
         });
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/CategoryDataProducerTests.cs
@@ -86,11 +86,11 @@ public class CategoryDataProducerTests
 
         var result = CategoryDataProducer.CreateCategoryValues(context, parentEntity, rule, properties);
 
-        Assert.Collection(result, new Action<IEntityValue>[]
-        {
+        Assert.Collection(result,
+        [
             entity => { assertEqual(entity, expectedName: "Alpha", expectedDisplayName: "First category"); },
             entity => { assertEqual(entity, expectedName: "Beta", expectedDisplayName: "Second category"); }
-        });
+        ]);
 
         static void assertEqual(IEntityValue entity, string expectedName, string expectedDisplayName)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/SupportedValueDataProducerTests.cs
@@ -27,21 +27,21 @@ public class SupportedValueDataProducerTests
         var properties = PropertiesAvailableStatusFactory.CreateSupportedValuesPropertiesAvailableStatus(includeAllProperties: true);
 
         var parentEntity = IEntityWithIdFactory.Create("ParentKey", "ParentKeyValue");
-        var iproperty = IPropertyFactory.CreateEnum(new[]
-        {
+        var iproperty = IPropertyFactory.CreateEnum(
+        [
             IEnumValueFactory.Create(displayName: "Alpha", name: "a"),
             IEnumValueFactory.Create(displayName: "Beta", name: "b"),
             IEnumValueFactory.Create(displayName: "Gamma", name: "c")
-        });
+        ]);
 
         var result = await SupportedValueDataProducer.CreateSupportedValuesAsync(parentEntity, iproperty, properties);
 
-        Assert.Collection(result, new Action<IEntityValue>[]
-        {
+        Assert.Collection(result,
+        [
             entity => assertEqual(entity, expectedDisplayName: "Alpha", expectedValue: "a"),
             entity => assertEqual(entity, expectedDisplayName: "Beta", expectedValue: "b"),
             entity => assertEqual(entity, expectedDisplayName: "Gamma", expectedValue: "c")
-        });
+        ]);
 
         static void assertEqual(IEntityValue entity, string expectedDisplayName, string expectedValue)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyDataProducerTests.cs
@@ -99,12 +99,12 @@ public class UIPropertyDataProducerTests
 
         var result = UIPropertyDataProducer.CreateUIPropertyValues(context, parentEntity, cache, QueryProjectPropertiesContext.ProjectFile, rule, properties);
 
-        Assert.Collection(result, new Action<IEntityValue>[]
-        {
+        Assert.Collection(result,
+        [
             entity => { assertEqual(entity, expectedName: "Alpha"); },
             entity => { assertEqual(entity, expectedName: "Beta"); },
             entity => { assertEqual(entity, expectedName: "Gamma"); }
-        });
+        ]);
 
         static void assertEqual(IEntityValue entity, string expectedName)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/PropertyPages/UIPropertyEditorDataProducerTests.cs
@@ -74,12 +74,12 @@ public class UIPropertyEditorDataProducerTests
 
         var results = UIPropertyEditorDataProducer.CreateEditorValues(context, parentEntity, rule, "MyProperty", properties);
 
-        Assert.Collection(results, new Action<IEntityValue>[]
-        {
+        Assert.Collection(results,
+        [
             entity => assertEqual(entity, expectedName: "Alpha"),
             entity => assertEqual(entity, expectedName: "Beta"),
             entity => assertEqual(entity, expectedName: "Gamma")
-        });
+        ]);
 
         static void assertEqual(IEntityValue entity, string expectedName)
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/QueryProjectPropertiesContextTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Query/QueryProjectPropertiesContextTests.cs
@@ -27,11 +27,11 @@ public class QueryProjectPropertiesContextTests
     {
         return new QueryProjectPropertiesContext[][]
         {
-            new QueryProjectPropertiesContext[] { QueryProjectPropertiesContext.ProjectFile, QueryProjectPropertiesContext.ProjectFile },
-            new QueryProjectPropertiesContext[] { new(true, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile },
-            new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, null), new(true, @"c:\ALPHA\Beta", null, null) },
-            new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyItemType", null) },
-            new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MYITEMNAME") }
+            [QueryProjectPropertiesContext.ProjectFile, QueryProjectPropertiesContext.ProjectFile],
+            [new(true, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile],
+            [new(true, @"C:\alpha\beta", null, null), new(true, @"c:\ALPHA\Beta", null, null)],
+            [new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyItemType", null)],
+            [new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MYITEMNAME")]
         };
     }
 
@@ -39,10 +39,10 @@ public class QueryProjectPropertiesContextTests
     {
         return new QueryProjectPropertiesContext[][]
         {
-            new QueryProjectPropertiesContext[] { new(false, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile },
-            new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, null), new(true, @"C:\alpha\gamma", null, null) },
-            new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyOtherItemType", null) },
-            new QueryProjectPropertiesContext[] { new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MyOtherItemName") }
+            [new(false, string.Empty, null, null), QueryProjectPropertiesContext.ProjectFile],
+            [new(true, @"C:\alpha\beta", null, null), new(true, @"C:\alpha\gamma", null, null)],
+            [new(true, @"C:\alpha\beta", "myItemType", null), new(true, @"C:\alpha\beta", "MyOtherItemType", null)],
+            [new(true, @"C:\alpha\beta", null, "MyItemName"), new(true, @"C:\alpha\beta", null, "MyOtherItemName")]
         };
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/References/DesignTimeAssemblyResolutionTests.cs
@@ -98,7 +98,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 0, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 0, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -109,7 +109,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, null, out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 1, null, out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -120,7 +120,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib", "System" }, 1, new VsResolvedAssemblyPath[2], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib", "System"], 1, new VsResolvedAssemblyPath[2], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -131,7 +131,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib", "System" }, 2, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib", "System"], 2, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -142,7 +142,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 2, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 2, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -153,7 +153,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[2], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 1, new VsResolvedAssemblyPath[2], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -166,7 +166,7 @@ public class DesignTimeAssemblyResolutionTests
 
         var resolution = CreateInstance(reference);
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.S_OK, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -179,7 +179,7 @@ public class DesignTimeAssemblyResolutionTests
 
         var resolution = CreateInstance(reference);
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.S_OK, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -193,7 +193,7 @@ public class DesignTimeAssemblyResolutionTests
 
         var resolution = CreateInstance(reference);
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { "mscorlib" }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["mscorlib"], 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.S_OK, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -209,7 +209,7 @@ public class DesignTimeAssemblyResolutionTests
     {
         var resolution = CreateInstance();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string?[] { input }, 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx([input], 1, new VsResolvedAssemblyPath[1], out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.E_INVALIDARG, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -233,7 +233,7 @@ public class DesignTimeAssemblyResolutionTests
         var resolution = CreateInstance(reference);
 
         var resolvedPaths = new VsResolvedAssemblyPath[1];
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { input }, 1, resolvedPaths, out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx([input], 1, resolvedPaths, out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.S_OK, result);
         Assert.Equal(1u, resolvedAssemblyPaths);
@@ -254,7 +254,7 @@ public class DesignTimeAssemblyResolutionTests
         var resolution = CreateInstance(reference);
 
         var resolvedPaths = new VsResolvedAssemblyPath[1];
-        var result = resolution.ResolveAssemblyPathInTargetFx(new string[] { input }, 1, resolvedPaths, out uint resolvedAssemblyPaths);
+        var result = resolution.ResolveAssemblyPathInTargetFx([input], 1, resolvedPaths, out uint resolvedAssemblyPaths);
 
         Assert.Equal(VSConstants.S_OK, result);
         Assert.Equal(0u, resolvedAssemblyPaths);
@@ -268,7 +268,7 @@ public class DesignTimeAssemblyResolutionTests
         var resolution = CreateInstance();
         resolution.Dispose();
 
-        var result = resolution.ResolveAssemblyPathInTargetFx(new[] { "System" }, 1, new VsResolvedAssemblyPath[1], out _);
+        var result = resolution.ResolveAssemblyPathInTargetFx(["System"], 1, new VsResolvedAssemblyPath[1], out _);
 
         Assert.Equal(VSConstants.E_UNEXPECTED, result);
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/XamlRuleTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/XamlRuleTestBase.cs
@@ -15,10 +15,10 @@ public abstract class XamlRuleTestBase
     {
         // Not all rules are embedded as manifests so we have to read the xaml files from the file system.
         (string, Type)[] projects =
-        {
+        [
             (Path.Combine(RepoUtil.FindRepoRootPath(), "src", "Microsoft.VisualStudio.ProjectSystem.Managed", "ProjectSystem", "Rules"), typeof(RuleExporter)),
             (Path.Combine(RepoUtil.FindRepoRootPath(), "src", "Microsoft.VisualStudio.ProjectSystem.VS.Managed", "ProjectSystem", "Rules"), typeof(VSRuleExporter))
-        };
+        ];
 
         bool foundDirectory = false;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsBuildManagerBridgeTests.cs
@@ -17,13 +17,13 @@ public class DesignTimeInputsBuildManagerBridgeTests : IDisposable
     {
         await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
             ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
-            ImmutableHashSet<string>.Empty,
+            [],
             ImmutableHashSet<DesignTimeInputFileChange>.Empty,
             "C:\\TempPE"));
 
         await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
             ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
-            ImmutableHashSet<string>.Empty,
+            [],
             new[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
             "C:\\TempPE"));
 
@@ -38,13 +38,13 @@ public class DesignTimeInputsBuildManagerBridgeTests : IDisposable
     {
         await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
             ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
-            ImmutableHashSet<string>.Empty,
+            [],
             Array.Empty<DesignTimeInputFileChange>(),
             ""));
 
         await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
-           ImmutableHashSet<string>.Empty,
-           ImmutableHashSet<string>.Empty,
+           [],
+           [],
            Array.Empty<DesignTimeInputFileChange>(),
            ""));
 
@@ -59,7 +59,7 @@ public class DesignTimeInputsBuildManagerBridgeTests : IDisposable
     {
         await _bridge.ApplyAsync(new DesignTimeInputSnapshot(
             ImmutableHashSet.CreateRange(new string[] { "Resources1.Designer.cs" }),
-            ImmutableHashSet<string>.Empty,
+            [],
             new[] { new DesignTimeInputFileChange("Resources1.Designer.cs", false) },
             "C:\\TempPE"));
 
@@ -67,7 +67,7 @@ public class DesignTimeInputsBuildManagerBridgeTests : IDisposable
 
         Assert.Equal("Resources1.Designer.cs", _lastCompiledFile);
         Assert.Equal("C:\\TempPE", _lastOutputPath);
-        Assert.Equal(ImmutableHashSet<string>.Empty, _lastSharedInputs);
+        Assert.Equal([], _lastSharedInputs);
     }
 
     public DesignTimeInputsBuildManagerBridgeTests()

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueueTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompiler.CompilationQueueTests.cs
@@ -11,7 +11,7 @@ public class CompilationQueueTests
     {
         var queue = new CompilationQueue();
 
-        queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+        queue.Push(new QueueItem("FileName", [], "", false));
 
         Assert.Equal(1, queue.Count);
     }
@@ -21,7 +21,7 @@ public class CompilationQueueTests
     {
         var queue = new CompilationQueue();
 
-        queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+        queue.Push(new QueueItem("FileName", [], "", false));
 
         queue.Pop();
 
@@ -41,9 +41,9 @@ public class CompilationQueueTests
     {
         var queue = new CompilationQueue();
 
-        queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+        queue.Push(new QueueItem("FileName", [], "", false));
 
-        queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", true));
+        queue.Push(new QueueItem("FileName", [], "", true));
 
         Assert.Equal(1, queue.Count);
         Assert.True(queue.Pop()?.IgnoreFileWriteTime);
@@ -54,7 +54,7 @@ public class CompilationQueueTests
     {
         var queue = new CompilationQueue();
 
-        queue.Push(new QueueItem("FileName", ImmutableHashSet<string>.Empty, "", false));
+        queue.Push(new QueueItem("FileName", [], "", false));
 
         queue.RemoveSpecific("FileName");
 
@@ -72,7 +72,7 @@ public class CompilationQueueTests
             new DesignTimeInputFileChange("FileName2", false)
         });
 
-        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1", "FileName2" }), ImmutableHashSet<string>.Empty, "");
+        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1", "FileName2" }), [], "");
 
         Assert.Equal(2, queue.Count);
     }
@@ -88,7 +88,7 @@ public class CompilationQueueTests
             new DesignTimeInputFileChange("FileName1", false)
         });
 
-        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), ImmutableHashSet<string>.Empty, "");
+        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), [], "");
 
         Assert.Equal(1, queue.Count);
     }
@@ -104,7 +104,7 @@ public class CompilationQueueTests
             new DesignTimeInputFileChange("FileName1", true)
         });
 
-        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), ImmutableHashSet<string>.Empty, "");
+        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), [], "");
 
         Assert.Equal(1, queue.Count);
         Assert.True(queue.Pop()?.IgnoreFileWriteTime);
@@ -121,7 +121,7 @@ public class CompilationQueueTests
             new DesignTimeInputFileChange("FileName2", false)
         });
 
-        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), ImmutableHashSet<string>.Empty, "");
+        queue.Update(range, ImmutableHashSet.CreateRange(new string[] { "FileName1" }), [], "");
 
         Assert.Equal(1, queue.Count);
         Assert.Equal("FileName1", queue.Pop()?.FileName);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsCompilerTests.cs
@@ -44,7 +44,7 @@ public class DesignTimeInputsCompilerTests : IDisposable
 
         await VerifyCompilation(1, inputs);
 
-        string tempPEDescriptionXml = await _manager.BuildDesignTimeOutputAsync("File1.cs", _outputPath, ImmutableHashSet<string>.Empty);
+        string tempPEDescriptionXml = await _manager.BuildDesignTimeOutputAsync("File1.cs", _outputPath, []);
 
         // This also validates that getting the description didn't force a compile, because the output is up to date
         Assert.Single(_compilationResults);
@@ -80,7 +80,7 @@ public class DesignTimeInputsCompilerTests : IDisposable
         // Remove the output file, should mean that getting the XML forces a compile
         _fileSystem.RemoveFile(Path.Combine(_outputPath, "File1.cs.dll"));
 
-        string tempPEDescriptionXml = await _manager.BuildDesignTimeOutputAsync("File1.cs", _outputPath, ImmutableHashSet<string>.Empty);
+        string tempPEDescriptionXml = await _manager.BuildDesignTimeOutputAsync("File1.cs", _outputPath, []);
 
         // Verify a second compile happened
         Assert.Equal(2, _compilationResults.Count);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsDataSourceTests.cs
@@ -32,8 +32,7 @@ public class DesignTimeInputsDataSourceTests
             },
 
             // A single design time input, and a normal file
-            new object[]
-            {
+            [
                 """
                 "CurrentState": {
                     "Compile": {
@@ -51,11 +50,10 @@ public class DesignTimeInputsDataSourceTests
                 """,
                 new string[] { "C:\\Project\\File1.cs" },
                 new string[] { }
-            },
+            ],
 
             // A single design time input, and a single shared design time input
-            new object[]
-            {
+            [
                 """
                 "CurrentState": {
                     "Compile": {
@@ -74,11 +72,10 @@ public class DesignTimeInputsDataSourceTests
                 """,
                 new string[] { "C:\\Project\\File1.cs" },
                 new string[] { "C:\\Project\\File2.cs" }
-            },
+            ],
 
             // A file that is both a design time and shared design time input
-            new object[]
-            {
+            [
                 """
                 "CurrentState": {
                     "Compile": {
@@ -94,11 +91,10 @@ public class DesignTimeInputsDataSourceTests
                 """,
                 new string[] { "C:\\Project\\File1.cs" },
                 new string[] { "C:\\Project\\File1.cs" }
-            },
+            ],
 
             // A design time input that is a linked file, and hence ignored
-            new object[]
-            {
+            [
                 """
                 "CurrentState": {
                     "Compile": {
@@ -114,7 +110,7 @@ public class DesignTimeInputsDataSourceTests
                 """,
                 new string[] { },
                 new string[] { }
-            },
+            ],
         };
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/TempPE/DesignTimeInputsFileWatcherTests.cs
@@ -29,44 +29,40 @@ public class DesignTimeInputsFileWatcherTests
             },
 
             // A design time input and a shared design time input
-            new object[]
-            {
+            [
                 new string[] { "File1.cs" },
                 new string[] { "File2.cs" },
                 new string[] { "File1.cs", "File2.cs" },
                 new string[] { },
                 new string[] { }
-            },
+            ],
 
             // A file that is both design time and shared, should only be watched once
-            new object[]
-            {
+            [
                 new string[] { "File1.cs" },
                 new string[] { "File2.cs", "File1.cs" },
                 new string[] { "File1.cs", "File2.cs" },
                 new string[] { },
                 new string[] { }
-            },
+            ],
 
             // A design time input that gets modified
-             new object[]
-            {
+             [
                 new string[] { "File1.cs" },
                 new string[] { },
                 new string[] { "File1.cs" },
                 new string[] { "File1.cs", "File1.cs", "File1.cs" },
                 new string[] { "File1.cs", "File1.cs", "File1.cs" }
-            },
+            ],
 
             // A design time input and a shared design time input, that both change, to ensure ordering is correct
-            new object[]
-            {
+            [
                 new string[] { "File1.cs" },
                 new string[] { "File2.cs" },
                 new string[] { "File1.cs", "File2.cs" },
                 new string[] { "File1.cs", "File2.cs" },
                 new string[] { "File1.cs", "File2.cs" }
-            },
+            ],
         };
     }
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UpToDate/BuildUpToDateCheckTests.cs
@@ -41,7 +41,7 @@ public sealed class BuildUpToDateCheckTests : BuildUpToDateCheckTestBase, IDispo
     private bool _isBuildAccelerationEnabledInSettings;
     private bool? _isBuildAccelerationEnabledInProject;
     private bool? _expectedIsBuildAccelerationEnabled;
-    private IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> _copyItems = Enumerable.Empty<(string Path, ImmutableArray<CopyItem> CopyItems)>();
+    private IEnumerable<(string Path, ImmutableArray<CopyItem> CopyItems)> _copyItems = [];
     private bool _isCopyItemsComplete = true;
     private IReadOnlyList<string>? _duplicateCopyItemRelativeTargetPaths;
     private IReadOnlyList<string>? _targetsWithoutReferenceAssemblies;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/WindowsForms/WindowsFormsAddItemFilterTests.cs
@@ -5,10 +5,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.WindowsForms;
 public class WindowsFormsAddItemFilterTests
 {
     [Theory]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Non-Windows Forms", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\General", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Windows Forms", true })]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\Non-Windows Forms", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\General", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\Windows Forms", true])]
     public void FiltersItemTemplateFolders_NonWindowsForms(string templateDir, bool shouldBeFiltered)
     {
         var filter = new WindowsFormsAddItemFilter(UnconfiguredProjectFactory.Create(scope: IProjectCapabilitiesScopeFactory.Create()));
@@ -21,10 +21,10 @@ public class WindowsFormsAddItemFilterTests
     }
 
     [Theory]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Non-Windows Forms", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\General", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Windows Forms", false })]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\Non-Windows Forms", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\General", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Extensions\dh64yf.343\ProjectTemplates\CSharp", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\Windows Forms", false])]
     public void FiltersItemTemplateFolders_WindowsForms(string templateDir, bool shouldBeFiltered)
     {
         var filter = new WindowsFormsAddItemFilter(UnconfiguredProjectFactory.Create(scope: IProjectCapabilitiesScopeFactory.Create(new string[] { "WindowsForms" })));
@@ -37,12 +37,12 @@ public class WindowsFormsAddItemFilterTests
     }
 
     [Theory]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\CSControlInheritanceWizard.vsz", true })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\CSFormInheritanceWizard.vsz", true })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\InheritedForm.vsz", true })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\InheritedControl.vsz", true })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\Class.vsz", false })]
-    [InlineData(new object[] { @"C:\Program Files\Visual Studio\Templates\ControlLibrary.vsz", false })]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\CSControlInheritanceWizard.vsz", true])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\CSFormInheritanceWizard.vsz", true])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\InheritedForm.vsz", true])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\InheritedControl.vsz", true])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\Class.vsz", false])]
+    [InlineData([@"C:\Program Files\Visual Studio\Templates\ControlLibrary.vsz", false])]
     public void FiltersItemTemplateFiles(string templateDir, bool shouldBeFiltered)
     {
         var filter = new WindowsFormsAddItemFilter(UnconfiguredProjectFactory.Create());


### PR DESCRIPTION
Fixes #9676

Bump a lot of packages. This brings in a newer compiler and newer analysers, which in turn require fixing up a bunch of diagnostics.

Then use the newer versions of the Roslyn APIs added for us in https://github.com/dotnet/roslyn/pull/78972

Recommend reviewing commit-by-commit. Some of the wide-sweeping changes were automated codefixes and don't require as much scrutiny.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9689)