### PR TITLE
Use newer vs-mef analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,6 +46,7 @@
     <PackageVersion Include="Microsoft.ServiceHub.Framework"                                         Version="4.9.11-beta" />
     <PackageVersion Include="Microsoft.VisualStudio.ComponentModelHost"                              Version="17.14.116" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition"                                     Version="17.13.50" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition.Analyzers"                           Version="18.3.29-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Core"                                       Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Data.Services"                                   Version="18.0.1755-preview.1" />
     <PackageVersion Include="Microsoft.VisualStudio.DataDesign.Common"                               Version="18.0.1755-preview.1" />

--- a/eng/imports/HostAgnostic.props
+++ b/eng/imports/HostAgnostic.props
@@ -33,6 +33,7 @@
 
     <!-- VS MEF -->
     <PackageReference Include="Microsoft.VisualStudio.Composition" />
+    <PackageReference Include="Microsoft.VisualStudio.Composition.Analyzers" />
 
     <PackageReference Include="MessagePack" />
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/ProjectSystem/VS/Automation/VsBuildManager.cs
@@ -38,7 +38,7 @@ internal class VSBuildManager : ConnectionPointContainer,
 
     // This has to be a property import to prevent a circular dependency as the bridge imports this class in order to fire events
     [Import]
-    internal Lazy<IDesignTimeInputsBuildManagerBridge, IAppliesToMetadataView>? DesignTimeInputsBuildManagerBridge { get; private set; }
+    internal Lazy<IDesignTimeInputsBuildManagerBridge, IAppliesToMetadataView> DesignTimeInputsBuildManagerBridge { get; private set; } = null!;
 
     /// <summary>
     /// Occurs when a design time output moniker is deleted.
@@ -72,7 +72,7 @@ internal class VSBuildManager : ConnectionPointContainer,
     {
         get
         {
-            if (DesignTimeInputsBuildManagerBridge?.AppliesTo(_unconfiguredProjectServices.Project.Capabilities) == true)
+            if (DesignTimeInputsBuildManagerBridge.AppliesTo(_unconfiguredProjectServices.Project.Capabilities))
             {
                 IDesignTimeInputsBuildManagerBridge bridge = DesignTimeInputsBuildManagerBridge.Value;
 
@@ -91,7 +91,7 @@ internal class VSBuildManager : ConnectionPointContainer,
     /// </summary>
     public string BuildDesignTimeOutput(string bstrOutputMoniker)
     {
-        if (DesignTimeInputsBuildManagerBridge?.AppliesTo(_unconfiguredProjectServices.Project.Capabilities) == true)
+        if (DesignTimeInputsBuildManagerBridge.AppliesTo(_unconfiguredProjectServices.Project.Capabilities))
         {
             IDesignTimeInputsBuildManagerBridge bridge = DesignTimeInputsBuildManagerBridge.Value;
 

--- a/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.ScopeComponents.cs
+++ b/tests/Microsoft.VisualStudio.ProjectSystem.Managed.VS.UnitTests/ProjectSystem/VS/ComponentComposition.ScopeComponents.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE.md file in the project root for more information.
 
 #pragma warning disable IDE0051 // Remove unused private members
+#pragma warning disable VSMEF003 // Exported type not implemented by exporting class
 
 using ImportAttribute = System.Composition.ImportAttribute;
 using ExportAttribute = System.Composition.ExportAttribute;
@@ -19,7 +20,7 @@ internal partial class ComponentComposition
     {
         [Import]
         [SharingBoundary(ExportContractNames.Scopes.ProjectService)]
-        private System.Composition.ExportFactory<IProjectService>? ProjectServiceFactory { get; set; }
+        private System.Composition.ExportFactory<IProjectService> ProjectServiceFactory { get; set; } = null!;
     }
 
     [Export(typeof(IProjectService))]
@@ -28,7 +29,7 @@ internal partial class ComponentComposition
     {
         [Import]
         [SharingBoundary(ExportContractNames.Scopes.UnconfiguredProject)]
-        private ExportFactory<UnconfiguredProject>? UnconfiguredProjectFactory { get; set; }
+        private ExportFactory<UnconfiguredProject> UnconfiguredProjectFactory { get; set; } = null!;
     }
 
     [Export(typeof(UnconfiguredProject))]
@@ -37,7 +38,7 @@ internal partial class ComponentComposition
     {
         [Import]
         [SharingBoundary(ExportContractNames.Scopes.ConfiguredProject)]
-        private ExportFactory<ConfiguredProject>? ConfiguredProjectFactory { get; set; }
+        private ExportFactory<ConfiguredProject> ConfiguredProjectFactory { get; set; } = null!;
     }
 
     [Export(typeof(ConfiguredProject))]


### PR DESCRIPTION
The vs-mef library received several new analyzers recently. This change bumps the package version and addresses all new diagnostics.