### PR TITLE
[18.0.x] Fix APIScan auth issue

### DIFF
--- a/eng/pipelines/templates/analyze-compliance.yml
+++ b/eng/pipelines/templates/analyze-compliance.yml
@@ -41,3 +41,4 @@ steps:
     # This value is provided from the DotNet-Project-System variable group, defined in the stage variables.
     env:
       AzureServicesAuthConnectionString: runAs=App;AppId=$(ApiScanClientId)
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)


### PR DESCRIPTION
APIScan requires an access token in order to run correctly. Pass it.