### PR TITLE
Give commands friendly names

### DIFF
--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/Menus.vsct
@@ -121,7 +121,7 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>&amp;Add New Item...</ButtonText>
-          <CommandName>AddNewItemAbove</CommandName>
+          <CommandName>Add New Item (Below)</CommandName>
         </Strings>
       </Button>
 
@@ -134,7 +134,7 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>&amp;Add Existing Item...</ButtonText>
-          <CommandName>AddExistingItemAbove</CommandName>
+          <CommandName>Add Existing Item (Above)</CommandName>
         </Strings>
       </Button>
 
@@ -147,7 +147,7 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>&amp;Add New Item...</ButtonText>
-          <CommandName>AddNewItemBelow</CommandName>
+          <CommandName>Add New Item (Below)</CommandName>
         </Strings>
       </Button>
 
@@ -160,7 +160,7 @@
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
           <ButtonText>&amp;Add Existing Item...</ButtonText>
-          <CommandName>AddExistingItemBelow</CommandName>
+          <CommandName>Add Existing Item (Below)</CommandName>
         </Strings>
       </Button>
       
@@ -173,7 +173,7 @@
         <Strings>
           <ButtonText>&amp;Pack</ButtonText>
           <ToolTipText>Generate NuGet Package</ToolTipText>
-          <CommandName>GenerateNuGetPackageProjectContextMenu</CommandName>
+          <CommandName>Pack</CommandName>
         </Strings>
       </Button>
 
@@ -184,9 +184,9 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
-          <ButtonText>&amp;Pack selection</ButtonText>
+          <ButtonText>&amp;Pack Selection</ButtonText>
           <ToolTipText>Generate NuGet Package for selected project</ToolTipText>
-          <CommandName>GenerateNuGetPackageTopLevelBuild</CommandName>
+          <CommandName>Pack Selection</CommandName>
         </Strings>
       </Button>
       
@@ -196,7 +196,8 @@
         <CommandFlag>DefaultInvisible</CommandFlag>
         <CommandFlag>DefaultDisabled</CommandFlag>
         <Strings>
-          <ButtonText>N&amp;avigate to Project</ButtonText>
+          <ButtonText>N&amp;avigate To Project</ButtonText>
+          <CommandName>Navigate To Project</CommandName>
         </Strings>
       </Button>
 

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.cs.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="cs" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">&amp;Přejít na projekt</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">&amp;Přejít na projekt</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Zabalit výběr</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Zabalit výběr</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.de.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="de" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">Zu Projekt n&amp;avigieren</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">Zu Projekt n&amp;avigieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Auswahl packen</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Auswahl packen</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.es.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="es" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">&amp;Navegar al proyecto</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">&amp;Navegar al proyecto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">Selección de &amp;paquete</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">Selección de &amp;paquete</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.fr.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="fr" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">A&amp;ccéder au projet</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">A&amp;ccéder au projet</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Compresser la sélection</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Compresser la sélection</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.it.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="it" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">P&amp;assa al progetto</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">P&amp;assa al progetto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">Crea &amp;pacchetto da selezione</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">Crea &amp;pacchetto da selezione</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ja.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ja" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">プロジェクトに移動(&amp;A)</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">プロジェクトに移動(&amp;A)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">パックの選択(&amp;P)</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">パックの選択(&amp;P)</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ko.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ko" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">프로젝트로 이동(&amp;A)</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">프로젝트로 이동(&amp;A)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">팩 선택(&amp;P)</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">팩 선택(&amp;P)</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pl.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pl" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">Prz&amp;ejdź do projektu</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">Prz&amp;ejdź do projektu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Spakuj wybrany</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Spakuj wybrany</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.pt-BR.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">N&amp;avegar para o Projeto</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">N&amp;avegar para o Projeto</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Seleção do pacote</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Seleção do pacote</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.ru.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="ru" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">П&amp;ерейти к проекту</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">П&amp;ерейти к проекту</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Упаковать выбранное</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Упаковать выбранное</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.tr.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="tr" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">Projeye Gi&amp;t</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">Projeye Gi&amp;t</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">&amp;Seçimi paketle</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">&amp;Seçimi paketle</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hans.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">导航到项目(&amp;A)</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">导航到项目(&amp;A)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">打包选项(&amp;P)</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">打包选项(&amp;P)</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
+++ b/src/Microsoft.VisualStudio.ProjectSystem.Managed.VS/xlf/Menus.vsct.zh-Hant.xlf
@@ -3,8 +3,13 @@
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Menus.vsct">
     <body>
       <trans-unit id="cmdidNavigateToProject|ButtonText">
-        <source>N&amp;avigate to Project</source>
-        <target state="translated">瀏覽至專案(&amp;A)</target>
+        <source>N&amp;avigate To Project</source>
+        <target state="needs-review-translation">瀏覽至專案(&amp;A)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="cmdidNavigateToProject|CommandName">
+        <source>Navigate To Project</source>
+        <target state="new">Navigate To Project</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidProjectDebugger|ButtonText">
@@ -23,13 +28,13 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageProjectContextMenu|CommandName">
-        <source>GenerateNuGetPackageProjectContextMenu</source>
-        <target state="translated">GenerateNuGetPackageProjectContextMenu</target>
+        <source>Pack</source>
+        <target state="needs-review-translation">GenerateNuGetPackageProjectContextMenu</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ButtonText">
-        <source>&amp;Pack selection</source>
-        <target state="translated">封裝選取項目(&amp;P)</target>
+        <source>&amp;Pack Selection</source>
+        <target state="needs-review-translation">封裝選取項目(&amp;P)</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|ToolTipText">
@@ -38,8 +43,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidGenerateNuGetPackageTopLevelBuild|CommandName">
-        <source>GenerateNuGetPackageTopLevelBuild</source>
-        <target state="translated">GenerateNuGetPackageTopLevelBuild</target>
+        <source>Pack Selection</source>
+        <target state="needs-review-translation">GenerateNuGetPackageTopLevelBuild</target>
         <note />
       </trans-unit>
       <trans-unit id="DebugTargetMenuDebugFrameworkMenu|ButtonText">
@@ -63,8 +68,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemAbove|CommandName">
-        <source>AddNewItemAbove</source>
-        <target state="translated">AddNewItemAbove</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="AddBelowMenu|ButtonText">
@@ -78,8 +83,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemAbove|CommandName">
-        <source>AddExistingItemAbove</source>
-        <target state="translated">AddExistingItemAbove</target>
+        <source>Add Existing Item (Above)</source>
+        <target state="needs-review-translation">AddExistingItemAbove</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|ButtonText">
@@ -88,8 +93,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddNewItemBelow|CommandName">
-        <source>AddNewItemBelow</source>
-        <target state="translated">AddNewItemBelow</target>
+        <source>Add New Item (Below)</source>
+        <target state="needs-review-translation">AddNewItemBelow</target>
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|ButtonText">
@@ -98,8 +103,8 @@
         <note />
       </trans-unit>
       <trans-unit id="cmdidAddExistingItemBelow|CommandName">
-        <source>AddExistingItemBelow</source>
-        <target state="translated">AddExistingItemBelow</target>
+        <source>Add Existing Item (Below)</source>
+        <target state="needs-review-translation">AddExistingItemBelow</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
CommandName controls the description of commands within Tools -> Customize, so they should be user friendly and based on the existing text.

Also Title Cased commands to model current design guidelines.

This is to avoid this:

<img width="715" height="680" alt="image" src="https://github.com/user-attachments/assets/3fdc4eed-f76b-4b48-94da-2f15b3b0df06" />
