### PR TITLE
Remove obsolete code

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -63,35 +63,6 @@ internal class ActiveConfiguredProjectsProvider : IActiveConfiguredProjectsProvi
     [ImportMany]
     public OrderPrecedenceImportCollection<IActiveConfiguredProjectsDimensionProvider> DimensionProviders { get; }
 
-    public async Task<ImmutableDictionary<string, ConfiguredProject>?> GetActiveConfiguredProjectsMapAsync()
-    {
-        ActiveConfiguredObjects<ConfiguredProject>? projects = await GetActiveConfiguredProjectsAsync();
-
-        if (projects?.Objects.IsEmpty != false)
-        {
-            return null;
-        }
-
-        var builder = PooledDictionary<string, ConfiguredProject>.GetInstance();
-
-        bool isCrossTargeting = projects.Objects.All(project => project.ProjectConfiguration.IsCrossTargeting());
-
-        if (isCrossTargeting)
-        {
-            foreach (ConfiguredProject project in projects.Objects)
-            {
-                string targetFramework = project.ProjectConfiguration.Dimensions[ConfigurationGeneral.TargetFrameworkProperty];
-                builder.Add(targetFramework, project);
-            }
-        }
-        else
-        {
-            builder.Add(string.Empty, projects.Objects[0]);
-        }
-
-        return builder.ToImmutableDictionaryAndFree();
-    }
-
     public async Task<ActiveConfiguredObjects<ConfiguredProject>?> GetActiveConfiguredProjectsAsync()
     {
         ActiveConfiguredObjects<ProjectConfiguration>? configurations = await GetActiveProjectConfigurationsAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ActiveConfiguredProjectsProvider.cs
@@ -8,8 +8,8 @@ namespace Microsoft.VisualStudio.ProjectSystem;
 [Export(typeof(IActiveConfiguredProjectsProvider))]
 internal class ActiveConfiguredProjectsProvider : IActiveConfiguredProjectsProvider
 {
-    // A project configuration is considered active if its dimensions matches the active solution configuration skipping 
-    // any ignored dimensions names (provided by IActiveConfiguredProjectsDimensionProvider instances):
+    // A project configuration is considered active if its dimensions match the active solution configuration, skipping 
+    // any ignored dimensions names (provided by IActiveConfiguredProjectsDimensionProvider instances).
     //
     // For example, given the following cross-targeting project:
     //

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -21,9 +21,6 @@ internal class ActiveDebugFrameworkServices : IActiveDebugFrameworkServices
         _commonProjectServices = commonProjectServices;
     }
 
-    /// <summary>
-    /// <see cref="IActiveDebugFrameworkServices.GetProjectFrameworksAsync"/>
-    /// </summary>
     public async Task<List<string>?> GetProjectFrameworksAsync()
     {
         // It is important that we return the frameworks in the order they are specified in the project to ensure the default is set
@@ -40,18 +37,12 @@ internal class ActiveDebugFrameworkServices : IActiveDebugFrameworkServices
         return BuildUtilities.GetPropertyValues(targetFrameworks).ToList();
     }
 
-    /// <summary>
-    /// <see cref="IActiveDebugFrameworkServices.SetActiveDebuggingFrameworkPropertyAsync"/>
-    /// </summary>
     public async Task SetActiveDebuggingFrameworkPropertyAsync(string activeFramework)
     {
         ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync();
         await props.ActiveDebugFramework.SetValueAsync(activeFramework);
     }
 
-    /// <summary>
-    /// <see cref="IActiveDebugFrameworkServices.GetActiveDebuggingFrameworkPropertyAsync"/>
-    /// </summary>
     public async Task<string?> GetActiveDebuggingFrameworkPropertyAsync()
     {
         ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync();
@@ -59,9 +50,6 @@ internal class ActiveDebugFrameworkServices : IActiveDebugFrameworkServices
         return activeValue;
     }
 
-    /// <summary>
-    /// <see cref="IActiveDebugFrameworkServices.GetConfiguredProjectForActiveFrameworkAsync"/>
-    /// </summary>
     public async Task<ConfiguredProject?> GetConfiguredProjectForActiveFrameworkAsync()
     {
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/ActiveDebugFrameworkServices.cs
@@ -40,14 +40,15 @@ internal class ActiveDebugFrameworkServices : IActiveDebugFrameworkServices
     public async Task SetActiveDebuggingFrameworkPropertyAsync(string activeFramework)
     {
         ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync();
+
         await props.ActiveDebugFramework.SetValueAsync(activeFramework);
     }
 
     public async Task<string?> GetActiveDebuggingFrameworkPropertyAsync()
     {
         ProjectDebugger props = await _commonProjectServices.ActiveConfiguredProjectProperties.GetProjectDebuggerPropertiesAsync();
-        string? activeValue = await props.ActiveDebugFramework.GetValueAsync() as string;
-        return activeValue;
+
+        return await props.ActiveDebugFramework.GetValueAsync() as string;
     }
 
     public async Task<ConfiguredProject?> GetConfiguredProjectForActiveFrameworkAsync()

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IActiveDebugFrameworkServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/IActiveDebugFrameworkServices.cs
@@ -25,7 +25,7 @@ public interface IActiveDebugFrameworkServices
     Task<string?> GetActiveDebuggingFrameworkPropertyAsync();
 
     /// <summary>
-    /// Returns the configured project which represents the active framework. This is valid whether multi-targeting or not.
+    /// Returns the configured project that corresponds with the active debugging framework. This is valid whether multi-targeting or not.
     /// </summary>
     Task<ConfiguredProject?> GetConfiguredProjectForActiveFrameworkAsync();
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IActiveConfiguredProjectsProvider.cs
@@ -15,18 +15,6 @@ namespace Microsoft.VisualStudio.ProjectSystem;
 internal interface IActiveConfiguredProjectsProvider
 {
     /// <summary>
-    ///     Gets all the active configured projects by TargetFramework dimension for the current unconfigured project.
-    ///     If the current project is not a cross-targeting project, then it returns a singleton key-value pair with an
-    ///     ignorable key and single active configured project as value.
-    /// </summary>
-    /// <returns>
-    ///     Map from TargetFramework dimension to active configured project, or <see langword="null" /> if there
-    ///     are no active <see cref="ConfiguredProject"/> objects.
-    /// </returns>
-    [Obsolete("This method will be removed in a future build.")]
-    Task<ImmutableDictionary<string, ConfiguredProject>?> GetActiveConfiguredProjectsMapAsync();
-
-    /// <summary>
     ///     Returns the ordered list of configured projects that are active for the current project, loading them if needed.
     /// </summary>
     /// <returns>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
@@ -13,15 +13,6 @@ internal class IActiveConfiguredProjectsProviderFactory(MockBehavior mockBehavio
         _mock.Verify();
     }
 
-    public IActiveConfiguredProjectsProviderFactory ImplementGetActiveConfiguredProjectsMapAsync(ImmutableDictionary<string, ConfiguredProject> configuredProjects)
-    {
-#pragma warning disable CS0618 // Type or member is obsolete
-        _mock.Setup(x => x.GetActiveConfiguredProjectsMapAsync())
-#pragma warning restore CS0618 // Type or member is obsolete
-                          .ReturnsAsync(configuredProjects);
-        return this;
-    }
-
     public IActiveConfiguredProjectsProviderFactory ImplementGetActiveConfiguredProjectsAsync(ActiveConfiguredObjects<ConfiguredProject> configuredProjects)
     {
         _mock.Setup(x => x.GetActiveConfiguredProjectsAsync())

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IActiveConfiguredProjectsProviderFactory.cs
@@ -2,14 +2,9 @@
 
 namespace Microsoft.VisualStudio.ProjectSystem.Debug;
 
-internal class IActiveConfiguredProjectsProviderFactory
+internal class IActiveConfiguredProjectsProviderFactory(MockBehavior mockBehavior = MockBehavior.Strict)
 {
-    private readonly Mock<IActiveConfiguredProjectsProvider> _mock;
-
-    public IActiveConfiguredProjectsProviderFactory(MockBehavior mockBehavior = MockBehavior.Strict)
-    {
-        _mock = new Mock<IActiveConfiguredProjectsProvider>(mockBehavior);
-    }
+    private readonly Mock<IActiveConfiguredProjectsProvider> _mock = new(mockBehavior);
 
     public IActiveConfiguredProjectsProvider Object => _mock.Object;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -74,23 +74,25 @@ public class ActiveDebugFrameworkServicesTests
         var data = new PropertyPageData(ProjectDebugger.SchemaName, ProjectDebugger.ActiveDebugFrameworkProperty, framework);
         var data2 = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworksProperty, "net462;net461;netcoreapp1.0");
 
-        var projects = ImmutableStringDictionary<ConfiguredProject>.EmptyOrdinal
-                        .Add("net461", ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|net461", Empty.PropertiesMap
-                                                                                .Add("Configuration", "Debug")
-                                                                                .Add("Platform", "AnyCPU")
-                                                                                .Add("TargetFramework", "net461"))))
-                        .Add("netcoreapp1.0", ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|netcoreapp1.0", Empty.PropertiesMap
-                                                                                .Add("Configuration", "Debug")
-                                                                                .Add("Platform", "AnyCPU")
-                                                                                .Add("TargetFramework", "netcoreapp1.0"))))
-                        .Add("net462", ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|net462", Empty.PropertiesMap
-                                                                                .Add("Configuration", "Debug")
-                                                                                .Add("Platform", "AnyCPU")
-                                                                                .Add("TargetFramework", "net462"))));
+        ImmutableArray<ConfiguredProject> projects =
+        [
+            ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|net461", Empty.PropertiesMap
+                .Add("Configuration", "Debug")
+                .Add("Platform", "AnyCPU")
+                .Add("TargetFramework", "net461"))),
+            ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|netcoreapp1.0", Empty.PropertiesMap
+                .Add("Configuration", "Debug")
+                .Add("Platform", "AnyCPU")
+                .Add("TargetFramework", "netcoreapp1.0"))),
+            ConfiguredProjectFactory.Create(null, new StandardProjectConfiguration("Debug|AnyCPU|net462", Empty.PropertiesMap
+                .Add("Configuration", "Debug")
+                .Add("Platform", "AnyCPU")
+                .Add("TargetFramework", "net462")))
+        ];
 
         var projectProperties = ProjectPropertiesFactory.Create(project, data, data2);
         var projectConfigProvider = new IActiveConfiguredProjectsProviderFactory(MockBehavior.Strict)
-                                   .ImplementGetActiveConfiguredProjectsMapAsync(projects);
+                                   .ImplementGetActiveConfiguredProjectsAsync(new ActiveConfiguredObjects<ConfiguredProject>(projects, ["TargetFramework"]));
 
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 


### PR DESCRIPTION
Looking at `ActiveDebugFrameworkServices` today with @LittleLittleCloud showed some confusing and obsolete code that should be removed. This removes it and fixes up the one usage to be clearer.