### PR TITLE
Use Microsoft.IO over System.IO

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -143,6 +143,10 @@
     <Using Include="Microsoft.VisualStudio.Composition.ImportCardinality" Alias="ImportCardinality" />
     <!-- Prevent accidental use of Microsoft.VisualStudio.Threading.IAsyncDisposable -->
     <Using Include="System.IAsyncDisposable" Alias="IAsyncDisposable" />
+    <!-- Enforce use of Microsoft.IO -->
+    <Using Include="Microsoft.IO.Path" Alias="Path" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Using Include="Microsoft.IO.Directory" Alias="Directory" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
+    <Using Include="Microsoft.IO.SearchOption" Alias="SearchOption" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
   <Import Project="eng\imports\LanguageSettings.props" />

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/IO/WindowsFileExplorer.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/IO/WindowsFileExplorer.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 using System.Runtime.InteropServices;
-using Path = Microsoft.IO.Path;
 
 namespace Microsoft.VisualStudio.IO;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/CreateFileFromTemplateService.cs
@@ -35,12 +35,20 @@ internal class CreateFileFromTemplateService : ICreateFileFromTemplateService
         Requires.NotNull(templateFile);
         Requires.NotNullOrEmpty(path);
 
-        string directoryName = Path.GetDirectoryName(path);
         string fileName = Path.GetFileName(path);
+        string? directoryName = Path.GetDirectoryName(path);
+
+        if (directoryName is null)
+        {
+            return false;
+        }
 
         string? templateLanguage = await GetTemplateLanguageAsync();
+
         if (string.IsNullOrEmpty(templateLanguage))
+        {
             return false;
+        }
 
         await _projectVsServices.ThreadingService.SwitchToUIThread();
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/LanguageServices/Handlers/CompileItemHandler.cs
@@ -43,7 +43,7 @@ internal class CompileItemHandler(UnconfiguredProject project) : AbstractEvaluat
 
     protected override void AddToContext(IWorkspaceProjectContext context, string fullPath, IImmutableDictionary<string, string> metadata, bool isActiveContext, IManagedProjectDiagnosticOutputService logger)
     {
-        string[]? folderNames = FileItemServices.GetLogicalFolderNames(Path.GetDirectoryName(Project.FullPath), fullPath, metadata);
+        string[]? folderNames = FileItemServices.GetLogicalFolderNames(Path.GetDirectoryName(Project.FullPath)!, fullPath, metadata);
 
         logger.WriteLine("Adding source file '{0}'", fullPath);
         context.AddSourceFile(fullPath, isInCurrentContext: isActiveContext, folderNames: folderNames);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/FileMoveNotificationListener.cs
@@ -11,7 +11,6 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 // Debug collides with Microsoft.VisualStudio.ProjectSystem.VS.Debug
 using DiagDebug = System.Diagnostics.Debug;
-using Path = System.IO.Path;
 using static Microsoft.CodeAnalysis.Rename.Renamer;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Rename;
@@ -75,7 +74,13 @@ internal class FileMoveNotificationListener : IFileMoveNotificationListener
             }
 
             // Get the relative folder path from the project to the destination.
-            string destinationFolderPath = Path.GetDirectoryName(_unconfiguredProject.MakeRelative(itemToMove.Destination));
+            string? destinationFolderPath = Path.GetDirectoryName(_unconfiguredProject.MakeRelative(itemToMove.Destination));
+
+            if ( (destinationFolderPath is null))
+            {
+                continue;
+            }
+
             string[] destinationFolders = destinationFolderPath.Split(Delimiter.Path, StringSplitOptions.RemoveEmptyEntries);
 
             // Since this rename only moves the location of the file to another directory, it will use the SyncNamespaceDocumentAction in Roslyn as the rename action within this set.

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Rename/RenamerProjectTreeActionHandler.cs
@@ -78,13 +78,14 @@ internal partial class RenamerProjectTreeActionHandler : ProjectTreeActionHandle
         Requires.NotNullOrEmpty(value);
 
         string? oldFilePath = node.FilePath;
-        string oldName = Path.GetFileNameWithoutExtension(oldFilePath);
+        string? oldName = Path.GetFileNameWithoutExtension(oldFilePath);
         string newFileWithExtension = value;
         CodeAnalysis.Project? project = GetCurrentProject();
 
         await CpsFileRenameAsync(context, node, value);
 
-        if (project is null ||
+        if (oldName is null ||
+            project is null ||
             await IsAutomationFunctionAsync() ||
             node.IsFolder ||
             _vsOnlineServices.ConnectedToVSOnline ||

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/DotNetReleasesProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/DotNetReleasesProvider.cs
@@ -4,7 +4,6 @@ using Microsoft.Deployment.DotNet.Releases;
 using Microsoft.VisualStudio.Linq;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
-using Path = Microsoft.IO.Path;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Retargeting;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/ProjectRetargetHandler.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Retargeting/ProjectRetargetHandler.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 using IFileSystem = Microsoft.VisualStudio.IO.IFileSystem;
-using Path = Microsoft.IO.Path;
 
 namespace Microsoft.VisualStudio.ProjectSystem.VS.Retargeting;
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Setup/DotNetEnvironment.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Setup/DotNetEnvironment.cs
@@ -69,7 +69,7 @@ internal class DotNetEnvironment : IDotNetEnvironment
             registryKey,
             "InstallLocation");
 
-        if (!string.IsNullOrEmpty(installLocation))
+        if (!Strings.IsNullOrEmpty(installLocation))
         {
             string dotnetExePath = Path.Combine(installLocation, "dotnet.exe");
             if (_fileSystem.FileExists(dotnetExePath))

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/TempPE/DesignTimeInputsChangeTracker.cs
@@ -196,6 +196,12 @@ internal class DesignTimeInputsChangeTracker : ProjectValueDataSourceBase<Design
         // Make sure we have the up to date output path. If either of these don't exist, they will be null and we'll handle the ArgumentException below
         string? basePath = configChanges.After.Properties.GetValueOrDefault(ConfigurationGeneral.ProjectDirProperty);
         string? objPath = configChanges.After.Properties.GetValueOrDefault(ConfigurationGeneral.IntermediateOutputPathProperty);
+
+        if (basePath is null || objPath is null)
+        {
+            return null;
+        }
+
         try
         {
             tempPEOutputPath = Path.Combine(basePath, objPath, "TempPE");

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Tree/Dependencies/AttachedCollections/Implementation/FrameworkReferenceAssemblyItem.cs
@@ -41,7 +41,7 @@ internal sealed class FrameworkReferenceAssemblyItem : RelatableItemBase, IObjec
     string? IObjectBrowserItem.AssemblyPath => GetAssemblyPath();
 
     private string? GetAssemblyPath() => Path is not null
-        ? System.IO.Path.GetFullPath(System.IO.Path.Combine(Framework.Path, Path))
+        ? Microsoft.IO.Path.GetFullPath(Microsoft.IO.Path.Combine(Framework.Path, Path))
         : null;
 
     private sealed class BrowseObject(FrameworkReferenceAssemblyItem item) : LocalizableProperties

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.FileSystemOperationAggregator.cs
@@ -169,7 +169,7 @@ internal sealed partial class BuildUpToDateCheck
                             if (destinationInfo is null)
                             {
                                 // Ensure the destination directory actually exists on disk
-                                _fileSystem.CreateDirectory(Path.GetDirectoryName(destination));
+                                _fileSystem.CreateDirectory(Path.GetDirectoryName(destination)!);
                             }
 
                             // TODO add retry logic in case of failed copies? MSBuild does this with CopyRetryCount and CopyRetryDelayMilliseconds

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/UpToDate/BuildUpToDateCheck.cs
@@ -722,7 +722,7 @@ internal sealed partial class BuildUpToDateCheck
     {
         ITimestampCache timestampCache = solutionBuildContext.CopyItemTimestamps;
 
-        string outputFullPath = Path.Combine(state.MSBuildProjectDirectory, state.OutputRelativeOrFullPath);
+        string outputFullPath = Path.Combine(state.MSBuildProjectDirectory!, state.OutputRelativeOrFullPath!);
 
         Log.Scope? scope1 = null;
 
@@ -1074,7 +1074,7 @@ internal sealed partial class BuildUpToDateCheck
 
                     var configuredFileSystemOperations = new ConfiguredFileSystemOperationAggregator(fileSystemOperations, isBuildAccelerationEnabled, copyInfo.TargetsWithoutReferenceAssemblies);
 
-                    string outputFullPath = Path.Combine(implicitState.MSBuildProjectDirectory, implicitState.OutputRelativeOrFullPath);
+                    string outputFullPath = Path.Combine(implicitState.MSBuildProjectDirectory!, implicitState.OutputRelativeOrFullPath!);
 
                     copyItemPaths.UnionWith(implicitState.ProjectCopyData.CopyItems.Select(copyItem => Path.Combine(outputFullPath, copyItem.RelativeTargetPath)));
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/LaunchSettingsProvider.cs
@@ -563,7 +563,9 @@ internal class LaunchSettingsProvider : ProjectValueDataSourceBase<ILaunchSettin
     {
         string fileName = await GetLaunchSettingsFilePathAsync();
 
-        string parentPath = Path.GetDirectoryName(fileName);
+        string? parentPath = Path.GetDirectoryName(fileName);
+
+        Assumes.NotNull(parentPath);
 
         _fileSystem.CreateDirectory(parentPath);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/ProjectTreeProviderExtensions.cs
@@ -40,7 +40,12 @@ internal static class ProjectTreeProviderExtensions
 
         string? projectFilePath = provider.GetPath(target.Root);
 
-        string rootPath = Path.GetDirectoryName(projectFilePath);
+        string? rootPath = Path.GetDirectoryName(projectFilePath);
+
+        if (rootPath is null)
+        {
+            return null;
+        }
 
         return Path.Combine(rootPath, relativePath);
     }

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/SpecialFileProviders/AppDesignerFolderSpecialFileProvider.cs
@@ -40,7 +40,7 @@ internal class AppDesignerFolderSpecialFileProvider : AbstractSpecialFileProvide
             return null;
 
         string? folderName = await GetDefaultAppDesignerFolderNameAsync();
-        if (string.IsNullOrEmpty(folderName))
+        if (Strings.IsNullOrEmpty(folderName))
             return null; // Developer has set the AppDesigner path to empty
 
         return Path.Combine(projectPath, folderName);

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Order/TreeItemOrderPropertyProvider.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Order/TreeItemOrderPropertyProvider.cs
@@ -24,7 +24,13 @@ internal class TreeItemOrderPropertyProvider : IProjectTreePropertiesProvider
 
     private static string[] GetPathFolders(string path)
     {
-        return GetPathComponents(Path.GetDirectoryName(path));
+        string? evaluatedInclude = Path.GetDirectoryName(path);
+        if (evaluatedInclude is null)
+        {
+            return [];
+        }
+
+        return GetPathComponents(evaluatedInclude);
     }
 
     /// <summary>

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.TestServices/ProjectSystem/ProjectTreeProvider.cs
@@ -68,7 +68,7 @@ internal class ProjectTreeProvider : IProjectTreeProvider
         if (target.IsRoot())
             return string.Empty;
 
-        return Path.Combine(GetAddNewItemDirectory(target.Parent!), target.Caption);
+        return Path.Combine(GetAddNewItemDirectory(target.Parent!)!, target.Caption);
     }
 
     public string? GetPath(IProjectTree node)

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Utilities/RepoUtil.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.UnitTests/Utilities/RepoUtil.cs
@@ -17,10 +17,10 @@ internal static class RepoUtil
         if (_root is null)
         {
             // Start with this DLL's location
-            string path = typeof(RepoUtil).Assembly.Location;
+            string? path = typeof(RepoUtil).Assembly.Location;
 
             // Walk up the tree until we find the 'artifacts' folder
-            while (!Path.GetFileName(path).Equals("artifacts", StringComparisons.Paths))
+            while (Path.GetFileName(path)?.Equals("artifacts", StringComparisons.Paths) is false)
             {
                 path = Path.GetDirectoryName(path);
             }
@@ -28,6 +28,8 @@ internal static class RepoUtil
             // Go up one more level
             _root = Path.GetDirectoryName(path);
         }
+
+        Assumes.NotNull(_root);
 
         return _root;
     }

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/DependencyRuleTests.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/DependencyRuleTests.cs
@@ -273,7 +273,7 @@ public sealed class DependencyRuleTests : XamlRuleTestBase
         {
             string unresolvedName = Path.GetFileNameWithoutExtension(unresolvedPath);
             string resolvedName = "Resolved" + unresolvedName;
-            string resolvedPath = Path.Combine(Path.GetDirectoryName(unresolvedPath), resolvedName + ".xaml");
+            string resolvedPath = Path.Combine(Path.GetDirectoryName(unresolvedPath)!, resolvedName + ".xaml");
 
             Assert.Contains(resolvedPath, resolvedPaths);
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/XamlRuleTestBase.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/Rules/XamlRuleTestBase.cs
@@ -24,7 +24,7 @@ public abstract class XamlRuleTestBase
 
         foreach ((string basePath, Type assemblyExporterType) in projects)
         {
-            string path = string.IsNullOrEmpty(suffix) ? basePath : Path.Combine(basePath, suffix);
+            string path = Strings.IsNullOrEmpty(suffix) ? basePath : Path.Combine(basePath, suffix);
 
             if (Directory.Exists(path))
             {


### PR DESCRIPTION
When targeting .NET Framework, some commonly-used System.IO classes have worse performance than in .NET. They are also not null-annotated, which can allow bugs to slip through undetected.

This change uses a global alias across the solution so that Path and Directory types come from the newer Microsoft.IO package/assembly. This gives us a reduction in allocations, access to newer methods (like Path.Join), and correct null annotations.

All other changes here are in response to the use of the newer package, mostly around handling null values correctly.