### PR TITLE
Use metadata to control when to load dynamic components.

### DIFF
--- a/eng/imports/Versions.props
+++ b/eng/imports/Versions.props
@@ -1,6 +1,6 @@
 <!-- Any changes to this file or format requires updates in project-system-vscode -->
 <Project>
   <PropertyGroup>
-    <CPSPackageVersion>18.0.75-pre</CPSPackageVersion>
+    <CPSPackageVersion>18.0.176-pre</CPSPackageVersion>
   </PropertyGroup>
 </Project>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Build/ImplicitlyTriggeredDebugBuildManager.cs
@@ -13,6 +13,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Build;
 /// </summary>
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.DotNet)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.ProjectBackgroundLoadCompleted)]
 internal class ImplicitlyTriggeredDebugBuildManager : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent, IVsUpdateSolutionEvents2, IVsUpdateSolutionEvents3
 {
     private readonly IStartupProjectHelper _startupProjectHelper;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/LanguageServiceHost.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.LanguageServices;
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [ExportInitialBuildRulesSubscriptions(CompilerCommandLineArgs.SchemaName)]
 [AppliesTo(ProjectCapability.DotNetLanguageService)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.AfterLoadInitialConfiguration)]
 internal sealed class LanguageServiceHost : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent, IWorkspaceWriter
 {
     /// <summary>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/NuGetRestoreService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/PackageRestore/NuGetRestoreService.cs
@@ -10,6 +10,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.PackageRestore;
 [Export(typeof(INuGetRestoreService))]
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.PackageReferences)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.AfterLoadInitialConfiguration)]
 internal class NuGetRestoreService : OnceInitializedOnceDisposed, INuGetRestoreService, IProjectDynamicLoadComponent, IVsProjectRestoreInfoSource
 {
     private readonly UnconfiguredProject _project;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Query/LaunchProfiles/LaunchSettingsTracker.cs
@@ -15,6 +15,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Query;
 [Export(typeof(LaunchSettingsTracker))]
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.LaunchProfiles)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.ProjectBackgroundLoadCompleted)]
 internal class LaunchSettingsTracker : IProjectDynamicLoadComponent
 {
     /// <remarks>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Setup/SetupComponentProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Setup/SetupComponentProvider.cs
@@ -21,6 +21,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.Setup;
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.DotNet)]
 [ExportInitialBuildRulesSubscriptions(SuggestedVisualStudioComponentId.SchemaName)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.ProjectBackgroundLoadCompleted)]
 internal sealed class SetupComponentProvider : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
 {
     private readonly UnconfiguredProject _unconfiguredProject;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/UpToDateCheckBuildEventNotifier.cs
@@ -12,6 +12,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.VS.UpToDate;
 /// </summary>
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(BuildUpToDateCheck.AppliesToExpression)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.ProjectBackgroundLoadCompleted)]
 internal sealed class UpToDateCheckBuildEventNotifier : OnceInitializedOnceDisposedAsync, IVsUpdateSolutionEvents2, IProjectDynamicLoadComponent
 {
     private readonly IProjectService _projectService;

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/PackageRestore/PackageRestoreDataSource.cs
@@ -16,6 +16,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.PackageRestore;
 [Export(typeof(IPackageRestoreDataSource))]
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.PackageReferences)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.ProjectBackgroundLoadCompleted)]
 internal partial class PackageRestoreDataSource : ChainedProjectValueDataSourceBase<RestoreData>, IPackageRestoreDataSource, IProjectDynamicLoadComponent
 {
     // This class represents the last data source in the package restore chain, which is made up of the following:

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Telemetry/SdkVersionReporter.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Telemetry/SdkVersionReporter.cs
@@ -9,6 +9,7 @@ namespace Microsoft.VisualStudio.ProjectSystem.Telemetry;
 /// </summary>
 [Export(ExportContractNames.Scopes.UnconfiguredProject, typeof(IProjectDynamicLoadComponent))]
 [AppliesTo(ProjectCapability.DotNet)]
+[ProjectDynamicLoadComponent(ProjectLoadCheckpoint.ProjectBackgroundLoadCompleted)]
 internal class SdkVersionReporter : IProjectDynamicLoadComponent
 {
     private readonly IUnconfiguredProjectCommonServices _projectVsServices;


### PR DESCRIPTION
Reinstates #9728 which was reverted in #9737.

Hold off on merging this until after the next checkpoint.