### PR TITLE
Bump CPS package versions

### DIFF
--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>18.0.75-pre</CPSPackageVersion>
+    <CPSPackageVersion>18.0.175-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsProject.cs
@@ -24,14 +24,14 @@ public partial class VSProject : VSLangProj.VSProject, IConnectionPointContainer
 {
     private readonly VSLangProj.VSProject _vsProject;
     private readonly IProjectThreadingService _threadingService;
-    private readonly IActiveConfiguredValue<ProjectProperties> _projectProperties;
+    private readonly IActiveConfiguredValue<ProjectPropertiesAccess> _projectProperties;
     private readonly BuildManager _buildManager;
 
     [ImportingConstructor]
     internal VSProject(
         [Import(ExportContractNames.VsTypes.CpsVSProject)] VSLangProj.VSProject vsProject,
         IProjectThreadingService threadingService,
-        IActiveConfiguredValue<ProjectProperties> projectProperties,
+        IActiveConfiguredValue<ProjectPropertiesAccess> projectProperties,
         UnconfiguredProject project,
         BuildManager buildManager)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -14,10 +14,10 @@ internal class CreateFileFromTemplateService : ICreateFileFromTemplateService
 {
     private readonly IUnconfiguredProjectVsServices _projectVsServices;
     private readonly IVsUIService<DTE2> _dte;
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
 
     [ImportingConstructor]
-    public CreateFileFromTemplateService(IUnconfiguredProjectVsServices projectVsServices, IVsUIService<SDTE, DTE2> dte, ProjectProperties properties)
+    public CreateFileFromTemplateService(IUnconfiguredProjectVsServices projectVsServices, IVsUIService<SDTE, DTE2> dte, ProjectPropertiesAccess properties)
     {
         _projectVsServices = projectVsServices;
         _dte = dte;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/AbstractProjectConfigurationProperties.cs
@@ -7,11 +7,11 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 public abstract class AbstractProjectConfigurationProperties : ProjectConfigurationProperties3
 {
-    private readonly ProjectProperties _projectProperties;
+    private readonly ProjectPropertiesAccess _projectProperties;
     private readonly IProjectThreadingService _threadingService;
 
     internal AbstractProjectConfigurationProperties(
-        ProjectProperties projectProperties,
+        ProjectPropertiesAccess projectProperties,
         IProjectThreadingService threadingService)
     {
         Requires.NotNull(projectProperties);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/CSharp/CSharpProjectConfigurationProperties.cs
@@ -14,7 +14,7 @@ public class CSharpProjectConfigurationProperties : AbstractProjectConfiguration
 {
     [ImportingConstructor]
     internal CSharpProjectConfigurationProperties(
-        ProjectProperties projectProperties,
+        ProjectPropertiesAccess projectProperties,
         IProjectThreadingService threadingService)
         : base(projectProperties, threadingService)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeExValueProvider.cs
@@ -29,7 +29,7 @@ internal sealed class OutputTypeExValueProvider : OutputTypeValueProviderBase
     }.ToImmutableDictionary(StringComparers.PropertyLiteralValues);
 
     [ImportingConstructor]
-    public OutputTypeExValueProvider(ProjectProperties properties)
+    public OutputTypeExValueProvider(ProjectPropertiesAccess properties)
         : base(properties)
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProvider.cs
@@ -25,7 +25,7 @@ internal sealed class OutputTypeValueProvider : OutputTypeValueProviderBase
     }.ToImmutableDictionary(StringComparers.PropertyLiteralValues);
 
     [ImportingConstructor]
-    public OutputTypeValueProvider(ProjectProperties properties)
+    public OutputTypeValueProvider(ProjectPropertiesAccess properties)
         : base(properties)
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/OutputTypeValueProviderBase.cs
@@ -6,13 +6,13 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 
 internal abstract class OutputTypeValueProviderBase : InterceptingPropertyValueProviderBase
 {
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
 
     protected abstract ImmutableDictionary<string, string> GetMap { get; }
     protected abstract ImmutableDictionary<string, string> SetMap { get; }
     protected abstract string DefaultGetValue { get; }
 
-    protected OutputTypeValueProviderBase(ProjectProperties properties)
+    protected OutputTypeValueProviderBase(ProjectPropertiesAccess properties)
     {
         _properties = properties;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikerValueProvider.cs
@@ -9,10 +9,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties;
 internal sealed class TargetFrameworkMonikerValueProvider : InterceptingPropertyValueProviderBase
 {
     private readonly IUnconfiguredProjectVsServices _unconfiguredProjectVsServices;
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
 
     [ImportingConstructor]
-    public TargetFrameworkMonikerValueProvider(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, ProjectProperties properties)
+    public TargetFrameworkMonikerValueProvider(IUnconfiguredProjectVsServices unconfiguredProjectVsServices, ProjectPropertiesAccess properties)
     {
         _unconfiguredProjectVsServices = unconfiguredProjectVsServices;
         _properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetFrameworkMonikersValueProvider.cs
@@ -29,7 +29,7 @@ internal class TargetFrameworkMonikersValueProvider : InterceptingPropertyValueP
 
         foreach (ConfiguredProject configuredProject in configuredProjects.Objects)
         {
-            ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+            ProjectPropertiesAccess projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectPropertiesAccess>();
             ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
             string? currentTargetFrameworkMoniker = (string?)await configuration.TargetFrameworkMoniker.GetValueAsync();
             Assumes.NotNull(currentTargetFrameworkMoniker);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/InterceptedProjectProperties/TargetPlatformMonikersValueProvider.cs
@@ -29,7 +29,7 @@ internal class TargetPlatformMonikersValueProvider : InterceptingPropertyValuePr
 
         foreach (ConfiguredProject configuredProject in configuredProjects.Objects)
         {
-            ProjectProperties projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectProperties>();
+            ProjectPropertiesAccess projectProperties = configuredProject.Services.ExportProvider.GetExportedValue<ProjectPropertiesAccess>();
             ConfigurationGeneral configuration = await projectProperties.GetConfigurationGeneralPropertiesAsync();
             string? currentPlatformMoniker = (string?)await configuration.TargetPlatformIdentifier.GetValueAsync();
             string? currentPlatformVersion = (string?)await configuration.TargetPlatformVersion.GetValueAsync();

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/SplashScreenEnumProvider.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Properties.VisualBasic;
 [ExportDynamicEnumValuesProvider("SplashScreenEnumProvider")]
 [AppliesTo(ProjectCapability.VisualBasic)]
 [method: ImportingConstructor]
-internal sealed class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties propertiesProvider) : IDynamicEnumValuesProvider
+internal sealed class SplashScreenEnumProvider([Import(typeof(VisualStudioWorkspace))] Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectPropertiesAccess propertiesProvider) : IDynamicEnumValuesProvider
 {
     public Task<IDynamicEnumValuesGenerator> GetProviderAsync(IList<NameValuePair>? options)
     {
@@ -32,7 +32,7 @@ internal sealed class SplashScreenEnumProvider([Import(typeof(VisualStudioWorksp
         return Task.FromResult<IDynamicEnumValuesGenerator>(new SplashScreenEnumGenerator(workspace, unconfiguredProject, propertiesProvider, includeEmptyValue, searchForEntryPointsInFormsOnly: true));
     }
 
-    private sealed class SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectProperties properties, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly) : IDynamicEnumValuesGenerator
+    private sealed class SplashScreenEnumGenerator(Workspace workspace, UnconfiguredProject unconfiguredProject, ProjectPropertiesAccess properties, bool includeEmptyValue, bool searchForEntryPointsInFormsOnly) : IDynamicEnumValuesGenerator
     {
         public bool AllowCustomValues => false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectConfigurationProperties.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectConfigurationProperties.cs
@@ -12,7 +12,7 @@ public class VisualBasicProjectConfigurationProperties : AbstractProjectConfigur
 {
     [ImportingConstructor]
     internal VisualBasicProjectConfigurationProperties(
-        ProjectProperties projectProperties,
+        ProjectPropertiesAccess projectProperties,
         IProjectThreadingService threadingService)
         : base(projectProperties, threadingService)
     {

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UnconfiguredProjectVsServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UnconfiguredProjectVsServices.cs
@@ -59,7 +59,7 @@ internal class UnconfiguredProjectVsServices : IUnconfiguredProjectVsServices
         get { return _commonServices.ActiveConfiguredProject; }
     }
 
-    public ProjectProperties ActiveConfiguredProjectProperties
+    public ProjectPropertiesAccess ActiveConfiguredProjectProperties
     {
         get { return _commonServices.ActiveConfiguredProjectProperties; }
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.VisualStudio</RootNamespace>
     <!-- The value of RuleInjectionClassName of XamlPropertyRule items defined by this project -->
-    <XamlPropertyRuleInjectionClassName>ProjectProperties</XamlPropertyRuleInjectionClassName>
+    <XamlPropertyRuleInjectionClassName>ProjectPropertiesAccess</XamlPropertyRuleInjectionClassName>
     <IsManagedProjectSystemProject>true</IsManagedProjectSystemProject>
     <TargetFrameworks>net472;$(NetCoreTargetFramework)</TargetFrameworks>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -55,7 +55,7 @@ internal class LaunchSettingsProvider : ProjectValueDataSourceBase<ILaunchSettin
     private readonly IFileWatcherService _fileWatcherService;
     private readonly IManagedProjectDiagnosticOutputService? _diagnosticOutputService;
     private readonly IActiveConfiguredProjectSubscriptionService? _projectSubscriptionService;
-    private readonly IActiveConfiguredValue<ProjectProperties?> _projectProperties;
+    private readonly IActiveConfiguredValue<ProjectPropertiesAccess?> _projectProperties;
     private readonly IProjectFaultHandlerService _projectFaultHandler;
 
     private readonly AsyncLazy<string> _launchSettingsFilePath;
@@ -78,7 +78,7 @@ internal class LaunchSettingsProvider : ProjectValueDataSourceBase<ILaunchSettin
         IFileSystem fileSystem,
         IUnconfiguredProjectCommonServices commonProjectServices,
         IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
-        IActiveConfiguredValue<ProjectProperties?> projectProperties,
+        IActiveConfiguredValue<ProjectPropertiesAccess?> projectProperties,
         IProjectFaultHandlerService projectFaultHandler,
         IFileWatcherService fileWatchService,
         IManagedProjectDiagnosticOutputService? diagnosticOutputService,

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/OutputTypeChecker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/OutputTypeChecker.cs
@@ -8,10 +8,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Debug;
 [AppliesTo(ProjectCapability.DotNet)]
 internal class OutputTypeChecker : IOutputTypeChecker
 {
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
 
     [ImportingConstructor]
-    public OutputTypeChecker(ProjectProperties properties)
+    public OutputTypeChecker(ProjectPropertiesAccess properties)
     {
         _properties = properties;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/IUnconfiguredProjectCommonServices.cs
@@ -24,9 +24,9 @@ internal interface IUnconfiguredProjectCommonServices
     ConfiguredProject ActiveConfiguredProject { get; }
 
     /// <summary>
-    ///     Gets the <see cref="ProjectProperties"/> of the currently active configured project.
+    ///     Gets the <see cref="ProjectPropertiesAccess"/> of the currently active configured project.
     /// </summary>
-    ProjectProperties ActiveConfiguredProjectProperties { get; }
+    ProjectPropertiesAccess ActiveConfiguredProjectProperties { get; }
 
     /// <summary>
     ///     Gets the <see cref="IProjectAccessor"/> which provides access to MSBuild evaluation and construction models for a project.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProvider.cs
@@ -25,7 +25,7 @@ internal class CompoundTargetFrameworkValueProvider : InterceptingPropertyValueP
     private const string TargetFrameworkProperty = ConfigurationGeneral.TargetFrameworkProperty;
     private const string SupportedOSPlatformVersionProperty = "SupportedOSPlatformVersion";
 
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
     private readonly ConfiguredProject _configuredProject;
     private bool? _useWPFProperty;
     private bool? _useWindowsFormsProperty;
@@ -43,7 +43,7 @@ internal class CompoundTargetFrameworkValueProvider : InterceptingPropertyValueP
     }
 
     [ImportingConstructor]
-    public CompoundTargetFrameworkValueProvider(ProjectProperties properties)
+    public CompoundTargetFrameworkValueProvider(ProjectPropertiesAccess properties)
     {
         _properties = properties;
         _configuredProject = properties.ConfiguredProject;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/InterceptedProjectProperties/TargetFrameworkValueProvider.cs
@@ -7,10 +7,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 [ExportInterceptingPropertyValueProvider("TargetFramework", ExportInterceptingPropertyValueProviderFile.ProjectFile)]
 internal sealed class TargetFrameworkValueProvider : InterceptingPropertyValueProviderBase
 {
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
 
     [ImportingConstructor]
-    public TargetFrameworkValueProvider(ProjectProperties properties)
+    public TargetFrameworkValueProvider(ProjectPropertiesAccess properties)
     {
         _properties = properties;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PlatformTargetBuildPropertyPageEnumProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Properties/PlatformTargetBuildPropertyPageEnumProvider.cs
@@ -15,7 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Properties;
 [ExportDynamicEnumValuesProvider("PlatformTargetEnumProvider")]
 [AppliesTo(ProjectCapability.DotNet)]
 [method: ImportingConstructor]
-internal sealed class PlatformTargetBuildPropertyPageEnumProvider(ProjectProperties properties) : IDynamicEnumValuesProvider, IDynamicEnumValuesGenerator
+internal sealed class PlatformTargetBuildPropertyPageEnumProvider(ProjectPropertiesAccess properties) : IDynamicEnumValuesProvider, IDynamicEnumValuesGenerator
 {
     public bool AllowCustomValues => false;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectPropertiesAccess.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/ProjectPropertiesAccess.cs
@@ -12,37 +12,37 @@ namespace Microsoft.VisualStudio.ProjectSystem;
 [Export]
 [ExcludeFromCodeCoverage]
 [ProjectSystemContract(ProjectSystemContractScope.ConfiguredProject, ProjectSystemContractProvider.Private, Cardinality = ImportCardinality.ExactlyOne)]
-internal partial class ProjectProperties : StronglyTypedPropertyAccess
+internal partial class ProjectPropertiesAccess : StronglyTypedPropertyAccess
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProjectProperties"/> class.
+    /// Initializes a new instance of the <see cref="ProjectPropertiesAccess"/> class.
     /// </summary>
     [ImportingConstructor]
-    public ProjectProperties([Import] ConfiguredProject configuredProject)
+    public ProjectPropertiesAccess([Import] ConfiguredProject configuredProject)
         : base(configuredProject)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProjectProperties"/> class.
+    /// Initializes a new instance of the <see cref="ProjectPropertiesAccess"/> class.
     /// </summary>
-    public ProjectProperties(ConfiguredProject configuredProject, string file, string itemType, string itemName)
+    public ProjectPropertiesAccess(ConfiguredProject configuredProject, string file, string itemType, string itemName)
         : base(configuredProject, file, itemType, itemName)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProjectProperties"/> class.
+    /// Initializes a new instance of the <see cref="ProjectPropertiesAccess"/> class.
     /// </summary>
-    public ProjectProperties(ConfiguredProject configuredProject, IProjectPropertiesContext projectPropertiesContext)
+    public ProjectPropertiesAccess(ConfiguredProject configuredProject, IProjectPropertiesContext projectPropertiesContext)
         : base(configuredProject, projectPropertiesContext)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="ProjectProperties"/> class.
+    /// Initializes a new instance of the <see cref="ProjectPropertiesAccess"/> class.
     /// </summary>
-    public ProjectProperties(ConfiguredProject configuredProject, UnconfiguredProject project)
+    public ProjectPropertiesAccess(ConfiguredProject configuredProject, UnconfiguredProject project)
         : base(configuredProject, project)
     {
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -11,10 +11,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders;
 [AppliesTo(ProjectCapability.AppDesigner)]
 internal class AppDesignerFolderSpecialFileProvider : AbstractSpecialFileProvider, IAppDesignerFolderSpecialFileProvider
 {
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
 
     [ImportingConstructor]
-    public AppDesignerFolderSpecialFileProvider(IPhysicalProjectTree projectTree, ProjectProperties properties)
+    public AppDesignerFolderSpecialFileProvider(IPhysicalProjectTree projectTree, ProjectPropertiesAccess properties)
         : base(projectTree, isFolder: true)
     {
         _properties = properties;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProvider.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.SpecialFileProviders;
 [AppliesTo(ProjectCapability.DotNet)]
 internal class AppManifestSpecialFileProvider : AbstractFindByNameUnderAppDesignerSpecialFileProvider
 {
-    private readonly ProjectProperties _properties;
+    private readonly ProjectPropertiesAccess _properties;
     private readonly ICreateFileFromTemplateService _templateFileCreationService;
 
     [ImportingConstructor]
@@ -19,7 +19,7 @@ internal class AppManifestSpecialFileProvider : AbstractFindByNameUnderAppDesign
         ISpecialFilesManager specialFilesManager,
         IPhysicalProjectTree projectTree,
         ICreateFileFromTemplateService templateFileCreationService,
-        ProjectProperties properties)
+        ProjectPropertiesAccess properties)
         : base("app.manifest", specialFilesManager, projectTree)
     {
         _templateFileCreationService = templateFileCreationService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AppDesignerFolderRenameHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/AppDesignerFolderRenameHandler.cs
@@ -13,10 +13,10 @@ namespace Microsoft.VisualStudio.ProjectSystem.Tree;
 [AppliesTo(ProjectCapability.AppDesigner)]
 internal class AppDesignerFolderRenameHandler : ProjectTreeActionHandlerBase
 {
-    private readonly IActiveConfiguredValue<ProjectProperties> _properties;
+    private readonly IActiveConfiguredValue<ProjectPropertiesAccess> _properties;
 
     [ImportingConstructor]
-    public AppDesignerFolderRenameHandler(IActiveConfiguredValue<ProjectProperties> properties)
+    public AppDesignerFolderRenameHandler(IActiveConfiguredValue<ProjectPropertiesAccess> properties)
     {
         _properties = properties;
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/UnconfiguredProjectCommonServices.cs
@@ -12,11 +12,11 @@ internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonSer
     private readonly Lazy<IProjectThreadingService> _threadingService;
     private readonly Lazy<IProjectAccessor> _projectAccessor;
     private readonly IActiveConfiguredValue<ConfiguredProject> _activeConfiguredProject;
-    private readonly IActiveConfiguredValue<ProjectProperties> _activeConfiguredProjectProperties;
+    private readonly IActiveConfiguredValue<ProjectPropertiesAccess> _activeConfiguredProjectProperties;
 
     [ImportingConstructor]
     public UnconfiguredProjectCommonServices(UnconfiguredProject project, Lazy<IProjectThreadingService> threadingService,
-                                             IActiveConfiguredValue<ConfiguredProject> activeConfiguredProject, IActiveConfiguredValue<ProjectProperties> activeConfiguredProjectProperties,
+                                             IActiveConfiguredValue<ConfiguredProject> activeConfiguredProject, IActiveConfiguredValue<ProjectPropertiesAccess> activeConfiguredProjectProperties,
                                              Lazy<IProjectAccessor> projectAccessor)
     {
         _project = project;
@@ -41,7 +41,7 @@ internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonSer
         get { return _activeConfiguredProject.Value; }
     }
 
-    public ProjectProperties ActiveConfiguredProjectProperties
+    public ProjectPropertiesAccess ActiveConfiguredProjectProperties
     {
         get { return _activeConfiguredProjectProperties.Value; }
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IUnconfiguredProjectCommonServicesFactory.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.ProjectSystem;
 internal static class IUnconfiguredProjectCommonServicesFactory
 {
     public static IUnconfiguredProjectCommonServices Create(UnconfiguredProject? project = null, IProjectThreadingService? threadingService = null,
-                                                            ConfiguredProject? configuredProject = null, ProjectProperties? projectProperties = null,
+                                                            ConfiguredProject? configuredProject = null, ProjectPropertiesAccess? projectProperties = null,
                                                             IProjectAccessor? projectAccessor = null)
     {
         var mock = new Mock<IUnconfiguredProjectCommonServices>();

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/ProjectPropertiesFactory.cs
@@ -4,26 +4,26 @@ using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.ProjectSystem;
 
-internal static class ProjectPropertiesFactory
+internal static class ProjectPropertiesAccessFactory
 {
-    public static ProjectProperties CreateEmpty()
+    public static ProjectPropertiesAccess CreateEmpty()
     {
         return Create(UnconfiguredProjectFactory.Create());
     }
 
-    public static ProjectProperties Create(string category, string propertyName, string? value)
+    public static ProjectPropertiesAccess Create(string category, string propertyName, string? value)
     {
         var data = new PropertyPageData(category, propertyName, value);
 
         return Create(data);
     }
 
-    public static ProjectProperties Create(params PropertyPageData[] data)
+    public static ProjectPropertiesAccess Create(params PropertyPageData[] data)
     {
         return Create(UnconfiguredProjectFactory.Create(), data);
     }
 
-    public static ProjectProperties Create(UnconfiguredProject project, params PropertyPageData[] data)
+    public static ProjectPropertiesAccess Create(UnconfiguredProject project, params PropertyPageData[] data)
     {
         var catalog = IPropertyPagesCatalogFactory.Create(data);
         var propertyPagesCatalogProvider = IPropertyPagesCatalogProviderFactory.Create(
@@ -46,6 +46,6 @@ internal static class ProjectPropertiesFactory
             o.Services == configuredProjectServices &&
             o.ProjectConfiguration == cfg);
 
-        return new ProjectProperties(configuredProject);
+        return new ProjectPropertiesAccess(configuredProject);
     }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/ActiveDebugFrameworkServicesTests.cs
@@ -14,7 +14,7 @@ public class ActiveDebugFrameworkServicesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworksProperty, frameworks);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 
@@ -37,7 +37,7 @@ public class ActiveDebugFrameworkServicesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ProjectDebugger.SchemaName, ProjectDebugger.ActiveDebugFrameworkProperty, framework);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 
@@ -53,7 +53,7 @@ public class ActiveDebugFrameworkServicesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ProjectDebugger.SchemaName, ProjectDebugger.ActiveDebugFrameworkProperty, "FrameworkOne");
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 
@@ -90,7 +90,7 @@ public class ActiveDebugFrameworkServicesTests
                 .Add("TargetFramework", "net462")))
         ];
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data, data2);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data, data2);
         var projectConfigProvider = new IActiveConfiguredProjectsProviderFactory(MockBehavior.Strict)
                                    .ImplementGetActiveConfiguredProjectsAsync(new ActiveConfiguredObjects<ConfiguredProject>(projects, ["TargetFramework"]));
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/LaunchSettingsProviderTests.cs
@@ -20,11 +20,11 @@ public class LaunchSettingsProviderTests
         activeProfileValue.Setup(s => s.Name).Returns(activeProfile);
         var debuggerData = new PropertyPageData(ProjectDebugger.SchemaName, ProjectDebugger.ActiveDebugProfileProperty, activeProfileValue.Object);
 
-        var projectProperties = ProjectPropertiesFactory.Create(AppDesigner.SchemaName, AppDesigner.FolderNameProperty, appDesignerFolder);
-        var activeConfigurationProjectProperties = IActiveConfiguredValueFactory.ImplementValue<ProjectProperties?>(() => projectProperties);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(AppDesigner.SchemaName, AppDesigner.FolderNameProperty, appDesignerFolder);
+        var activeConfigurationProjectProperties = IActiveConfiguredValueFactory.ImplementValue<ProjectPropertiesAccess?>(() => projectProperties);
         var configuredProject = ConfiguredProjectFactory.Create();
         var project = UnconfiguredProjectFactory.Create(fullPath: @"c:\test\Project1\Project1.csproj", configuredProject: configuredProject);
-        var properties = ProjectPropertiesFactory.Create(project, [debuggerData]);
+        var properties = ProjectPropertiesAccessFactory.Create(project, [debuggerData]);
         var threadingService = IProjectThreadingServiceFactory.Create();
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(project, threadingService, null, properties);
         var projectServices = IUnconfiguredProjectServicesFactory.Create(
@@ -1045,7 +1045,7 @@ internal class LaunchSettingsUnderTest : LaunchSettingsProvider
         IFileSystem fileSystem,
         IUnconfiguredProjectCommonServices commonProjectServices,
         IActiveConfiguredProjectSubscriptionService? projectSubscriptionService,
-        IActiveConfiguredValue<ProjectProperties?> projectProperties,
+        IActiveConfiguredValue<ProjectPropertiesAccess?> projectProperties,
         IProjectFaultHandlerService projectFaultHandler,
         IDefaultLaunchProfileProvider defaultLaunchProfileProvider,
         IFileWatcherService fileWatcherService,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/OutputTypeCheckerTest.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Debug/OutputTypeCheckerTest.cs
@@ -51,7 +51,7 @@ public class OutputTypeCheckerTest
 
     private static OutputTypeChecker CreateFailedOutputTypeChecker()
     {
-        var projectProperties = ProjectPropertiesFactory.CreateEmpty();
+        var projectProperties = ProjectPropertiesAccessFactory.CreateEmpty();
 
         return new OutputTypeChecker2(projectProperties);
     }
@@ -62,12 +62,12 @@ public class OutputTypeCheckerTest
 
         var outputTypeEnum = new PageEnumValue(new EnumValue { Name = outputType });
         var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypeEnum);
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         return new OutputTypeChecker(projectProperties);
     }
 
-    internal class OutputTypeChecker2(ProjectProperties properties) : OutputTypeChecker(properties)
+    internal class OutputTypeChecker2(ProjectPropertiesAccess properties) : OutputTypeChecker(properties)
     {
         protected override Task<IEnumValue?> GetEvaluatedOutputTypeAsync()
         {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/ApplicationPropertyPage/CompoundTargetFrameworkValueProviderTests.cs
@@ -25,7 +25,7 @@ public class CompoundTargetFrameworkValueProviderTests
         var iProjectProperties = IProjectPropertiesFactory.CreateWithPropertiesAndValues(propertiesAndValues);
 
         // New target framework properties
-        var projectProperties = ProjectPropertiesFactory.Create(
+        var projectProperties = ProjectPropertiesAccessFactory.Create(
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkProperty, tf, null),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkMonikerProperty, tfm, null),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkIdentifierProperty, tfi, null),

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/TargetFrameworkValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/Properties/InterceptingProjectProperties/TargetFrameworkValueProviderTests.cs
@@ -14,7 +14,7 @@ public class TargetFrameworkValueProviderTests
         var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TargetFrameworkMonikerProperty, configuredTargetFramework.FullName);
 
         var project = UnconfiguredProjectFactory.Create();
-        var properties = ProjectPropertiesFactory.Create(project, data);
+        var properties = ProjectPropertiesAccessFactory.Create(project, data);
         var delegateProvider = IProjectPropertiesProviderFactory.Create();
 
         var instancePropertiesMock = IProjectPropertiesFactory

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProviderTests.cs
@@ -272,14 +272,14 @@ public class AppDesignerFolderSpecialFileProviderTests
         Assert.Null(result);
     }
 
-    private static ProjectProperties CreateProperties(string appDesignerFolderName)
+    private static ProjectPropertiesAccess CreateProperties(string appDesignerFolderName)
     {
-        return ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(), [
+        return ProjectPropertiesAccessFactory.Create(UnconfiguredProjectFactory.Create(), [
                 new PropertyPageData(AppDesigner.SchemaName, AppDesigner.FolderNameProperty, appDesignerFolderName)
             ]);
     }
 
-    private static AppDesignerFolderSpecialFileProvider CreateInstance(IPhysicalProjectTree? physicalProjectTree = null, ProjectProperties? properties = null)
+    private static AppDesignerFolderSpecialFileProvider CreateInstance(IPhysicalProjectTree? physicalProjectTree = null, ProjectPropertiesAccess? properties = null)
     {
         physicalProjectTree ??= IPhysicalProjectTreeFactory.Create();
         properties ??= CreateProperties(appDesignerFolderName: "Properties");

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/SpecialFileProviders/AppManifestSpecialFileProviderTests.cs
@@ -16,9 +16,9 @@ public class AppManifestSpecialFileProviderTests : AbstractFindByNameUnderAppDes
         return CreateInstanceWithOverrideCreateFileAsync<AppManifestSpecialFileProvider>(specialFilesManager, projectTree, properties);
     }
 
-    private ProjectProperties CreateProperties(string appManifestPropertyValue)
+    private ProjectPropertiesAccess CreateProperties(string appManifestPropertyValue)
     {
-        return ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(),
+        return ProjectPropertiesAccessFactory.Create(UnconfiguredProjectFactory.Create(),
             new PropertyPageData(
                 ConfigurationGeneralBrowseObject.SchemaName,
                 ConfigurationGeneralBrowseObject.ApplicationManifestProperty,

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/ProjectSystem/UnconfiguredProjectCommonServicesTests.cs
@@ -9,7 +9,7 @@ public class UnconfiguredProjectCommonServicesTests
     {
         var project = UnconfiguredProjectFactory.Create();
         var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
         var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
         var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
@@ -24,7 +24,7 @@ public class UnconfiguredProjectCommonServicesTests
     {
         var project = UnconfiguredProjectFactory.Create();
         var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
         var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
         var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
@@ -39,7 +39,7 @@ public class UnconfiguredProjectCommonServicesTests
     {
         var project = UnconfiguredProjectFactory.Create();
         var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
         var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
         var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
@@ -54,7 +54,7 @@ public class UnconfiguredProjectCommonServicesTests
     {
         var project = UnconfiguredProjectFactory.Create();
         var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
         var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
         var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());
@@ -69,7 +69,7 @@ public class UnconfiguredProjectCommonServicesTests
     {
         var project = UnconfiguredProjectFactory.Create();
         var threadingService = new Lazy<IProjectThreadingService>(() => IProjectThreadingServiceFactory.Create());
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties.ConfiguredProject);
         var activeConfiguredProjectProperties = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
         var projectAccessor = new Lazy<IProjectAccessor>(() => IProjectAccessorFactory.Create());

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesFactory.cs
@@ -14,7 +14,7 @@ internal static class IUnconfiguredProjectVsServicesFactory
     public static IUnconfiguredProjectVsServices Implement(Func<IVsHierarchy>? hierarchyCreator = null,
                                                            Func<IVsProject4>? projectCreator = null,
                                                            Func<IProjectThreadingService>? threadingServiceCreator = null,
-                                                           Func<ProjectProperties>? projectProperties = null,
+                                                           Func<ProjectPropertiesAccess>? projectProperties = null,
                                                            Func<ConfiguredProject>? configuredProjectCreator = null,
                                                            Func<UnconfiguredProject>? unconfiguredProjectCreator = null)
     {

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Mocks/IUnconfiguredProjectVsServicesMock.cs
@@ -30,9 +30,9 @@ internal class IUnconfiguredProjectVsServicesMock : AbstractMock<IUnconfiguredPr
         return this;
     }
 
-    public IUnconfiguredProjectVsServicesMock ImplementActiveConfiguredProjectProperties(ProjectProperties? projectProperties)
+    public IUnconfiguredProjectVsServicesMock ImplementActiveConfiguredProjectProperties(ProjectPropertiesAccess? projectProperties)
     {
-        SetupGet<ProjectProperties?>(m => m.ActiveConfiguredProjectProperties)
+        SetupGet<ProjectPropertiesAccess?>(m => m.ActiveConfiguredProjectProperties)
             .Returns(projectProperties);
 
         return this;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Automation/VsLangProjectPropertiesTests.cs
@@ -17,7 +17,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var vsproject = CreateInstance(
                             Mock.Of<VSLangProj.VSProject>(),
                             threadingService: Mock.Of<IProjectThreadingService>(),
-                            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>());
+                            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectPropertiesAccess>>());
         Assert.NotNull(vsproject);
     }
 
@@ -37,7 +37,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var vsproject = CreateInstance(
                             innerVSProjectMock.Object,
                             threadingService: Mock.Of<IProjectThreadingService>(),
-                            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>());
+                            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectPropertiesAccess>>());
         Assert.NotNull(vsproject);
         Assert.True(imports.Equals(vsproject.Imports));
         Assert.Equal(events, vsproject.Events);
@@ -66,7 +66,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var vsproject = new VSProjectTestImpl(
                             innerVSProjectMock.Object,
                             threadingService: Mock.Of<IProjectThreadingService>(),
-                            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>(),
+                            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectPropertiesAccess>>(),
                             project: unconfiguredProjectMock.Object,
                             buildManager: Mock.Of<BuildManager>());
 
@@ -85,7 +85,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfigurationGeneralBrowseObject.SchemaName, ConfigurationGeneralBrowseObject.OutputTypeProperty, 4, setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
         var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
@@ -102,7 +102,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfigurationGeneralBrowseObject.SchemaName, ConfigurationGeneralBrowseObject.OutputTypeProperty, 1, setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
         var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
@@ -119,7 +119,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.AssemblyNameProperty, "Blah", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
         var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
@@ -136,7 +136,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.ProjectDirProperty, "somepath");
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
         var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
@@ -149,7 +149,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfigurationGeneralBrowseObject.SchemaName, ConfigurationGeneralBrowseObject.FullPathProperty, "testvalue");
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
         var activeConfiguredProject = IActiveConfiguredValueFactory.ImplementValue(() => projectProperties);
 
         var vsLangProjectProperties = CreateInstance(Mock.Of<VSLangProj.VSProject>(), IProjectThreadingServiceFactory.Create(), activeConfiguredProject);
@@ -162,7 +162,7 @@ public class VSProject_VSLangProjectPropertiesTests
         var vsproject = CreateInstance(
             Mock.Of<VSLangProj.VSProject>(),
             threadingService: Mock.Of<IProjectThreadingService>(),
-            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectProperties>>(),
+            projectProperties: Mock.Of<IActiveConfiguredValue<ProjectPropertiesAccess>>(),
             buildManager: Mock.Of<BuildManager>());
         Assert.Null(vsproject.ExtenderCATID);
     }
@@ -170,7 +170,7 @@ public class VSProject_VSLangProjectPropertiesTests
     private static VSProject CreateInstance(
         VSLangProj.VSProject vsproject,
         IProjectThreadingService threadingService,
-        IActiveConfiguredValue<ProjectProperties> projectProperties,
+        IActiveConfiguredValue<ProjectPropertiesAccess> projectProperties,
         UnconfiguredProject? project = null,
         BuildManager? buildManager = null)
     {
@@ -184,7 +184,7 @@ public class VSProject_VSLangProjectPropertiesTests
         public VSProjectTestImpl(
             VSLangProj.VSProject vsProject,
             IProjectThreadingService threadingService,
-            IActiveConfiguredValue<ProjectProperties> projectProperties,
+            IActiveConfiguredValue<ProjectPropertiesAccess> projectProperties,
             UnconfiguredProject project,
             BuildManager buildManager)
             : base(vsProject, threadingService, projectProperties, project, buildManager)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/CreateFileFromTemplateServiceTests.cs
@@ -85,18 +85,18 @@ public class CreateFileFromTemplateServiceTests
         return CreateInstance(null, null, null);
     }
 
-    private static CreateFileFromTemplateService CreateInstance(IUnconfiguredProjectVsServices? projectVsServices, DTE2? dte, ProjectProperties? properties)
+    private static CreateFileFromTemplateService CreateInstance(IUnconfiguredProjectVsServices? projectVsServices, DTE2? dte, ProjectPropertiesAccess? properties)
     {
         projectVsServices ??= IUnconfiguredProjectVsServicesFactory.Create();
         dte ??= DTEFactory.Create();
-        properties ??= ProjectPropertiesFactory.CreateEmpty();
+        properties ??= ProjectPropertiesAccessFactory.CreateEmpty();
 
         return new CreateFileFromTemplateService(projectVsServices, IVsUIServiceFactory.Create<SDTE, DTE2>(dte), properties);
     }
 
-    private static ProjectProperties CreateProperties()
+    private static ProjectPropertiesAccess CreateProperties()
     {
-        var properties = ProjectPropertiesFactory.Create(UnconfiguredProjectFactory.Create(),
+        var properties = ProjectPropertiesAccessFactory.Create(UnconfiguredProjectFactory.Create(),
                     new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.TemplateLanguageProperty, "CSharp"));
 
         return properties;

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/VsContainedLanguageComponentsFactoryTests.cs
@@ -42,7 +42,7 @@ public class VsContainedLanguageComponentsFactoryTests
     public void GetContainedLanguageFactoryForFile_WhenLanguageServiceIdEmptyOrInvalid_ReturnE_FAIL(string languageServiceId)
     {
         var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true);
-        var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, languageServiceId);
+        var properties = ProjectPropertiesAccessFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, languageServiceId);
 
         var factory = CreateInstance(project, properties: properties);
 
@@ -55,7 +55,7 @@ public class VsContainedLanguageComponentsFactoryTests
     public void GetContainedLanguageFactoryForFile_WhenNoContainedLanguageFactory_ReturnE_FAIL()
     {
         var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true);
-        var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
+        var properties = ProjectPropertiesAccessFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
 
         var factory = CreateInstance(project, containedLanguageFactory: null!, properties: properties);
 
@@ -69,7 +69,7 @@ public class VsContainedLanguageComponentsFactoryTests
     {
         var hierarchy = IVsHierarchyFactory.Create();
         var project = IVsProject_Factory.ImplementIsDocumentInProject(found: true, itemid: 1);
-        var properties = ProjectPropertiesFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
+        var properties = ProjectPropertiesAccessFactory.Create(ConfigurationGeneral.SchemaName, ConfigurationGeneral.LanguageServiceIdProperty, LanguageServiceId);
         var containedLanguageFactory = IVsContainedLanguageFactoryFactory.Create();
 
         var factory = CreateInstance(project, containedLanguageFactory: containedLanguageFactory, hierarchy: hierarchy, properties: properties);
@@ -94,7 +94,7 @@ public class VsContainedLanguageComponentsFactoryTests
         IVsProject4 project,
         IVsContainedLanguageFactory? containedLanguageFactory = null,
         IVsHierarchy? hierarchy = null,
-        ProjectProperties? properties = null,
+        ProjectPropertiesAccess? properties = null,
         IWorkspaceWriter? workspaceWriter = null)
     {
         var serviceProvider = IOleAsyncServiceProviderFactory.ImplementQueryServiceAsync(containedLanguageFactory, new Guid(LanguageServiceId));

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/CSharp/CSharpProjectConfigurationPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/CSharp/CSharpProjectConfigurationPropertiesTests.cs
@@ -18,7 +18,7 @@ public class CSharpProjectConfigurationPropertiesTests
     {
         Assert.Throws<ArgumentNullException>("threadingService", () =>
         {
-            new CSharpProjectConfigurationProperties(ProjectPropertiesFactory.CreateEmpty(), null!);
+            new CSharpProjectConfigurationProperties(ProjectPropertiesAccessFactory.CreateEmpty(), null!);
         });
     }
 
@@ -29,7 +29,7 @@ public class CSharpProjectConfigurationPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfiguredBrowseObject.SchemaName, ConfiguredBrowseObject.CodeAnalysisRuleSetProperty, "Blah", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
         Assert.Equal("Blah", vsLangProjectProperties.CodeAnalysisRuleSet);
@@ -46,7 +46,7 @@ public class CSharpProjectConfigurationPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfiguredBrowseObject.SchemaName, ConfiguredBrowseObject.LangVersionProperty, "6", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
         Assert.Equal("6", vsLangProjectProperties.LanguageVersion);
@@ -63,7 +63,7 @@ public class CSharpProjectConfigurationPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfiguredBrowseObject.SchemaName, ConfiguredBrowseObject.OutputPathProperty, "OldPath", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
         Assert.Equal("OldPath", vsLangProjectProperties.OutputPath);
@@ -73,7 +73,7 @@ public class CSharpProjectConfigurationPropertiesTests
         Assert.Equal(setValues.Single(), testValue);
     }
 
-    private static CSharpProjectConfigurationProperties CreateInstance(ProjectProperties projectProperties, IProjectThreadingService projectThreadingService)
+    private static CSharpProjectConfigurationProperties CreateInstance(ProjectPropertiesAccess projectProperties, IProjectThreadingService projectThreadingService)
     {
         return new CSharpProjectConfigurationProperties(projectProperties, projectThreadingService);
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeExValueProviderTests.cs
@@ -14,7 +14,7 @@ public class OutputTypeExValueProviderTests
     [InlineData("", "0")]
     public async Task GetEvaluatedValue(object outputTypePropertyValue, string expectedMappedValue)
     {
-        var properties = ProjectPropertiesFactory.Create(
+        var properties = ProjectPropertiesAccessFactory.Create(
             UnconfiguredProjectFactory.Create(),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypePropertyValue));
         var provider = new OutputTypeExValueProvider(properties);
@@ -32,7 +32,7 @@ public class OutputTypeExValueProviderTests
     public async Task SetValue(string incomingValue, string expectedOutputTypeValue)
     {
         var setValues = new List<object>();
-        var properties = ProjectPropertiesFactory.Create(
+        var properties = ProjectPropertiesAccessFactory.Create(
             UnconfiguredProjectFactory.Create(),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, "InitialValue", setValues));
         var provider = new OutputTypeExValueProvider(properties);
@@ -45,7 +45,7 @@ public class OutputTypeExValueProviderTests
     public async Task SetValue_ThrowsKeyNotFoundException()
     {
         var setValues = new List<object>();
-        var properties = ProjectPropertiesFactory.Create(
+        var properties = ProjectPropertiesAccessFactory.Create(
             UnconfiguredProjectFactory.Create(),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, "InitialValue", setValues));
         var provider = new OutputTypeExValueProvider(properties);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/OutputTypeValueProviderTests.cs
@@ -14,7 +14,7 @@ public class OutputTypeValueProviderTests
     [InlineData("", "0")]
     public async Task GetEvaluatedValue(object outputTypePropertyValue, string expectedMappedValue)
     {
-        var properties = ProjectPropertiesFactory.Create(
+        var properties = ProjectPropertiesAccessFactory.Create(
             UnconfiguredProjectFactory.Create(),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, outputTypePropertyValue));
         var provider = new OutputTypeValueProvider(properties);
@@ -30,7 +30,7 @@ public class OutputTypeValueProviderTests
     public async Task SetValue(string incomingValue, string expectedOutputTypeValue)
     {
         var setValues = new List<object>();
-        var properties = ProjectPropertiesFactory.Create(
+        var properties = ProjectPropertiesAccessFactory.Create(
             UnconfiguredProjectFactory.Create(),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, "InitialValue", setValues));
         var provider = new OutputTypeValueProvider(properties);
@@ -45,7 +45,7 @@ public class OutputTypeValueProviderTests
     public async Task SetValue_ThrowsKeyNotFoundException(string invalidValue)
     {
         var setValues = new List<object>();
-        var properties = ProjectPropertiesFactory.Create(
+        var properties = ProjectPropertiesAccessFactory.Create(
             UnconfiguredProjectFactory.Create(),
             new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.OutputTypeProperty, "InitialValue", setValues));
         var provider = new OutputTypeValueProvider(properties);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectConfigurationPropertiesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Properties/VisualBasic/VisualBasicProjectConfigurationPropertiesTests.cs
@@ -18,7 +18,7 @@ public class VisualBasicProjectConfigurationPropertiesTests
     {
         Assert.Throws<ArgumentNullException>("threadingService", () =>
         {
-            new VisualBasicProjectConfigurationProperties(ProjectPropertiesFactory.CreateEmpty(), null!);
+            new VisualBasicProjectConfigurationProperties(ProjectPropertiesAccessFactory.CreateEmpty(), null!);
         });
     }
 
@@ -29,7 +29,7 @@ public class VisualBasicProjectConfigurationPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfiguredBrowseObject.SchemaName, ConfiguredBrowseObject.CodeAnalysisRuleSetProperty, "Blah", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
         Assert.Equal("Blah", vsLangProjectProperties.CodeAnalysisRuleSet);
@@ -46,7 +46,7 @@ public class VisualBasicProjectConfigurationPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfiguredBrowseObject.SchemaName, ConfiguredBrowseObject.LangVersionProperty, "9", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
         Assert.Equal("9", vsLangProjectProperties.LanguageVersion);
@@ -63,7 +63,7 @@ public class VisualBasicProjectConfigurationPropertiesTests
         var project = UnconfiguredProjectFactory.Create();
         var data = new PropertyPageData(ConfiguredBrowseObject.SchemaName, ConfiguredBrowseObject.OutputPathProperty, "OldPath", setValues);
 
-        var projectProperties = ProjectPropertiesFactory.Create(project, data);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project, data);
 
         var vsLangProjectProperties = CreateInstance(projectProperties, IProjectThreadingServiceFactory.Create());
         Assert.Equal("OldPath", vsLangProjectProperties.OutputPath);
@@ -73,7 +73,7 @@ public class VisualBasicProjectConfigurationPropertiesTests
         Assert.Equal(setValues.Single(), testValue);
     }
 
-    private static VisualBasicProjectConfigurationProperties CreateInstance(ProjectProperties projectProperties, IProjectThreadingService projectThreadingService)
+    private static VisualBasicProjectConfigurationProperties CreateInstance(ProjectPropertiesAccess projectProperties, IProjectThreadingService projectThreadingService)
     {
         return new VisualBasicProjectConfigurationProperties(projectProperties, projectThreadingService);
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/UnconfiguredProjectVsServicesTests.cs
@@ -56,7 +56,7 @@ public class UnconfiguredProjectVsServicesTests
     public void Constructor_ValueAsCommonServices_SetsActiveConfiguredProjectProjectToCommonServicesActiveConfiguredProject()
     {
         var project = UnconfiguredProjectFactory.Create();
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(configuredProject: projectProperties.ConfiguredProject);
 
         var vsServices = CreateInstance(commonServices);
@@ -68,7 +68,7 @@ public class UnconfiguredProjectVsServicesTests
     public void Constructor_ValueAsCommonServices_SetsActiveConfiguredProjectPropertiesToCommonServicesActiveConfiguredProjectProperties()
     {
         var project = UnconfiguredProjectFactory.Create();
-        var projectProperties = ProjectPropertiesFactory.Create(project);
+        var projectProperties = ProjectPropertiesAccessFactory.Create(project);
         var commonServices = IUnconfiguredProjectCommonServicesFactory.Create(projectProperties: projectProperties);
 
         var vsServices = CreateInstance(commonServices);

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SdkVersionReporterTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/Telemetry/SdkVersionReporterTests.cs
@@ -25,7 +25,7 @@ public static class SdkVersionReporterTests
         TelemetryParameters? result = null;
 
         var projectVsServices = IUnconfiguredProjectVsServicesFactory.Implement(
-            projectProperties: () => ProjectPropertiesFactory.Create(
+            projectProperties: () => ProjectPropertiesAccessFactory.Create(
                 project: UnconfiguredProjectFactory.Create(),
                 data: new PropertyPageData(ConfigurationGeneral.SchemaName, ConfigurationGeneral.NETCoreSdkVersionProperty, version ?? string.Empty)));
 


### PR DESCRIPTION
This introduced a new warning about ambiguous names, which is treated as an error.

> The namespace 'Microsoft.VisualStudio.ProjectSystem.ProjectProperties' in 'Microsoft.VisualStudio.ProjectSystem.dll' conflicts with the type 'ProjectProperties' in 'Microsoft.VisualStudio.ProjectSystem.Managed.dll'

To avoid this we could introduce an assembly alias and update all usages in code to reflect that.

Or, given the type `ProjectProperties` is internal, we can just rename it to avoid the conflict. That's what we do here.