### PR TITLE
Fix flakey test

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/SolutionBuildManagerTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Build/SolutionBuildManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
+using System.Diagnostics;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -79,7 +80,8 @@ public class SolutionBuildManagerTests
         var mockVsHierarchy2 = new Mock<IVsHierarchy>();
         var joinableTaskContext = JoinableTaskContext.CreateNoOpContext();
 
-        var buildStartTimes = new List<DateTime>();
+        var sw = Stopwatch.StartNew();
+        var buildStartTimes = new List<TimeSpan>();
         var tcsForFirstListener = new TaskCompletionSource<IVsUpdateSolutionEvents>();
         var tcsForSecondListener = new TaskCompletionSource<IVsUpdateSolutionEvents>();
         var eventListeners = new List<IVsUpdateSolutionEvents>();
@@ -109,7 +111,7 @@ public class SolutionBuildManagerTests
                 It.IsAny<int>()))
             .Callback(() =>
             {
-                buildStartTimes.Add(DateTime.UtcNow);
+                buildStartTimes.Add(sw.Elapsed);
             })
             .Returns(HResult.OK);
 


### PR DESCRIPTION
This test would fail with:

> Second build should start after the first build

Based on the comparison:

```c#
buildStartTimes[1] > buildStartTimes[0]
```

These `buildStartTimes` values were `DateTime` instances, captured using `DateTime.UtcNow`. That can be problematic when comparing timestamps that are close together, as `DateTime.Now` and friends only update every 15ms or so.

One possible fix is to use a more fine-grained timer. `Stopwatch` has much better precision and should avoid having two successive timestamps being equal.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9720)