### PR TITLE
Remove ReleaseVersion from interface definition and ProjectRetargetHa…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/IDotNetReleasesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/IDotNetReleasesProvider.cs
@@ -1,7 +1,5 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
-using Microsoft.Deployment.DotNet.Releases;
-
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Retargeting;
 
 /// <summary>
@@ -18,8 +16,8 @@ internal interface IDotNetReleasesProvider
     /// <returns>
     /// A task that represents the asynchronous operation. The task result contains the supported or latest SDK version as a string, or null if no suitable version is found.
     /// </returns>
-    Task<ReleaseVersion?> GetSupportedOrLatestSdkVersionAsync(
-        ReleaseVersion? sdkVersion,
+    Task<string?> GetSupportedOrLatestSdkVersionAsync(
+        string? sdkVersion,
         bool includePreview = false,
         CancellationToken cancellationToken = default);
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/ProjectRetargetHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/ProjectRetargetHandler.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Text.Json;
-using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
@@ -76,14 +75,14 @@ internal sealed partial class ProjectRetargetHandler : IProjectRetargetHandler, 
 
     private async Task<TargetChange?> GetTargetChangeAsync(IVsTrackProjectRetargeting2 retargetingService)
     {
-        ReleaseVersion? sdkVersion = await GetSdkVersionForProjectAsync();
+        string? sdkVersion = await GetSdkVersionForProjectAsync();
 
         if (sdkVersion is null)
         {
             return null;
         }
 
-        ReleaseVersion? retargetVersion = await _releasesProvider.Value.GetSupportedOrLatestSdkVersionAsync(sdkVersion, includePreview: true);
+        string? retargetVersion = await _releasesProvider.Value.GetSupportedOrLatestSdkVersionAsync(sdkVersion, includePreview: true);
 
         if (retargetVersion is null || sdkVersion == retargetVersion)
         {
@@ -132,7 +131,7 @@ internal sealed partial class ProjectRetargetHandler : IProjectRetargetHandler, 
         return null;
     }
 
-    private async Task<ReleaseVersion?> GetSdkVersionForProjectAsync()
+    private async Task<string?> GetSdkVersionForProjectAsync()
     {
         string projectDirectory = _unconfiguredProject.GetProjectDirectory();
 
@@ -148,12 +147,7 @@ internal sealed partial class ProjectRetargetHandler : IProjectRetargetHandler, 
                     if (doc.RootElement.TryGetProperty("sdk", out JsonElement sdkProp) &&
                         sdkProp.TryGetProperty("version", out JsonElement versionProp))
                     {
-                        if (ReleaseVersion.TryParse(versionProp.GetString(), out ReleaseVersion parsedVersions))
-                        {
-                            return parsedVersions;
-                        }
-
-                        return null;
+                        return versionProp.GetString();
                     }
                 }
                 catch /* ignore errors */


### PR DESCRIPTION
…ndler to avoid premature image load of assembly

We will only use this internally in DotNetReleasesProvider