### PR TITLE
Update Ngen priorities for VS

### DIFF
--- a/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
+++ b/setup/ProjectSystemSetup/ProjectSystemSetup.csproj
@@ -41,7 +41,7 @@
       <Name>%(Filename)</Name>
       <IncludeOutputGroupsInVSIXLocalOnly>DebugSymbolsProjectOutputGroup</IncludeOutputGroupsInVSIXLocalOnly>
       <Ngen>true</Ngen>
-      <NgenPriority>1</NgenPriority>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
   </ItemGroup>
 


### PR DESCRIPTION
Updated ngen priorities for our ongoing efforts to reduce the time it takes to ngen pri 1 assemblies. The following two assemblies are being changed to priority 2:

- common7\ide\extensions\microsoft\managedprojectsystem\microsoft.visualstudio.projectsystem.managed.vs.dll
- common7\ide\extensions\microsoft\managedprojectsystem\microsoft.visualstudio.projectsystem.managed.dll