### PR TITLE
Increase unit test timeout from 1 to 10 seconds

### DIFF
--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceFactoryTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/LanguageServices/WorkspaceFactoryTests.cs
@@ -59,7 +59,7 @@ public class WorkspaceFactoryTests
 
         broadcastBlock.Complete();
 
-        await actionBlock.Completion.WithTimeout(TimeSpan.FromSeconds(1));
+        await actionBlock.Completion.WithTimeout(TimeSpan.FromSeconds(10));
 
         Assert.Equal(outputs.Count, actualOutputs.Count);
 


### PR DESCRIPTION
On a busy machine, one second might not be enough for this unit test to complete successfully. I observed this test fail in a pipeline run, so it seems a good idea to increase it slightly, as the cost of a false negative is high.