### PR TITLE
Show "Copy if different" in item properties

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Compile.BrowseObject.xaml
@@ -39,6 +39,8 @@
                DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest"
                DisplayName="Copy if newer" />
+    <EnumValue Name="IfDifferent"
+               DisplayName="Copy if different" />
   </EnumProperty>
 
   <StringProperty Name="CustomTool"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Content.BrowseObject.xaml
@@ -39,6 +39,8 @@
                DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest"
                DisplayName="Copy if newer" />
+    <EnumValue Name="IfDifferent"
+               DisplayName="Copy if different" />
   </EnumProperty>
 
   <StringProperty Name="CustomTool"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EditorConfigFiles.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EditorConfigFiles.BrowseObject.xaml
@@ -39,6 +39,8 @@
                DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest"
                DisplayName="Copy if newer" />
+    <EnumValue Name="IfDifferent"
+               DisplayName="Copy if different" />
   </EnumProperty>
 
   <StringProperty Name="CustomTool"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/EmbeddedResource.BrowseObject.xaml
@@ -39,6 +39,8 @@
                DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest"
                DisplayName="Copy if newer" />
+    <EnumValue Name="IfDifferent"
+               DisplayName="Copy if different" />
   </EnumProperty>
 
   <StringProperty Name="CustomTool"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/None.BrowseObject.xaml
@@ -39,6 +39,8 @@
                DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest"
                DisplayName="Copy if newer" />
+    <EnumValue Name="IfDifferent"
+               DisplayName="Copy if different" />
   </EnumProperty>
 
   <StringProperty Name="CustomTool"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/Resource.BrowseObject.xaml
@@ -39,6 +39,8 @@
                DisplayName="Copy always" />
     <EnumValue Name="PreserveNewest"
                DisplayName="Copy if newer" />
+    <EnumValue Name="IfDifferent"
+               DisplayName="Copy if different" />
   </EnumProperty>
 
   <StringProperty Name="CustomTool"

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.cs.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Určuje zdrojový soubor, který se zkopíruje do výstupního adresáře.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Nekopírovat</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.de.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Gibt an, dass die Quelldatei in das Ausgabeverzeichnis kopiert wird.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Nicht kopieren</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.es.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Especifica que el archivo de código fuente se copiará en el directorio de salida.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">No copiar</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.fr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Spécifie le fichier source à copier dans le répertoire de sortie.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Ne pas copier</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.it.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Consente di specificare se il file di origine verrà copiato nella directory di output.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Non copiare</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.ja.xlf
@@ -32,6 +32,11 @@
         <target state="translated">ソース ファイルを出力ディレクトリにコピーするよう指定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">コピーしない</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.ko.xlf
@@ -32,6 +32,11 @@
         <target state="translated">소스 파일을 출력 디렉터리로 복사할 것인지 여부를 지정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">복사 안 함</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.pl.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Określa plik źródłowy, który zostanie skopiowany do katalogu wyjściowego.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Nie kopiuj</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.pt-BR.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Especifica se o arquivo fonte deve ser copiado no diretório de saída.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Não copiar</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.ru.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Указывает, что исходный файл будет скопирован в указанный каталог</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Не копировать</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.tr.xlf
@@ -32,6 +32,11 @@
         <target state="translated">Kaynak dosyasının çıkış dizinine kopyalanacağını belirtir.</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Kopyalama</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.zh-Hans.xlf
@@ -32,6 +32,11 @@
         <target state="translated">指定将源文件复制到输出目录。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">不复制</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Compile.BrowseObject.xaml.zh-Hant.xlf
@@ -32,6 +32,11 @@
         <target state="translated">指定是否要將原始程式檔複製到輸出目錄。</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">不要複製</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Vlastnosti souboru</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Dateieigenschaften</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Propiedades del archivo</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Propriétés du fichier</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Proprietà file</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">ファイルのプロパティ</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">파일 속성</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Właściwości pliku</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Propriedades do Arquivo</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Свойства файла</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">Dosya Özellikleri</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">文件属性</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Content.BrowseObject.xaml.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Content.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|Content|DisplayName">
         <source>File Properties</source>
         <target state="translated">檔案屬性</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Vlastnosti souboru</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Dateieigenschaften</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Propiedades del archivo</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Propriétés du fichier</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Proprietà file</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">ファイルのプロパティ</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">파일 속성</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Właściwości pliku</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Propriedades do Arquivo</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Свойства файла</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">Dosya Özellikleri</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">文件属性</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EditorConfigFiles.BrowseObject.xaml.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../EditorConfigFiles.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EditorConfigFiles|Description">
         <source>File Properties</source>
         <target state="translated">檔案屬性</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Vložený prostředek</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Eingebettete Ressource</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Recurso incrustado</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Ressource incorporée</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Risorsa incorporata</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">埋め込みリソース</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">포함 리소스</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Zasób osadzony</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Recurso Inserido</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Внедренный ресурс</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">Eklenmiş Kaynak</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">嵌入的资源</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/EmbeddedResource.BrowseObject.xaml.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../EmbeddedResource.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|EmbeddedResource|DisplayName">
         <source>Embedded Resource</source>
         <target state="translated">內嵌資源</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Obecné</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Allgemein</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">General</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Général</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Generale</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">全般</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">일반</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Ogólne</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Geral</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Общие</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">Genel</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">常规</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/None.BrowseObject.xaml.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../None.BrowseObject.xaml">
     <body>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Rule|None|DisplayName">
         <source>General</source>
         <target state="translated">一般</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.cs.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Kopírovat vždycky</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Nekopírovat</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.de.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Immer kopieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Nicht kopieren</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.es.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Copiar siempre</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">No copiar</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.fr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Toujours copier</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Ne pas copier</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.it.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Copia sempre</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Non copiare</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.ja.xlf
@@ -37,6 +37,11 @@
         <target state="translated">常にコピーする</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">コピーしない</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.ko.xlf
@@ -37,6 +37,11 @@
         <target state="translated">항상 복사</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">복사 안 함</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.pl.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Zawsze kopiuj</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Nie kopiuj</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.pt-BR.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Copiar sempre</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Não copiar</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.ru.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Всегда копировать</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Не копировать</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.tr.xlf
@@ -37,6 +37,11 @@
         <target state="translated">Her zaman kopyala</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">Kopyalama</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.zh-Hans.xlf
@@ -37,6 +37,11 @@
         <target state="translated">始终复制</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">不复制</target>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Rules/Items/xlf/Resource.BrowseObject.xaml.zh-Hant.xlf
@@ -37,6 +37,11 @@
         <target state="translated">永遠複製</target>
         <note />
       </trans-unit>
+      <trans-unit id="EnumValue|CopyToOutputDirectory.IfDifferent|DisplayName">
+        <source>Copy if different</source>
+        <target state="new">Copy if different</target>
+        <note />
+      </trans-unit>
       <trans-unit id="EnumValue|CopyToOutputDirectory.Never|DisplayName">
         <source>Do not copy</source>
         <target state="translated">不要複製</target>


### PR DESCRIPTION
The `IfDifferent` value is valid in modern MSBuild:

https://github.com/dotnet/msbuild/blob/863bbb87f1b5cbf792fbefb7005ff83bb8af0e4b/src/MSBuild/MSBuild/Microsoft.Build.CommonTypes.xsd#L776

This change adds an option for it in the project properties pane:

<img width="800" height="254" alt="image" src="https://github.com/user-attachments/assets/0675494f-09b2-4444-8dbc-239112891dd6" />

This was split out from #9858.