### PR TITLE
Use JTF to run async operation

### DIFF
--- a/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
+++ b/src/Microsoft.VisualStudio.Editors/PropPages/ReferencePropPage.vb
@@ -8,15 +8,15 @@ Imports System.Runtime.InteropServices
 Imports System.Text.RegularExpressions
 Imports System.Threading
 Imports System.Windows.Forms
-
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.VisualStudio.ComponentModelHost
 Imports Microsoft.VisualStudio.Editors.Common
 Imports Microsoft.VisualStudio.Editors.Interop
 Imports Microsoft.VisualStudio.LanguageServices
-Imports Microsoft.VisualStudio.Utilities
+Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
+Imports Microsoft.VisualStudio.Utilities
 Imports Microsoft.VisualStudio.WCFReference.Interop
 
 Namespace Microsoft.VisualStudio.Editors.PropertyPages
@@ -550,9 +550,10 @@ Namespace Microsoft.VisualStudio.Editors.PropertyPages
 
                     ' We need to find the project that matches by project file path
                     If project.FilePath IsNot Nothing AndAlso String.Compare(project.FilePath, DTEProject.FullName, ignoreCase:=True) = 0 Then
-                        Dim compilationTask = project.GetCompilationAsync(cancellationTokenSource.Token)
-                        compilationTask.Wait(cancellationTokenSource.Token)
-                        Dim compilation = compilationTask.Result
+                        Dim compilation = ThreadHelper.JoinableTaskFactory.Run(
+                            Async Function()
+                                Return Await project.GetCompilationAsync(cancellationTokenSource.Token)
+                            End Function)
 
                         Dim namespaceNames As New List(Of String)
                         Dim namespacesToProcess As New Stack(Of INamespaceSymbol)


### PR DESCRIPTION
This `Wait` call is known to trigger occasional hangs. Run it through JTF.

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2633869

This code has existed since the creation of this repo in 2015, and probably for some time before that. This particular code path only happens in legacy projects that don't use the newer Project Properties UI.