### PR TITLE
Fixes default value for runningUnderDebugger

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/HotReload/ProjectHotReloadSession.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/HotReload/ProjectHotReloadSession.cs
@@ -74,7 +74,7 @@ internal sealed class ProjectHotReloadSession : IProjectHotReloadSessionInternal
 
     public Task StartSessionAsync(CancellationToken cancellationToken)
     {
-        return StartSessionAsync(runningUnderDebugger: false, cancellationToken);
+        return StartSessionAsync(runningUnderDebugger: !_debugLaunchOptions.HasFlag(DebugLaunchOptions.NoDebug), cancellationToken);
     }
 
     public async Task StartSessionAsync(bool runningUnderDebugger, CancellationToken cancellationToken)


### PR DESCRIPTION
We have updated WebProject to use the `StartSessionAsync` overload since it passes `DebugLaunchOptions` to CreateSession, but that value is not used yet.
