### PR TITLE
Onboard to VSSDK analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,6 +54,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Interop"                                         Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.ManagedInterfaces"                               Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.RpcContracts"                                    Version="17.15.15-pre" />
+    <PackageVersion Include="Microsoft.VisualStudio.SDK.Analyzers"                                   Version="17.7.88" />
     <PackageVersion Include="Microsoft.VisualStudio.Settings.15.0"                                   Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Interop"                     Version="3.12.2159" />
     <PackageVersion Include="Microsoft.VisualStudio.Shell.15.0"                                      Version="18.0.1755-preview.1" />

--- a/eng/imports/VisualStudio.props
+++ b/eng/imports/VisualStudio.props
@@ -30,11 +30,12 @@
     <PackageReference Include="Microsoft.VisualStudio.Interop" />
     <PackageReference Include="Microsoft.VisualStudio.ManagedInterfaces" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.Analyzers" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Design" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" />
     <PackageReference Include="Microsoft.VisualStudio.Telemetry" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" />
     <PackageReference Include="NuGet.VisualStudio" />
     


### PR DESCRIPTION
Onboard to VSSDK analyzers, specifically to see warnings from [VSSDK008](https://github.com/microsoft/VSSDK-Analyzers/blob/main/doc/VSSDK008.md) which reveals UI thread affinity in MEF part construction