### PR TITLE
Remove verify settings from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -449,14 +449,3 @@ dotnet_diagnostic.CA1307.severity = suggestion    # Specify StringComparison
 [artifacts/*/obj/Microsoft.VisualStudio.ProjectSystem.Managed/net8.0/*.cs]
 # CS0618: Type or member is obsolete
 dotnet_diagnostic.CS0618.severity = silent
-
-
-# Verify settings
-[*.{received,verified}.{txt,xml,json}]
-charset = "utf-8-bom"
-end_of_line = lf
-indent_size = unset
-indent_style = unset
-insert_final_newline = false
-tab_width = unset
-trim_trailing_whitespace = false


### PR DESCRIPTION
Since #9764, we no longer use Verify for snapshot testing.

Remove its configuration from our `.editorconfig` file.