### PR TITLE
Treat warnings as errors in release builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,6 +44,11 @@
     <DebugType Condition="'$(OfficialBuild)' != 'true' AND '$(CIBuild)' != 'true' AND '$(BuildingInsideVisualStudio)' == 'true'">full</DebugType>
   </PropertyGroup>
 
+  <!-- Treat warnings as errors in release builds, so they're caught during CI. -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <!-- General -->
   <PropertyGroup>
     <!-- Variable used for executing a PowerShell command with arguments for the MSBuild/commandline environment. -->


### PR DESCRIPTION
Lately we've started seeing warnings creeping into the codebase. These should be caught by CI and prevented.

To make it easier to reproduce CI behaviour locally, this setting is enabled for release builds. If CI fails and you want to recreate the error locally, switch to release mode and build.