### PR TITLE
Only opt into data source for WinForms/WPF

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets
@@ -139,7 +139,7 @@
     <!-- Capabilities for WPF and WinForms -->
     <ProjectCapability Include="WPF" Condition="'$(UseWPF)' == 'true'" />
     <ProjectCapability Include="WindowsForms" Condition="'$(UseWindowsForms)' == 'true'" />
-    <ProjectCapability Include="DataSourceWindow" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')" />
+    <ProjectCapability Include="DataSourceWindow" Condition="('$(TargetFrameworkIdentifier)' == '.NETFramework' Or ('$(TargetFrameworkIdentifier)' == '.NETCoreApp' And '$(_TargetFrameworkVersionWithoutV)' >= '3.0')) And ('$(UseWindowsForms)' == 'true' Or '$(UseWPF)' == 'true')" />
   </ItemGroup>
 
   <!-- List of well known rule Contexts that determine which catalog the rule shows up in CPS:


### PR DESCRIPTION
This only opts Data Source Windows in for WPF/WinForms projects and nothing else - it doesn't nothing for other projects.

See https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/651666 for more details.

I tested this, and this works as expected, hides for any project except for WinForms/WPF.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9711)