### PR TITLE
Harden build against failures by allowing rerun and proper condition on copy task

### DIFF
--- a/eng/pipelines/templates/build-official-release.yml
+++ b/eng/pipelines/templates/build-official-release.yml
@@ -36,7 +36,7 @@ jobs:
       - output: pipelineArtifact
         displayName: Publish Build Artifacts
         targetPath: $(Build.SourcesDirectory)/artifacts/output
-        artifactName: $(Build.BuildNumber)
+        artifactName: $(Build.BuildNumber)-$(System.JobAttempt)
         condition: succeededOrFailed()
       - output: pipelineArtifact
         displayName: Publish Staging Artifacts
@@ -260,9 +260,10 @@ jobs:
     displayName: Copy Staging Artifact Filter
     condition: succeededOrFailed()
     
-    # This output folder is used for 1ES code signing validation
+    # This output folder is used for 1ES code signing validation, as well as publishing binlog, so it should always be run.
   - task: CopyFiles@2
     displayName: Copy necessary files to output folder
+    condition: succeededOrFailed()
     inputs:
       SourceFolder: $(Build.SourcesDirectory)/artifacts/$(BuildConfiguration)
       TargetFolder: $(Build.SourcesDirectory)/artifacts/output


### PR DESCRIPTION
* make copy output folder step succeeded or failed so that copy of binlogs happens on main build task failure
* append a job attempt number to artifact name, so build job can be rerun in case of failure