### PR TITLE
FUTDC support for CopyToOutputDirectory="IfDifferent"

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rules/CopyToOutputDirectoryItem.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rules/CopyToOutputDirectoryItem.xaml
@@ -16,6 +16,7 @@
     <EnumValue Name="Never" />
     <EnumValue Name="Always" />
     <EnumValue Name="PreserveNewest" />
+    <EnumValue Name="IfDifferent" />
   </EnumProperty>
 
   <BoolProperty Name="BuildAccelerationOnly"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.CopyType.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.CopyType.cs
@@ -10,6 +10,7 @@ internal sealed partial class BuildUpToDateCheck
     internal enum CopyType
     {
         PreserveNewest,
+        IfDifferent,
         Always
     }
 }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -797,6 +797,7 @@ internal sealed partial class BuildUpToDateCheck
                 switch (copyType)
                 {
                     case CopyType.Always:
+                    case CopyType.IfDifferent:
                     {
                         // We have already validated the presence of these files, so we don't expect these to return
                         // false. If one of them does, the corresponding size would be zero, so we would schedule a build.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/CopyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/CopyItem.cs
@@ -69,7 +69,12 @@ internal readonly struct CopyItem
                 return BuildUpToDateCheck.CopyType.PreserveNewest;
             }
 
-            throw Assumes.Fail($"CopyToOutputDirectory should be Always or PreserveNewest, not {value}");
+            if (string.Equals(value, CopyToOutputDirectoryItem.CopyToOutputDirectoryValues.IfDifferent, StringComparisons.PropertyLiteralValues))
+            {
+                return BuildUpToDateCheck.CopyType.IfDifferent;
+            }
+
+            throw Assumes.Fail($"CopyToOutputDirectory should be Always, PreserveNewest or IfDifferent, not {value}");
         }
     }
 


### PR DESCRIPTION
The `IfDifferent` value is valid in modern MSBuild:

https://github.com/dotnet/msbuild/blob/863bbb87f1b5cbf792fbefb7005ff83bb8af0e4b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd#L776

Without this change, attempting to use it causes an error in the FUTDC:

```
=====================
20-Nov-25 11:17:37
LimitedFunctionality
System.AggregateException: Project system data flow 'UpToDateCheckConfiguredInputDataSource: 36760100' closed because of an exception.
CopyToOutputDirectory should be Always or PreserveNewest, not IfDifferent
---> (Inner Exception #0) Microsoft.Assumes+InternalErrorException: CopyToOutputDirectory should be Always or PreserveNewest, not IfDifferent
   at Microsoft.Assumes.Fail(String message)
   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.CopyItem.<GetCopyType>g__ParseCopyType|15_0(String value)
   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.CopyItem.GetCopyType(IImmutableDictionary`2 metadata)
   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.UpToDateCheckImplicitConfiguredInput.<>c.<Update>b__76_24(KeyValuePair`2 pair)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at System.Collections.Immutable.ImmutableArray.CreateRange[T](IEnumerable`1 items)
   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.UpToDateCheckImplicitConfiguredInput.<>c__DisplayClass76_0.<Update>g__UpdateCopyData|9()
   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.UpToDateCheckImplicitConfiguredInput.Update(IProjectSubscriptionUpdate jointRuleUpdate, IProjectSubscriptionUpdate sourceItemsUpdate, IProjectItemSchema projectItemSchema, IProjectCatalogSnapshot projectCatalogSnapshot)
   at Microsoft.VisualStudio.ProjectSystem.VS.UpToDate.UpToDateCheckImplicitConfiguredInputDataSource.<>c__DisplayClass12_0.<<LinkExternalInput>g__TransformAsync|0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.VisualStudio.ProjectSystem.TransformBlockSlim`2.TransformBlockSlimAsync.<ProcessInputAsync>d__3.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Microsoft.VisualStudio.ProjectSystem.DataReceivingBlockSlim`1.<ProcessInputQueueAsync>d__5.MoveNext()
<--- (Inner Exception #0) 
===================
```

This change adds support for it. The FUTDC already treats "Always" in the same way as "IfDifferent" (which helps performance a lot), so the user wouldn't notice a difference between these two options for builds in VS, but there would be a different for command-line builds.

**EDIT** Showing this in the properties window was moved to a separate PR given the below discussion: https://github.com/dotnet/project-system/pull/9861