### PR TITLE
Remove explicit SourceLink package refs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,12 +21,6 @@
     <!-- https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/672/Archive-Symbols-with-Symweb?anchor=portable-pdbs -->
     <PackageVersion Include="Microsoft.DiaSymReader.Pdb2Pdb"                                         Version="1.1.0-beta2-22320-02" />
     <PackageVersion Include="Microsoft.DotNet.XliffTasks"                                            Version="1.0.0-beta.23073.2" />
-    <!--
-      The SourceLink package depends on the repo provider used.
-      The following package is only valid when using from GitHub repo.
-      https://github.com/dotnet/sourcelink#using-source-link-in-net-projects
-    -->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub"                                            Version="1.1.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild"                             Version="2.0.115" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NpmPack"                     Version="2.0.117" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.Swix"                        Version="2.0.115" />

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -13,11 +13,6 @@
     <PackageReference Include="Microsoft.DiaSymReader.Pdb2Pdb"      ExcludeAssets="all" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.DotNet.XliffTasks"         PrivateAssets="all" />
     <PackageReference Include="Microsoft.Net.Compilers.Toolset"     PrivateAssets="all" />
-    <!--
-      The SourceLink package depends on the repo provider used.
-      https://github.com/dotnet/sourcelink#using-source-link-in-net-projects
-    -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub"         PrivateAssets="all" />
     <!-- Path Property: PkgMicrosoft_VisualStudioEng_MicroBuild_Core -->
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" PrivateAssets="all" GeneratePathProperty="true" />
     <!-- Note: We require Nerdbank.GitVersioning beyond simply generating version numbers. It also produces some assembly information such as AssemblyName and PublicKeyToken into a *.ThisAssembly.cs file. -->

--- a/eng/imports/Workarounds.targets
+++ b/eng/imports/Workarounds.targets
@@ -12,6 +12,7 @@
 
   <!-- The build.cmd will run the Test target on all projects. Non-test projects have no Test target. This target is overridden for test projects. -->
   <Target Name="Test" />
+  
   <!-- Workaround for https://github.com/dotnet/wpf/issues/810 -->
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
 

--- a/eng/imports/Workarounds.targets
+++ b/eng/imports/Workarounds.targets
@@ -10,20 +10,6 @@
     <None Remove="$(Pkgxunit_runner_console)\**\xunit.abstractions.dll" Condition="'$(Pkgxunit_runner_console)' != ''"/>
   </ItemGroup>
 
-  <PropertyGroup>
-    <InitializeSourceRootDependsOn>$(InitializeSourceRootDependsOn);RemoveSourceRootsWithoutSourceLinkUrl</InitializeSourceRootDependsOn>
-  </PropertyGroup>
-
-  <!-- The build.cmd will run the Test target on all projects. Non-test projects have no Test target. This target is overridden for test projects. -->
-  <Target Name="Test" />
-
-  <!-- Workaround for https://github.com/NuGet/Home/issues/9431 -->
-  <Target Name="RemoveSourceRootsWithoutSourceLinkUrl">
-    <ItemGroup>
-      <SourceRoot Remove="@(SourceRoot)" Condition="'%(SourceRoot.SourceLinkUrl)' == ''" />
-    </ItemGroup>
-  </Target>
-
   <!-- Workaround for https://github.com/dotnet/wpf/issues/810 -->
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
 

--- a/eng/imports/Workarounds.targets
+++ b/eng/imports/Workarounds.targets
@@ -10,6 +10,8 @@
     <None Remove="$(Pkgxunit_runner_console)\**\xunit.abstractions.dll" Condition="'$(Pkgxunit_runner_console)' != ''"/>
   </ItemGroup>
 
+  <!-- The build.cmd will run the Test target on all projects. Non-test projects have no Test target. This target is overridden for test projects. -->
+  <Target Name="Test" />
   <!-- Workaround for https://github.com/dotnet/wpf/issues/810 -->
   <Import Project="$(_WpfTempProjectNuGetFilePathNoExt).targets" Condition="'$(_WpfTempProjectNuGetFilePathNoExt)' != '' and Exists('$(_WpfTempProjectNuGetFilePathNoExt).targets')"/>
 


### PR DESCRIPTION
Source Link is included in the SDK since NET 8.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/project-system/pull/9755)