### PR TITLE
don't assume pending session to be null when creating pending session

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -98,7 +98,6 @@ internal sealed class ProjectHotReloadSessionManager : OnceInitializedOnceDispos
                     hotReloadSessionState.Session = projectHotReloadSession;
                     await projectHotReloadSession.ApplyLaunchVariablesAsync(environmentVariables, default);
 
-                    Assumes.True(_pendingSessionState is null, "Attempt to overwrite unprocessed pending hot reload sessions state.");
                     _pendingSessionState = hotReloadSessionState;
 
                     return true;


### PR DESCRIPTION
It's possible that there're pending session that is not activated when a debugtargetprovider's debug launch targets being queried for several times.

fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2577607