### PR TITLE
Fix: Add defensive check in ActivateSessionAsync to prevent null refe…

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/HotReload/ProjectHotReloadSessionManager.cs
@@ -194,7 +194,11 @@ internal sealed class ProjectHotReloadSessionManager : OnceInitializedOnceDispos
 
     public Task ActivateSessionAsync(IVsLaunchedProcess? launchedProcess, VsDebugTargetProcessInfo vsDebugTargetProcessInfo)
     {
-        Assumes.True(_pendingSessionState is not null, "No pending hot reload session to activate.");
+        // If there's no pending session to activate, return early instead of throwing
+        if (_pendingSessionState is null)
+        {
+            return Task.CompletedTask;
+        }
 
         return _semaphore.ExecuteAsync(ActivateSessionInternalAsync);
 


### PR DESCRIPTION
# Fix: Add defensive check in ActivateSessionAsync to prevent null reference exception

## Summary
Fixes a critical exception in Hot Reload session activation where `ActivateSessionAsync` was called without a valid pending session, resulting in `System.AggregateException` with inner `Microsoft.Assumes+InternalErrorException: No pending hot reload session to activate.`

## Root Cause Analysis (RCA) - Commit f75543e

### Background
The issue was introduced in commit **f75543efbd04244ae438a2969d357cacfd14d1ba** by @bigmiao-zhang on Oct 8, 2025. This commit aimed to "Activate hotreload session on both OnAfterLaunchAsync in ProjectLaunchTargetsProvider" but introduced a critical flow control bug.

### What Changed in f75543e
The problematic change was in `ProjectLaunchTargetsProvider.cs`:

**BEFORE f75543e:**
```csharp
public Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<VsDebugTargetProcessInfo> processInfos)
{
    return Task.CompletedTask;  // No-op - did nothing
}
```

**AFTER f75543e:**
```csharp
public async Task OnAfterLaunchAsync(DebugLaunchOptions launchOptions, ILaunchProfile profile, IReadOnlyList<VsDebugTargetProcessInfo> processInfos)
{
    var configuredProjectForDebug = await GetConfiguredProjectForDebugAsync();
    var hotReloadSessionManager = configuredProjectForDebug.GetExportedService<IProjectHotReloadSessionManager>();
    await hotReloadSessionManager.ActivateSessionAsync(null, processInfos[0]);  // ❌ UNCONDITIONAL CALL
}
```

### The Critical Bug
The code now **unconditionally** calls `ActivateSessionAsync` from both `OnAfterLaunchAsync` methods in `ProjectLaunchTargetsProvider`, but there's no guarantee that:

1. `TryCreatePendingSessionAsync` was ever called
2. `TryCreatePendingSessionAsync` returned `true` (successfully created a pending session)
3. There isn't a timing/threading issue between session creation and activation

### Error Flow
1. **Launch Process**: User starts debugging a project
2. **Session Creation**: `QueryDebugTargetsAsync` calls `TryCreatePendingSessionAsync`
3. **Session Creation Fails**: Method returns `false` due to:
   - Project doesn't support Hot Reload
   - Startup hooks disabled 
   - Optimization enabled
   - Debug symbols disabled
   - etc.
4. **Pending State**: `_pendingSessionState` remains `null`
5. **Launch Completion**: `OnAfterLaunchAsync` is called regardless of session creation success
6. **Unconditional Activation**: Calls `ActivateSessionAsync(null, processInfos[0])`
7. **Exception**: `Assumes.True(_pendingSessionState is not null, "No pending hot reload session to activate.")` throws

### Code Flow Analysis

**QueryDebugTargetsAsync (CORRECT):**
```csharp
if (await hotReloadSessionManager.TryCreatePendingSessionAsync(...))
{
    debugTargets[0].tgtFlags = debugTargets[0].tgtFlags | (uint)__VSDBGLAUNCHFLAGS6.DBGLAUNCH_EnableXamlHotReload;
}
// ✅ Only enables Hot Reload if session creation succeeded
```

**OnAfterLaunchAsync (BROKEN):**
```csharp
await hotReloadSessionManager.ActivateSessionAsync(null, processInfos[0]);
// ❌ Always calls activation regardless of whether session was created
```

### Impact
- **Critical**: Any project that fails Hot Reload session creation will crash during debug launch
- **Scope**: Affects all .NET projects that don't meet Hot Reload requirements
- **User Experience**: Debug sessions fail to start with cryptic exception message

## The Fix
Added a defensive null check in `ActivateSessionAsync` to handle cases where no pending session exists:

```csharp
public Task ActivateSessionAsync(IVsLaunchedProcess? launchedProcess, VsDebugTargetProcessInfo vsDebugTargetProcessInfo)
{
    // If there's no pending session to activate, return early instead of throwing
    if (_pendingSessionState is null)
    {
        return Task.CompletedTask;
    }
    
    // ... rest of activation logic
}
```

### Why This Fix is Correct
1. **Defensive Programming**: API should be robust against invalid state
2. **Graceful Degradation**: If Hot Reload can't be activated, debugging should still work
3. **Consistent Behavior**: `ActivateSessionInternalAsync` already has similar null checks
4. **Backwards Compatible**: Doesn't change successful Hot Reload scenarios

## Alternative Approaches Considered
1. **Fix the Caller**: Add checks in `ProjectLaunchTargetsProvider` before calling `ActivateSessionAsync`
   - ❌ Requires exposing internal state or adding new API methods
   - ❌ Doesn't protect against other potential callers
   
2. **Store Success State**: Track whether `TryCreatePendingSessionAsync` succeeded
   - ❌ Adds complexity and potential race conditions
   - ❌ Duplicates state that already exists (`_pendingSessionState`)

3. **Revert f75543e**: Remove the unconditional activation
   - ❌ Loses the intended functionality improvement
   - ❌ May break other scenarios that depend on the new behavior

## Testing
- [x] Code compiles successfully
- [x] Fix handles null `_pendingSessionState` gracefully
- [ ] Manual testing: Debug launch with Hot Reload requirements not met
- [ ] Manual testing: Debug launch with Hot Reload working normally

## Validation Steps
1. Create a project with Hot Reload disabled (optimization enabled, debug symbols disabled, etc.)
2. Start debugging
3. Verify debug session starts successfully without Hot Reload exception
4. Create a project with Hot Reload enabled
5. Start debugging  
6. Verify Hot Reload works normally

## Related Issues
- Resolves the `System.AggregateException` with `Microsoft.Assumes+InternalErrorException` during debug launch
- Improves robustness of Hot Reload session management
- Maintains compatibility with existing Hot Reload functionality

---

**Regression Risk**: ⚠️ **LOW** - Fix is defensive and only affects error case that was previously crashing

**Breaking Changes**: ✅ **NONE** - Graceful handling instead of exception throwing