### PR TITLE
Remove PATs from Project System localization

### DIFF
--- a/eng/pipelines/official.yml
+++ b/eng/pipelines/official.yml
@@ -161,13 +161,6 @@ extends:
       displayName: Localization
       # [] clears the dependency on the previous stages allowing parallelism.
       dependsOn: []
-      variables:
-      # Variable group containing the PATs required for running OneLocBuild.
-      # See: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
-      # Variables used:
-      # - BotAccount-dotnet-bot-repo-PAT
-      # - dn-bot-ceapex-package-r
-      - group: OneLocBuildVariables
       jobs:
       - template: eng/pipelines/templates/generate-localization.yml@self
         

--- a/eng/pipelines/templates/generate-localization.yml
+++ b/eng/pipelines/templates/generate-localization.yml
@@ -36,6 +36,21 @@ jobs:
       # See: https://docs.microsoft.com/dotnet/core/tools/dotnet-run#options
       arguments: '-- -r "$(System.DefaultWorkingDirectory)" -o "$(Build.StagingDirectory)"'
 
+  - task: AzureCLI@2
+    displayName: Authenticate to Ceapex
+    inputs:
+      azureSubscription: dnceng-onelocbuild-ceapex
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 --output tsv
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "Failed to get an Azure DevOps access token."
+          exit 1
+        }
+
+        Write-Host "##vso[task.setvariable variable=CeapexEntraToken;issecret=true]$accessToken"
+
   # Runs the localization process on the resource files provided within LocProject.json.
   # Details for the process can be found here: https://ceapex.visualstudio.com/CEINTL/_wiki/wikis/CEINTL.wiki/107/Localization-with-OneLocBuild-Task
   # YAML reference: https://dev.azure.com/ceapex/CEINTL/_git/OneLocBuild?_a=contents&version=GBmain&path=/src/OneLocBuildTaskExtension/OneLocBuildTask/task.json
@@ -43,14 +58,8 @@ jobs:
     displayName: Run OneLocBuild
     inputs:
       locProj: $(Build.StagingDirectory)/loc/LocProject.json
-      repoType: gitHub
-      # Uses the dotnet-bot account for creating PRs: https://github.com/dotnet-bot
-      # Variable value comes from OneLocBuildVariables: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
-      gitHubPatVariable: $(BotAccount-dotnet-bot-repo-PAT)
       packageSourceAuth: patAuth
-      # Provides read access to the ceapex AzDO instance: https://dev.azure.com/ceapex/
-      # Variable value comes from OneLocBuildVariables: https://devdiv.visualstudio.com/DevDiv/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=343&path=OneLocBuildVariables
-      patVariable: $(dn-bot-ceapex-package-r)
+      patVariable: $(CeapexEntraToken)
       isCreatePrSelected: true
       isAutoCompletePrSelected: false
       isShouldReusePrSelected: true


### PR DESCRIPTION
## Summary

- remove the unused `BotAccount-dotnet-bot-repo-PAT` input from the custom OneLoc job
- replace `dn-bot-ceapex-package-r` with a short-lived Azure DevOps token acquired through `dnceng-onelocbuild-ceapex`
- remove the now-unused `OneLocBuildVariables` variable group from the localization stage

Pipeline 9675 has been authorized for the workload identity service connection.

## Runtime context

Project System localization runs against the DevDiv Azure Repos repository. Current production logs show `/repotype: AzureReposGit`, `/githubpat: -`, and `/mirror: False`, so no GitHub App migration is needed.

Tracks https://dev.azure.com/dnceng/internal/_workitems/edit/12314