### PR TITLE
Remove VSSDK FUTDC overrides

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,7 +67,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Utilities"                                       Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation"                                      Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudio.XmlEditor"                                       Version="17.13.0-preview-1-35408-014" />
-    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="17.13.17-preview1-ga15b669c04" />
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools"                                             Version="18.0.136-preview1" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow"                                        Version="9.0.0" />
     <PackageVersion Include="System.Formats.Asn1"                                                    Version="8.0.1" />
     <PackageVersion Include="Microsoft.VSDesigner"                                                   Version="18.0.1755-preview.1" />

--- a/setup/Directory.Build.targets
+++ b/setup/Directory.Build.targets
@@ -40,27 +40,6 @@
     <MakeDir Directories="$(VisualStudioSetupInsertionPath)" />
   </Target>
 
-  <!--
-    The properties and targets below will add the VSIXSourceItems (files that go in the VSIX) and the VSIX file itself to the item group that tracks when files are up-to-date.
-    This ensures that these files are recognized in VS to force the VS Extension Project to build when the files are changed, such as prior to debugging.
-  -->
-  <PropertyGroup Condition="'$(IsVsixProject)' == 'true'">
-    <CollectUpToDateCheckInputDesignTimeDependsOn>$(CollectUpToDateCheckInputDesignTimeDependsOn);AddUpToDateCheckVSIXSourceItems</CollectUpToDateCheckInputDesignTimeDependsOn>
-    <CollectUpToDateCheckOutputDesignTimeDependsOn>$(CollectUpToDateCheckOutputDesignTimeDependsOn);AddUpToDateCheckTargetVsixContainer</CollectUpToDateCheckOutputDesignTimeDependsOn>
-  </PropertyGroup>
-
-  <Target Name="AddUpToDateCheckVSIXSourceItems" DependsOnTargets="GetVsixSourceItems" Condition="'$(IsVsixProject)' == 'true'">
-    <ItemGroup>
-      <UpToDateCheckInput Include="@(VSIXSourceItem)" Set="VsixItems" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="AddUpToDateCheckTargetVsixContainer" Condition="'$(IsVsixProject)' == 'true'">
-    <ItemGroup>
-      <UpToDateCheckOutput Include="$(TargetVsixContainer)" Set="VsixItems" />
-    </ItemGroup>
-  </Target>
-
   <!-- This is only needed for VSIX projects as SWIX projects have their own version of the GetVsixPrimaryOutputs target. -->
   <!-- The override for this for SWIX projects is in Microsoft.VisualStudio.Internal.MicroBuild.Swix.targets. -->
   <Import Project="..\eng\imports\OverrideGetVsixPrimaryOutputs.targets" Condition="'$(IsVsixProject)' == 'true'" />


### PR DESCRIPTION
These targets could cause issues during DTBs (The target "GetVsixSourceItems" does not exist in the project.) if the VSSDK wasn't restored.

Newer versions of the VSSDK implement the equivalent logic.

This change removes our explicit overrides. If we see any issues with the FUTDC after this we can work with the VSSDK team to address any gaps.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9722)