### PR TITLE
use GetPropertyValue instead of GetProperty().EvaluatedValue

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Workspace.cs
@@ -656,10 +656,7 @@ internal sealed class Workspace : OnceInitializedOnceDisposedUnderLockAsync, IWo
         {
             Validate();
 
-            string? value = _projectInstance.GetProperty(name)?.EvaluatedValue;
-
-            // Return the empty string rather than null.
-            return value ?? "";
+            return _projectInstance.GetPropertyValue(name);
         }
 
         public override ImmutableArray<string> GetItemValues(string name)


### PR DESCRIPTION
GetPropertyValue is optimized in the cache mode. 

It would read data directly without causing extra lazy structure (ProjectPropertyInstance) to be created.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9717)