### PR TITLE
Ignore destination symbolic links during build acceleration

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -174,8 +174,7 @@ internal sealed partial class BuildUpToDateCheck
 
                             // TODO add retry logic in case of failed copies? MSBuild does this with CopyRetryCount and CopyRetryDelayMilliseconds
 
-                            FileInfo destinationFileInfo = new(destination);
-                            if (!destinationFileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                            if (!_fileSystem.IsReparsePoint(destination))
                             {
                                 // Copy the file
                                 _fileSystem.CopyFile(source, destination, overwrite: true, clearReadOnly: true);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -174,8 +174,12 @@ internal sealed partial class BuildUpToDateCheck
 
                             // TODO add retry logic in case of failed copies? MSBuild does this with CopyRetryCount and CopyRetryDelayMilliseconds
 
-                            // Copy the file
-                            _fileSystem.CopyFile(source, destination, overwrite: true, clearReadOnly: true);
+                            FileInfo destinationFileInfo = new(destination);
+                            if (!destinationFileInfo.Attributes.HasFlag(FileAttributes.ReparsePoint))
+                            {
+                                // Copy the file
+                                _fileSystem.CopyFile(source, destination, overwrite: true, clearReadOnly: true);
+                            }
 
                             copyCount++;
                         }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/IFileSystem.cs
@@ -54,4 +54,9 @@ internal interface IFileSystem
     bool DirectoryExists(string path);
     void CreateDirectory(string path);
     string GetFullPath(string path);
+
+    /// <summary>
+    /// Gets whether <paramref name="path"/> is a file that refers to a reparse point.
+    /// </summary>
+    bool IsReparsePoint(string path);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/IO/Win32FileSystem.cs
@@ -150,4 +150,25 @@ internal class Win32FileSystem : IFileSystem
     {
         return Path.GetFullPath(path);
     }
+
+    public bool IsReparsePoint(string path)
+    {
+        try
+        {
+            FileAttributes attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReparsePoint) == FileAttributes.ReparsePoint)
+                return true;
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (NotSupportedException)
+        {
+        }
+
+        return false;
+    }
 }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Mocks/IFileSystemMock.cs
@@ -17,6 +17,7 @@ internal class IFileSystemMock : IFileSystem
     {
         public string? FileContents;
         public DateTime LastWriteTimeUtc = DateTime.MaxValue;
+        public FileAttributes Attributes = FileAttributes.Normal;
 
         public void SetLastWriteTime()
         {
@@ -102,6 +103,16 @@ internal class IFileSystemMock : IFileSystem
         }
 
         return Path.GetFullPath(path);
+    }
+
+    public bool IsReparsePoint(string path)
+    {
+        if (Files.TryGetValue(path, out FileData data))
+        {
+            return (data.Attributes & FileAttributes.ReparsePoint) != 0;
+        }
+
+        return false;
     }
 
     public void RemoveFile(string path)


### PR DESCRIPTION
Fixes #9548 

When using symbolic links for build output, build acceleration causes exceptions because it attempts to copy the source file over a symbolic link that points back to the source file itself. Therefore, if the destination is a symbolic link, we ignore it.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9747)